### PR TITLE
Add ReliableGPT to Khoj - Handle OpenAI Errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
     "langchain >= 0.0.187",
     "pypdf >= 3.9.0",
     "requests >= 2.26.0",
+    "reliableGPT == 0.2.6",
 ]
 dynamic = ["version"]
 

--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -17,6 +17,8 @@ from tenacity import (
     wait_exponential,
     wait_random_exponential,
 )
+from reliablegpt import reliableGPT
+openai.ChatCompletion.create = reliableGPT(openai.ChatCompletion.create, user_email='khoj@ai.com')
 
 # Internal Packages
 from khoj.utils.helpers import merge_dicts


### PR DESCRIPTION
Add https://github.com/BerriAI/reliableGPT to Khoj to handle the following errors:

- OpenAI APIError, OpenAI Timeout, OpenAI Rate Limit Errors, OpenAI Service UnavailableError / Overloaded
- Context Window Errors
- Invalid API Key errors

Khoj users can specify fallback strategies for error handling - eg. if GPT-4 is overloaded use GPT 3.5 Turbo, Anthropic etc 
