### PR TITLE
Support multiple Github repositories and support indexing of multiple file types

### DIFF
--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -84,12 +84,21 @@
         window.onload = function () {
             fetch('/api/chat?client=web')
                 .then(response => response.json())
-                .then(data => data.response)
-                .then(chat_logs => {
+                .then(data => {
+                    if (data.detail) {
+                        // If the server returns a 500 error with detail, render it as a message.
+                        renderMessage(data.detail + " You can configure Khoj chat in your <a class='inline-chat-link' href='/config'>settings</a>.", "khoj");
+                    }
+                    return data.response;
+                })
+                .then(response => {
                     // Render conversation history, if any
-                    chat_logs.forEach(chat_log => {
+                    response.forEach(chat_log => {
                         renderMessageWithReference(chat_log.message, chat_log.by, chat_log.context, new Date(chat_log.created));
                     });
+                })
+                .catch(err => {
+                    return;
                 });
 
              // Set welcome message on load
@@ -233,6 +242,12 @@
         }
         #chat-input {
             font-size: medium;
+        }
+
+        a.inline-chat-link {
+            color: #475569;
+            text-decoration: none;
+            border-bottom: 1px dotted #475569;
         }
 
         @media (pointer: coarse), (hover: none) {

--- a/src/khoj/interface/web/content_type_github_input.html
+++ b/src/khoj/interface/web/content_type_github_input.html
@@ -16,31 +16,25 @@
                         <input type="text" id="pat-token" name="pat" value="{{ current_config['pat_token'] }}">
                     </td>
                 </tr>
-                <tr>
-                    <td>
-                        <label for="repo-owner">Repository Owner</label>
-                    </td>
-                    <td>
-                        <input type="text" id="repo-owner" name="repo_owner" value="{{ current_config['repo_owner'] }}">
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <label for="repo-name">Repository Name</label>
-                    </td>
-                    <td>
-                        <input type="text" id="repo-name" name="repo_name" value="{{ current_config['repo_name'] }}">
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <label for="repo-branch">Repository Branch</label>
-                    </td>
-                    <td>
-                        <input type="text" id="repo-branch" name="repo_branch" value="{{ current_config['repo_branch'] }}">
-                    </td>
-                </tr>
             </table>
+            <h4>Repositories</h4>
+            <div id="repositories" class="section-cards">
+                {% for repo in current_config['repos'] %}
+                <div class="card repo" id="repo-card-{{loop.index}}">
+                    <label for="repo-owner">Repository Owner</label>
+                    <input type="text" id="repo-owner-{{loop.index}}" name="repo_owner" value="{{ repo.owner }}">
+                    <label for="repo-name">Repository Name</label>
+                    <input type="text" id="repo-name-{{loop.index}}" name="repo_name" value="{{ repo.name}}">
+                    <label for="repo-branch">Repository Branch</label>
+                    <input type="text" id="repo-branch-{{loop.index}}" name="repo_branch" value="{{ repo.branch }}">
+                    <button type="button"
+                            class="remove-repo-button"
+                            onclick="remove_repo({{loop.index}})"
+                            id="remove-repo-button-{{loop.index}}">Remove Repository</button>
+                </div>
+                {% endfor %}
+            </div>
+            <button type="button" id="add-repository-button">Add Repository</button>
             <h4>You probably don't need to edit these.</h4>
 
             <table>
@@ -68,16 +62,86 @@
         </form>
     </div>
 </div>
+<style>
+    div.repo {
+        width: 100%;
+        height: 100%;
+        grid-template-rows: none;
+    }
+    div#repositories {
+        margin-bottom: 12px;
+    }
+    button.remove-repo-button {
+        background-color: gainsboro;
+    }
+</style>
 <script>
+    const add_repo_button = document.getElementById("add-repository-button");
+    add_repo_button.addEventListener("click", function(event) {
+        event.preventDefault();
+        var repo = document.createElement("div");
+        repo.classList.add("card");
+        repo.classList.add("repo");
+        const id = Date.now();
+        repo.id = "repo-card-" + id;
+        repo.innerHTML = `
+            <label for="repo-owner">Repository Owner</label>
+            <input type="text" id="repo-owner" name="repo_owner">
+            <label for="repo-name">Repository Name</label>
+            <input type="text" id="repo-name" name="repo_name">
+            <label for="repo-branch">Repository Branch</label>
+            <input type="text" id="repo-branch" name="repo_branch">
+            <button type="button"
+                    class="remove-repo-button"
+                    onclick="remove_repo(${id})"
+                    id="remove-repo-button-${id}">Remove Repository</button>
+        `;
+        document.getElementById("repositories").appendChild(repo);
+    })
+
+    function remove_repo(index) {
+        document.getElementById("repo-card-" + index).remove();
+    }
+
     submit.addEventListener("click", function(event) {
         event.preventDefault();
 
-        var compressed_jsonl = document.getElementById("compressed-jsonl").value;
-        var embeddings_file = document.getElementById("embeddings-file").value;
-        var pat_token = document.getElementById("pat-token").value;
-        var repo_owner = document.getElementById("repo-owner").value;
-        var repo_name = document.getElementById("repo-name").value;
-        var repo_branch = document.getElementById("repo-branch").value;
+        const compressed_jsonl = document.getElementById("compressed-jsonl").value;
+        const embeddings_file = document.getElementById("embeddings-file").value;
+        const pat_token = document.getElementById("pat-token").value;
+
+        if (pat_token == "") {
+            document.getElementById("success").innerHTML = "❌ Please enter a Personal Access Token.";
+            document.getElementById("success").style.display = "block";
+            return;
+        }
+
+
+        var cards = document.getElementById("repositories").getElementsByClassName("repo");
+        var repos = [];
+
+        for (var i = 0; i < cards.length; i++) {
+            var card = cards[i];
+            var owner = card.getElementsByTagName("input")[0].value;
+            var name = card.getElementsByTagName("input")[1].value;
+            var branch = card.getElementsByTagName("input")[2].value;
+
+            if (owner == "" || name == "" || branch == "") {
+                continue;
+            }
+
+            repos.push({
+                "owner": owner,
+                "name": name,
+                "branch": branch,
+            });
+        }
+
+        if (repos.length == 0) {
+            document.getElementById("success").innerHTML = "❌ Please add at least one repository.";
+            document.getElementById("success").style.display = "block";
+            return;
+        }
 
         const csrfToken = document.cookie.split('; ').find(row => row.startsWith('csrftoken'))?.split('=')[1];
         fetch('/api/config/data/content_type/github', {
@@ -88,9 +152,7 @@
             },
             body: JSON.stringify({
                 "pat_token": pat_token,
-                "repo_owner": repo_owner,
-                "repo_name": repo_name,
-                "repo_branch": repo_branch,
+                "repos": repos,
                 "compressed_jsonl": compressed_jsonl,
                 "embeddings_file": embeddings_file,
             })

--- a/src/khoj/interface/web/index.html
+++ b/src/khoj/interface/web/index.html
@@ -57,6 +57,27 @@
             }).join("\n") + `</div>`;
         }
 
+        function render_mutliple(query, data, type) {
+            let org_files = data.filter((item) => item.additional.file.endsWith(".org"));
+            let md_files = data.filter((item) => item.additional.file.endsWith(".md"));
+            let pdf_files = data.filter((item) => item.additional.file.endsWith(".pdf"));
+
+            let html = "";
+            if (org_files.length > 0) {
+                html += render_org(query, org_files, type);
+            }
+
+            if (md_files.length > 0) {
+                html += render_markdown(query, md_files);
+            }
+
+            if (pdf_files.length > 0) {
+                html += render_pdf(query, pdf_files);
+            }
+
+            return html;
+        }
+
         function render_json(data, query, type) {
             if (type === "markdown") {
                 return render_markdown(query, data);
@@ -71,7 +92,7 @@
             } else if (type === "pdf") {
                 return render_pdf(query, data);
             } else if (type == "github") {
-                return render_markdown(query, data);
+                return render_mutliple(query, data, type);
             } else {
                 return `<div id="results-plugin">`
                     + data.map((item) => `<p>${item.entry}</p>`).join("\n")

--- a/src/khoj/processor/markdown/markdown_to_jsonl.py
+++ b/src/khoj/processor/markdown/markdown_to_jsonl.py
@@ -10,13 +10,17 @@ from khoj.processor.text_to_jsonl import TextToJsonl
 from khoj.utils.helpers import get_absolute_path, is_none_or_empty, timer
 from khoj.utils.constants import empty_escape_sequences
 from khoj.utils.jsonl import dump_jsonl, compress_jsonl_data
-from khoj.utils.rawconfig import Entry
+from khoj.utils.rawconfig import Entry, TextContentConfig
 
 
 logger = logging.getLogger(__name__)
 
 
 class MarkdownToJsonl(TextToJsonl):
+    def __init__(self, config: TextContentConfig):
+        super().__init__(config)
+        self.config = config
+
     # Define Functions
     def process(self, previous_entries=None):
         # Extract required fields from config

--- a/src/khoj/processor/org_mode/orgnode.py
+++ b/src/khoj/processor/org_mode/orgnode.py
@@ -53,14 +53,19 @@ def normalize_filename(filename):
     return escaped_filename
 
 
-def makelist(filename):
+def makelist_with_filepath(filename):
+    f = open(filename, "r")
+    return makelist(f, filename)
+
+
+def makelist(file, filename):
     """
     Read an org-mode file and return a list of Orgnode objects
     created from this file.
     """
     ctr = 0
 
-    f = open(filename, "r")
+    f = file
 
     todos = {
         "TODO": "",

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -80,7 +80,12 @@ async def set_content_config_github_data(updated_config: GithubContentConfig):
     if not state.config:
         state.config = FullConfig()
         state.config.search_type = SearchConfig.parse_obj(constants.default_config["search-type"])
-    state.config.content_type = ContentConfig(github=updated_config)
+
+    if not state.config.content_type:
+        state.config.content_type = ContentConfig(**{"github": updated_config})
+    else:
+        state.config.content_type.github = updated_config
+
     try:
         save_config_to_file_updated_state()
         return {"status": "ok"}
@@ -93,7 +98,12 @@ async def set_content_config_data(content_type: str, updated_config: TextContent
     if not state.config:
         state.config = FullConfig()
         state.config.search_type = SearchConfig.parse_obj(constants.default_config["search-type"])
-    state.config.content_type = ContentConfig(**{content_type: updated_config})
+
+    if not state.config.content_type:
+        state.config.content_type = ContentConfig(**{content_type: updated_config})
+    else:
+        state.config.content_type[content_type] = updated_config
+
     try:
         save_config_to_file_updated_state()
         return {"status": "ok"}

--- a/src/khoj/utils/constants.py
+++ b/src/khoj/utils/constants.py
@@ -49,9 +49,9 @@ default_config = {
         },
         "github": {
             "pat-token": None,
-            "repo-name": None,
-            "repo-owner": None,
-            "repo-branch": "master",
+            "repos": [
+                {"name": "khoj", "owner": "khoj-ai", "branch": "master"},
+            ],
             "compressed-jsonl": "~/.khoj/content/github/github.jsonl.gz",
             "embeddings-file": "~/.khoj/content/github/github_embeddings.pt",
         },

--- a/src/khoj/utils/constants.py
+++ b/src/khoj/utils/constants.py
@@ -49,9 +49,7 @@ default_config = {
         },
         "github": {
             "pat-token": None,
-            "repos": [
-                {"name": "khoj", "owner": "khoj-ai", "branch": "master"},
-            ],
+            "repos": [],
             "compressed-jsonl": "~/.khoj/content/github/github.jsonl.gz",
             "embeddings-file": "~/.khoj/content/github/github_embeddings.pt",
         },

--- a/src/khoj/utils/rawconfig.py
+++ b/src/khoj/utils/rawconfig.py
@@ -41,11 +41,15 @@ class TextContentConfig(TextConfigBase):
         return input_filter
 
 
+class GithubRepoConfig(ConfigBase):
+    name: str
+    owner: str
+    branch: Optional[str] = "master"
+
+
 class GithubContentConfig(TextConfigBase):
     pat_token: str
-    repo_name: str
-    repo_owner: str
-    repo_branch: Optional[str] = "master"
+    repos: List[GithubRepoConfig]
 
 
 class ImageContentConfig(ConfigBase):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ from khoj.utils.rawconfig import (
     ProcessorConfig,
     TextContentConfig,
     GithubContentConfig,
+    GithubRepoConfig,
     ImageContentConfig,
     SearchConfig,
     TextSearchConfig,
@@ -92,9 +93,13 @@ def content_config(tmp_path_factory, search_config: SearchConfig):
 
     content_config.github = GithubContentConfig(
         pat_token=os.getenv("GITHUB_PAT_TOKEN", ""),
-        repo_name="lantern",
-        repo_owner="khoj-ai",
-        repo_branch="master",
+        repos=[
+            GithubRepoConfig(
+                owner="khoj-ai",
+                name="lantern",
+                branch="master",
+            )
+        ],
         compressed_jsonl=content_dir.joinpath("github.jsonl.gz"),
         embeddings_file=content_dir.joinpath("github_embeddings.pt"),
     )

--- a/tests/test_orgnode.py
+++ b/tests/test_orgnode.py
@@ -14,7 +14,7 @@ def test_parse_entry_with_no_headings(tmp_path):
     orgfile = create_file(tmp_path, entry)
 
     # Act
-    entries = orgnode.makelist(orgfile)
+    entries = orgnode.makelist_with_filepath(orgfile)
 
     # Assert
     assert len(entries) == 1
@@ -38,7 +38,7 @@ Body Line 1"""
     orgfile = create_file(tmp_path, entry)
 
     # Act
-    entries = orgnode.makelist(orgfile)
+    entries = orgnode.makelist_with_filepath(orgfile)
 
     # Assert
     assert len(entries) == 1
@@ -71,7 +71,7 @@ Body Line 2"""
     orgfile = create_file(tmp_path, entry)
 
     # Act
-    entries = orgnode.makelist(orgfile)
+    entries = orgnode.makelist_with_filepath(orgfile)
 
     # Assert
     assert len(entries) == 1
@@ -109,7 +109,7 @@ def test_render_entry_with_property_drawer_and_empty_body(tmp_path):
 """
 
     # Act
-    parsed_entries = orgnode.makelist(orgfile)
+    parsed_entries = orgnode.makelist_with_filepath(orgfile)
 
     # Assert
     assert f"{parsed_entries[0]}" == expected_entry
@@ -131,7 +131,7 @@ Body Line 2
     orgfile = create_file(tmp_path, entry)
 
     # Act
-    entries = orgnode.makelist(orgfile)
+    entries = orgnode.makelist_with_filepath(orgfile)
 
     # Assert
     # SOURCE link rendered with Heading
@@ -155,7 +155,7 @@ Body Line 1"""
     orgfile = create_file(tmp_path, entry, filename="test[1].org")
 
     # Act
-    entries = orgnode.makelist(orgfile)
+    entries = orgnode.makelist_with_filepath(orgfile)
 
     # Assert
     assert len(entries) == 1
@@ -197,7 +197,7 @@ Body 2
     orgfile = create_file(tmp_path, content)
 
     # Act
-    entries = orgnode.makelist(orgfile)
+    entries = orgnode.makelist_with_filepath(orgfile)
 
     # Assert
     assert len(entries) == 2
@@ -225,7 +225,7 @@ Body Line 1"""
     orgfile = create_file(tmp_path, entry)
 
     # Act
-    entries = orgnode.makelist(orgfile)
+    entries = orgnode.makelist_with_filepath(orgfile)
 
     # Assert
     assert len(entries) == 1
@@ -248,7 +248,7 @@ Body Line 1"""
     orgfile = create_file(tmp_path, entry)
 
     # Act
-    entries = orgnode.makelist(orgfile)
+    entries = orgnode.makelist_with_filepath(orgfile)
 
     # Assert
     assert len(entries) == 1
@@ -272,7 +272,7 @@ Body Line 1
     orgfile = create_file(tmp_path, entry)
 
     # Act
-    entries = orgnode.makelist(orgfile)
+    entries = orgnode.makelist_with_filepath(orgfile)
 
     # Assert
     assert len(entries) == 1
@@ -298,7 +298,7 @@ entry body
     orgfile = create_file(tmp_path, body)
 
     # Act
-    entries = orgnode.makelist(orgfile)
+    entries = orgnode.makelist_with_filepath(orgfile)
 
     # Assert
     assert len(entries) == 2
@@ -320,7 +320,7 @@ entry body
     orgfile = create_file(tmp_path, body)
 
     # Act
-    entries = orgnode.makelist(orgfile)
+    entries = orgnode.makelist_with_filepath(orgfile)
 
     # Assert
     assert len(entries) == 2


### PR DESCRIPTION
## Incoming
- Add support for indexing multiple Github repositories
- Add integration to read org files as well as markdown files in the plain text files from the repo
- Render multiple file types in the `Search` view
- Add support for configuring multiple repositories in the settings page
- [Bonus] Add additional error handling in the chat window if the user hasn't configured their settings correctly

Closes #244 and begins #245 