### PR TITLE
Add demo view for Khoj

### DIFF
--- a/src/khoj/interface/web/assets/khoj.css
+++ b/src/khoj/interface/web/assets/khoj.css
@@ -48,7 +48,7 @@
 }
 .khoj-nav {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-auto-flow: column;
     grid-gap: 32px;
     justify-self: center;
 }

--- a/src/khoj/interface/web/base_config.html
+++ b/src/khoj/interface/web/base_config.html
@@ -2,6 +2,7 @@
 <html data-theme="light">
     <head>
         <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0 maximum-scale=1.0">
         <link rel="icon" type="image/png" sizes="128x128" href="/static/assets/icons/favicon-128x128.png">
         <title>Khoj - Settings</title>
         <link rel="stylesheet" href="/static/assets/pico.min.css">

--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -113,13 +113,31 @@
         }
     </script>
     <body>
-       <!--Add Header Logo and Nav Pane-->
+        <!--Add Header Logo and Nav Pane-->
         <div class="khoj-header">
-            <img class="khoj-logo" src="/static/assets/icons/khoj-logo-sideways.svg" alt="Khoj"></img>
+            {% if demo %}
+                <!-- Banner linking to https://khoj.dev -->
+                <div class="khoj-banner-container">
+                    <a class="khoj-banner" href="https://khoj.dev" target="_blank">
+                        Check out what else we're building
+                    </a>
+                </div>
+            {% endif %}
+            {% if demo %}
+                <a href="https://khoj.dev" target="_blank">
+                    <img class="khoj-logo" src="/static/assets/icons/khoj-logo-sideways.svg" alt="Khoj"></img>
+                </a>
+            {% else %}
+                <a href="https://lantern.khoj.dev" target="_blank">
+                    <img class="khoj-logo" src="/static/assets/icons/khoj-logo-sideways.svg" alt="Khoj"></img>
+                </a>
+            {% endif %}
             <nav class="khoj-nav">
                 <a class="khoj-nav-selected" href="/chat">Chat</a>
                 <a href="/">Search</a>
-                <a href="/config">Settings</a>
+                {% if not demo %}
+                    <a href="/config">Settings</a>
+                {% endif %}
             </nav>
         </div>
 
@@ -295,6 +313,31 @@
             body > * {
                 grid-column: 2;
             }
+        }
+
+        div.khoj-banner-container {
+            background: linear-gradient(-45deg, #FFC107, #FF9800, #FF5722, #FF9800, #FFC107);
+            background-size: 400% 400%;
+            animation: gradient 15s ease infinite;
+            text-align: center;
+            padding: 10px;
+        }
+
+        @keyframes gradient {
+            0% {
+                background-position: 0% 50%;
+            }
+            50% {
+                background-position: 100% 50%;
+            }
+            100% {
+                background-position: 0% 50%;
+            }
+        }
+
+        a.khoj-banner {
+            color: black;
+            text-decoration: none;
         }
     </style>
 </html>

--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -119,8 +119,12 @@
                 <!-- Banner linking to https://khoj.dev -->
                 <div class="khoj-banner-container">
                     <a class="khoj-banner" href="https://khoj.dev" target="_blank">
-                        Check out what else we're building
+                        <p id="khoj-banner" class="khoj-banner">
+                            Enroll in Khoj cloud to get your own Github assistant
+                        </p>
                     </a>
+                    <input type="text" id="khoj-banner-email" placeholder="email" class="khoj-banner-email"></input>
+                    <button id="khoj-banner-submit" class="khoj-banner-button">Submit</button>
                 </div>
             {% endif %}
             {% if demo %}
@@ -304,6 +308,9 @@
                 margin: 4px;
                 grid-template-columns: auto;
             }
+            a.khoj-banner {
+                display: block;
+            }
         }
         @media only screen and (min-width: 600px) {
             body {
@@ -337,7 +344,67 @@
 
         a.khoj-banner {
             color: black;
+        }
+
+        a.khoj-logo {
+            text-align: center;
+        }
+
+        p.khoj-banner {
+            margin: 0;
+            padding: 10px;
+        }
+
+        button#khoj-banner-submit,
+        input#khoj-banner-email {
+            padding: 10px;
+            border-radius: 5px;
+            border: 1px solid #475569;
+            background: #f9fafc;
+        }
+
+        button#khoj-banner-submit:hover,
+        input#khoj-banner-email:hover {
+            box-shadow: 0 0 11px #aaa;
+        }
+
+        p#khoj-banner {
+            display: inline;
+        }
+
+        a.khoj-banner {
+            color: black;
             text-decoration: none;
         }
     </style>
+    <script>
+        var khojBannerSubmit = document.getElementById("khoj-banner-submit");
+
+        khojBannerSubmit.addEventListener("click", function(event) {
+            event.preventDefault();
+            var email = document.getElementById("khoj-banner-email").value;
+            fetch("https://lantern.khoj.dev/beta/users/", {
+                    method: "POST",
+                    body: JSON.stringify({
+                        email: email
+                    }),
+                    headers: {
+                        "Content-Type": "application/json"
+                    }
+                }).then(function(response) {
+                    return response.json();
+                }).then(function(data) {
+                    console.log(data);
+                    if (data.user != null) {
+                        document.getElementById("khoj-banner").innerHTML = "Thanks for signing up. We'll be in touch soon! 🚀";
+                        document.getElementById("khoj-banner-submit").remove();
+                    } else {
+                        document.getElementById("khoj-banner").innerHTML = "There was an error signing up. Please contact team@khoj.dev";
+                    }
+                }).catch(function(error) {
+                    console.log(error);
+                    document.getElementById("khoj-banner").innerHTML = "There was an error signing up. Please contact team@khoj.dev";
+                });
+            });
+    </script>
 </html>

--- a/src/khoj/interface/web/index.html
+++ b/src/khoj/interface/web/index.html
@@ -232,13 +232,36 @@
     </script>
 
     <body>
+        {% if demo %}
+            <!-- Banner linking to https://khoj.dev -->
+                <div class="khoj-banner-container">
+                    <a class="khoj-banner" href="https://khoj.dev" target="_blank">
+                        <p id="khoj-banner" class="khoj-banner">
+                            Enroll in Khoj beta to get your own Github search engine
+                        </p>
+                    </a>
+                    <input type="text" id="khoj-banner-email" placeholder="email" class="khoj-banner-email"></input>
+                    <button id="khoj-banner-submit" class="khoj-banner-button">Submit</button>
+                </div>
+        {% endif %}
+
         <!--Add Header Logo and Nav Pane-->
         <div class="khoj-header">
-            <img class="khoj-logo" src="/static/assets/icons/khoj-logo-sideways.svg" alt="Khoj"></img>
+            {% if demo %}
+                <a class="khoj-logo" href="https://khoj.dev" target="_blank">
+                    <img class="khoj-logo" src="/static/assets/icons/khoj-logo-sideways.svg" alt="Khoj"></img>
+                </a>
+            {% else %}
+                <a class="khoj-logo" href="https://lantern.khoj.dev" target="_blank">
+                    <img class="khoj-logo" src="/static/assets/icons/khoj-logo-sideways.svg" alt="Khoj"></img>
+                </a>
+            {% endif %}
             <nav class="khoj-nav">
                 <a href="/chat">Chat</a>
                 <a class="khoj-nav-selected" href="/">Search</a>
-                <a href="/config">Settings</a>
+                {% if not demo %}
+                    <a href="/config">Settings</a>
+                {% endif %}
             </nav>
         </div>
 
@@ -411,13 +434,90 @@
             border-radius: 5px;
             padding: 10px;
             margin: 10px 0;
-            border: 1px solid rgb(229, 229, 229);
+            border: 4px solid rgb(229, 229, 229);
         }
 
         img {
             max-width: 90%;
         }
 
+        div.khoj-banner-container {
+            background: linear-gradient(-45deg, #FFC107, #FF9800, #FF5722, #FF9800, #FFC107);
+            background-size: 400% 400%;
+            animation: gradient 15s ease infinite;
+            text-align: center;
+            padding: 10px;
+        }
+
+        @keyframes gradient {
+            0% {
+                background-position: 0% 50%;
+            }
+            50% {
+                background-position: 100% 50%;
+            }
+            100% {
+                background-position: 0% 50%;
+            }
+        }
+
+        a.khoj-banner {
+            color: black;
+            display: block;
+        }
+
+        a.khoj-logo {
+            text-align: center;
+        }
+
+        p.khoj-banner {
+            margin: 0;
+            padding: 10px;
+        }
+
+        button#khoj-banner-submit,
+        input#khoj-banner-email {
+            padding: 10px;
+            border-radius: 5px;
+            border: 1px solid #475569;
+            background: #f9fafc;
+        }
+
+        button#khoj-banner-submit:hover,
+        input#khoj-banner-email:hover {
+            box-shadow: 0 0 11px #aaa;
+        }
+
     </style>
+    <script>
+        var khojBannerSubmit = document.getElementById("khoj-banner-submit");
+
+        khojBannerSubmit.addEventListener("click", function(event) {
+            event.preventDefault();
+            var email = document.getElementById("khoj-banner-email").value;
+            fetch("https://lantern.khoj.dev/beta/users/", {
+                    method: "POST",
+                    body: JSON.stringify({
+                        email: email
+                    }),
+                    headers: {
+                        "Content-Type": "application/json"
+                    }
+                }).then(function(response) {
+                    return response.json();
+                }).then(function(data) {
+                    console.log(data);
+                    if (data.user != null) {
+                        document.getElementById("khoj-banner").innerHTML = "Thanks for signing up. We'll be in touch soon! 🚀";
+                        document.getElementById("khoj-banner-submit").remove();
+                    } else {
+                        document.getElementById("khoj-banner").innerHTML = "There was an error signing up. Please contact team@khoj.dev";
+                    }
+                }).catch(function(error) {
+                    console.log(error);
+                    document.getElementById("khoj-banner").innerHTML = "There was an error signing up. Please contact team@khoj.dev";
+                });
+            });
+    </script>
 
 </html>

--- a/src/khoj/interface/web/index.html
+++ b/src/khoj/interface/web/index.html
@@ -232,22 +232,19 @@
     </script>
 
     <body>
-        {% if demo %}
-            <!-- Banner linking to https://khoj.dev -->
+        <!--Add Header Logo and Nav Pane-->
+        <div class="khoj-header">
+            {% if demo %}
+                <!-- Banner linking to https://khoj.dev -->
                 <div class="khoj-banner-container">
                     <a class="khoj-banner" href="https://khoj.dev" target="_blank">
                         <p id="khoj-banner" class="khoj-banner">
-                            Enroll in Khoj beta to get your own Github search engine
+                            Enroll in Khoj cloud to get your own Github assistant
                         </p>
                     </a>
                     <input type="text" id="khoj-banner-email" placeholder="email" class="khoj-banner-email"></input>
                     <button id="khoj-banner-submit" class="khoj-banner-button">Submit</button>
                 </div>
-        {% endif %}
-
-        <!--Add Header Logo and Nav Pane-->
-        <div class="khoj-header">
-            {% if demo %}
                 <a class="khoj-logo" href="https://khoj.dev" target="_blank">
                     <img class="khoj-logo" src="/static/assets/icons/khoj-logo-sideways.svg" alt="Khoj"></img>
                 </a>
@@ -463,7 +460,6 @@
 
         a.khoj-banner {
             color: black;
-            display: block;
         }
 
         a.khoj-logo {
@@ -486,6 +482,16 @@
         button#khoj-banner-submit:hover,
         input#khoj-banner-email:hover {
             box-shadow: 0 0 11px #aaa;
+        }
+
+        p#khoj-banner {
+            display: inline;
+        }
+
+        @media only screen and (max-width: 600px) {
+            a.khoj-banner {
+                display: block;
+            }
         }
 
     </style>

--- a/src/khoj/main.py
+++ b/src/khoj/main.py
@@ -129,6 +129,7 @@ def set_state(args):
     state.verbose = args.verbose
     state.host = args.host
     state.port = args.port
+    state.demo = args.demo
 
 
 def start_server(app, host=None, port=None, socket=None):

--- a/src/khoj/processor/github/github_to_jsonl.py
+++ b/src/khoj/processor/github/github_to_jsonl.py
@@ -15,6 +15,7 @@ from khoj.processor.org_mode.org_to_jsonl import OrgToJsonl
 from khoj.processor.text_to_jsonl import TextToJsonl
 from khoj.utils.jsonl import dump_jsonl, compress_jsonl_data
 from khoj.utils.rawconfig import Entry
+from khoj.utils import state
 
 
 logger = logging.getLogger(__name__)
@@ -38,6 +39,10 @@ class GithubToJsonl(TextToJsonl):
             return
 
     def process(self, previous_entries=None):
+        # If demo mode is enabled, don't re-process any of the repositories. This is resource intensive.
+        if state.demo and previous_entries is not None:
+            return self.update_entries_with_ids(previous_entries, previous_entries)
+
         current_entries = []
         for repo in self.config.repos:
             current_entries += self.process_repo(repo, previous_entries)
@@ -193,7 +198,7 @@ class GithubToJsonl(TextToJsonl):
 
     def _get_issues(self, issues_url: Union[str, None]) -> List[Dict]:
         issues = []
-        per_page = 30
+        per_page = 100
         params = {"per_page": per_page, "state": "all"}
 
         while issues_url is not None:
@@ -225,7 +230,7 @@ class GithubToJsonl(TextToJsonl):
     def get_comments(self, comments_url: Union[str, None]) -> List[Dict]:
         # By default, the number of results per page is 30. We'll keep it as-is for now.
         comments = []
-        per_page = 30
+        per_page = 100
         params = {"per_page": per_page}
 
         while comments_url is not None:

--- a/src/khoj/routers/web_client.py
+++ b/src/khoj/routers/web_client.py
@@ -21,95 +21,94 @@ VALID_CONTENT_TYPES = ["org", "ledger", "markdown", "pdf"]
 
 # Create Routes
 @web_client.get("/", response_class=FileResponse)
-def index():
-    return FileResponse(constants.web_directory / "index.html")
-
-
-@web_client.get("/config", response_class=HTMLResponse)
-def config_page(request: Request):
-    return templates.TemplateResponse("config.html", context={"request": request})
-
-
-@web_client.get("/config/content_type/github", response_class=HTMLResponse)
-def github_config_page(request: Request):
-    default_copy = constants.default_config.copy()
-    default_github = default_copy["content-type"]["github"]  # type: ignore
-
-    default_config = TextContentConfig(
-        compressed_jsonl=default_github["compressed-jsonl"],
-        embeddings_file=default_github["embeddings-file"],
-    )
-
-    current_config = (
-        state.config.content_type.github
-        if state.config and state.config.content_type and state.config.content_type.github
-        else default_config
-    )
-
-    current_config = json.loads(current_config.json())
-
-    return templates.TemplateResponse(
-        "content_type_github_input.html", context={"request": request, "current_config": current_config}
-    )
-
-
-@web_client.get("/config/content_type/{content_type}", response_class=HTMLResponse)
-def content_config_page(request: Request, content_type: str):
-    if content_type not in VALID_CONTENT_TYPES:
-        return templates.TemplateResponse("config.html", context={"request": request})
-
-    default_copy = constants.default_config.copy()
-    default_content_type = default_copy["content-type"][content_type]  # type: ignore
-
-    default_config = TextContentConfig(
-        compressed_jsonl=default_content_type["compressed-jsonl"],
-        embeddings_file=default_content_type["embeddings-file"],
-    )
-
-    current_config = (
-        state.config.content_type[content_type]
-        if state.config and state.config.content_type and state.config.content_type[content_type]  # type: ignore
-        else default_config
-    )
-    current_config = json.loads(current_config.json())
-
-    return templates.TemplateResponse(
-        "content_type_input.html",
-        context={
-            "request": request,
-            "current_config": current_config,
-            "content_type": content_type,
-        },
-    )
-
-
-@web_client.get("/config/processor/conversation", response_class=HTMLResponse)
-def conversation_processor_config_page(request: Request):
-    default_copy = constants.default_config.copy()
-    default_processor_config = default_copy["processor"]["conversation"]  # type: ignore
-    default_processor_config = ConversationProcessorConfig(
-        openai_api_key="",
-        model=default_processor_config["model"],
-        conversation_logfile=default_processor_config["conversation-logfile"],
-        chat_model=default_processor_config["chat-model"],
-    )
-
-    current_processor_conversation_config = (
-        state.config.processor.conversation
-        if state.config and state.config.processor and state.config.processor.conversation
-        else default_processor_config
-    )
-    current_processor_conversation_config = json.loads(current_processor_conversation_config.json())
-
-    return templates.TemplateResponse(
-        "processor_conversation_input.html",
-        context={
-            "request": request,
-            "current_config": current_processor_conversation_config,
-        },
-    )
+def index(request: Request):
+    return templates.TemplateResponse("index.html", context={"request": request, "demo": state.demo})
 
 
 @web_client.get("/chat", response_class=FileResponse)
-def chat_page():
-    return FileResponse(constants.web_directory / "chat.html")
+def chat_page(request: Request):
+    return templates.TemplateResponse("chat.html", context={"request": request, "demo": state.demo})
+
+
+if not state.demo:
+
+    @web_client.get("/config", response_class=HTMLResponse)
+    def config_page(request: Request):
+        return templates.TemplateResponse("config.html", context={"request": request})
+
+    @web_client.get("/config/content_type/github", response_class=HTMLResponse)
+    def github_config_page(request: Request):
+        default_copy = constants.default_config.copy()
+        default_github = default_copy["content-type"]["github"]  # type: ignore
+
+        default_config = TextContentConfig(
+            compressed_jsonl=default_github["compressed-jsonl"],
+            embeddings_file=default_github["embeddings-file"],
+        )
+
+        current_config = (
+            state.config.content_type.github
+            if state.config and state.config.content_type and state.config.content_type.github
+            else default_config
+        )
+
+        current_config = json.loads(current_config.json())
+
+        return templates.TemplateResponse(
+            "content_type_github_input.html", context={"request": request, "current_config": current_config}
+        )
+
+    @web_client.get("/config/content_type/{content_type}", response_class=HTMLResponse)
+    def content_config_page(request: Request, content_type: str):
+        if content_type not in VALID_CONTENT_TYPES:
+            return templates.TemplateResponse("config.html", context={"request": request})
+
+        default_copy = constants.default_config.copy()
+        default_content_type = default_copy["content-type"][content_type]  # type: ignore
+
+        default_config = TextContentConfig(
+            compressed_jsonl=default_content_type["compressed-jsonl"],
+            embeddings_file=default_content_type["embeddings-file"],
+        )
+
+        current_config = (
+            state.config.content_type[content_type]
+            if state.config and state.config.content_type and state.config.content_type[content_type]  # type: ignore
+            else default_config
+        )
+        current_config = json.loads(current_config.json())
+
+        return templates.TemplateResponse(
+            "content_type_input.html",
+            context={
+                "request": request,
+                "current_config": current_config,
+                "content_type": content_type,
+            },
+        )
+
+    @web_client.get("/config/processor/conversation", response_class=HTMLResponse)
+    def conversation_processor_config_page(request: Request):
+        default_copy = constants.default_config.copy()
+        default_processor_config = default_copy["processor"]["conversation"]  # type: ignore
+        default_processor_config = ConversationProcessorConfig(
+            openai_api_key="",
+            model=default_processor_config["model"],
+            conversation_logfile=default_processor_config["conversation-logfile"],
+            chat_model=default_processor_config["chat-model"],
+        )
+
+        current_processor_conversation_config = (
+            state.config.processor.conversation
+            if state.config and state.config.processor and state.config.processor.conversation
+            else default_processor_config
+        )
+        current_processor_conversation_config = json.loads(current_processor_conversation_config.json())
+
+        return templates.TemplateResponse(
+            "processor_conversation_input.html",
+            context={
+                "request": request,
+                "current_config": current_processor_conversation_config,
+            },
+        )

--- a/src/khoj/utils/cli.py
+++ b/src/khoj/utils/cli.py
@@ -34,6 +34,7 @@ def cli(args=None):
         help="Path to UNIX socket for server. Use to run server behind reverse proxy. Default: /tmp/uvicorn.sock",
     )
     parser.add_argument("--version", "-V", action="store_true", help="Print the installed Khoj version and exit")
+    parser.add_argument("--demo", action="store_true", default=False, help="Run Khoj in demo mode")
 
     args = parser.parse_args(args)
 

--- a/src/khoj/utils/state.py
+++ b/src/khoj/utils/state.py
@@ -27,6 +27,7 @@ search_index_lock = threading.Lock()
 SearchType = utils_config.SearchType
 telemetry: List[Dict[str, str]] = []
 previous_query: str = None
+demo: bool = False
 
 if torch.cuda.is_available():
     # Use CUDA GPU


### PR DESCRIPTION
# Incoming
- Add a separate view if the instance is meant for demo purposes. This adds a banner prompting users to sign up for the waitlist and guides them to the landing page. This view also hides the settings page.
- In theory, this will be suitable for any Khoj instance that's meant for external-facing purposes (as in, outside of the user's network)
- Prevent re-indexing for Github data if this is a demo instance
- Fix up some issues with the CSS which made settings page small in mobile
- In the frontend views for Khoj, add a button to get on the waitlist and links to the landing page