### PR TITLE
Fix configuration setup logic in Obsidian

### DIFF
--- a/src/interface/obsidian/src/search_modal.ts
+++ b/src/interface/obsidian/src/search_modal.ts
@@ -161,7 +161,7 @@ export class KhojSearchModal extends SuggestModal<SearchResult> {
         // Open vault file at heading of chosen search result
         if (file_match) {
             let resultHeading = file_match.extension !== 'pdf' ? result.entry.split('\n', 1)[0] : '';
-            let linkToEntry = `${file_match.path}${resultHeading}`
+            let linkToEntry = resultHeading.startsWith('#') ? `${file_match.path}${resultHeading}` : file_match.path;
             this.app.workspace.openLinkText(linkToEntry, '');
             console.log(`Link: ${linkToEntry}, File: ${file_match.path}, Heading: ${resultHeading}`);
         }

--- a/src/interface/obsidian/src/utils.ts
+++ b/src/interface/obsidian/src/utils.ts
@@ -1,6 +1,5 @@
 import { FileSystemAdapter, Notice, RequestUrlParam, request, Vault, Modal } from 'obsidian';
 import { KhojSetting } from 'src/settings'
-import * as fs from 'fs';
 
 export function getVaultAbsolutePath(vault: Vault): string {
     let adaptor = vault.adapter;
@@ -111,9 +110,9 @@ export async function configureKhojBackend(vault: Vault, setting: KhojSetting, n
                     data["content-type"]["pdf"]["input-filter"].length != 1 ||
                     data["content-type"]["pdf"]["input-filter"][0] !== pdfInVault)) {
 
-                let pdfs = fs.readdirSync(vaultPath).filter(file => file.endsWith(".pdf"));
+                let hasPdfFiles = app.vault.getFiles().some(file => file.extension === 'pdf');
 
-                if (pdfs.length > 0) {
+                if (hasPdfFiles) {
                     // Update pdf config in khoj content-type config
                     // Set pdf config to only index pdf files in configured obsidian vault
                     let khojPdfIndexDirectory = getIndexDirectoryFromBackendConfig(data["content-type"]["pdf"]["embeddings-file"]);

--- a/src/interface/obsidian/src/utils.ts
+++ b/src/interface/obsidian/src/utils.ts
@@ -73,28 +73,26 @@ export async function configureKhojBackend(vault: Vault, setting: KhojSetting, n
                 }
             }
             // Else if khoj is not configured to index markdown files in configured obsidian vault
-            else if (data["content-type"]["markdown"]["input-filter"] == null ||
+            else if (
                 data["content-type"]["markdown"]["input-files"] != null ||
+                data["content-type"]["markdown"]["input-filter"] == null ||
                 data["content-type"]["markdown"]["input-filter"].length != 1 ||
                 data["content-type"]["markdown"]["input-filter"][0] !== mdInVault) {
-                // Update markdown config in khoj content-type config
-                // Set markdown config to only index markdown files in configured obsidian vault
-                let khojMdIndexDirectory = getIndexDirectoryFromBackendConfig(data["content-type"]["markdown"]["embeddings-file"]);
-                data["content-type"]["markdown"] = {
-                    "input-filter": [mdInVault],
-                    "input-files": null,
-                    "embeddings-file": `${khojMdIndexDirectory}/${indexName}.pt`,
-                    "compressed-jsonl": `${khojMdIndexDirectory}/${indexName}.jsonl.gz`,
-                }
+                    // Update markdown config in khoj content-type config
+                    // Set markdown config to only index markdown files in configured obsidian vault
+                    let khojMdIndexDirectory = getIndexDirectoryFromBackendConfig(data["content-type"]["markdown"]["embeddings-file"]);
+                    data["content-type"]["markdown"] = {
+                        "input-filter": [mdInVault],
+                        "input-files": null,
+                        "embeddings-file": `${khojMdIndexDirectory}/${indexName}.pt`,
+                        "compressed-jsonl": `${khojMdIndexDirectory}/${indexName}.jsonl.gz`,
+                    }
             }
 
             if (khoj_already_configured && !data["content-type"]["pdf"]) {
-                // Add pdf config to khoj content-type config
-                // Set pdf config to index pdf files in configured obsidian vault
+                const hasPdfFiles = app.vault.getFiles().some(file => file.extension === 'pdf');
 
-                let pdfs = fs.readdirSync(vaultPath).filter(file => file.endsWith(".pdf"));
-
-                if (pdfs.length > 0) {
+                if (hasPdfFiles) {
                     data["content-type"]["pdf"] = {
                         "input-filter": [pdfInVault],
                         "input-files": null,
@@ -107,9 +105,11 @@ export async function configureKhojBackend(vault: Vault, setting: KhojSetting, n
             }
             // Else if khoj is not configured to index pdf files in configured obsidian vault
             else if (khoj_already_configured &&
-                (data["content-type"]["pdf"]["input-filter"] == null ||
-                data["content-type"]["pdf"]["input-filter"].length != 1 ||
-                data["content-type"]["pdf"]["input-filter"][0] !== pdfInVault)) {
+                (
+                    data["content-type"]["pdf"]["input-files"] != null ||
+                    data["content-type"]["pdf"]["input-filter"] == null ||
+                    data["content-type"]["pdf"]["input-filter"].length != 1 ||
+                    data["content-type"]["pdf"]["input-filter"][0] !== pdfInVault)) {
 
                 let pdfs = fs.readdirSync(vaultPath).filter(file => file.endsWith(".pdf"));
 


### PR DESCRIPTION
# Incoming
- Don't add the pdf vault to the Khoj configuration if the user does not have any PDFs in their vault
- For markdown configuration, reset all preset values to follow the Obsidian vault. Eventually, we'll need to have better support for users who have an Obsidian vault and also have files outside their vault, but this should suffice for now
- If a file has no subheadings, do not try to deep link to the matching entry