### PR TITLE
Skip indexing a PDF that has a loading error

### DIFF
--- a/src/khoj/processor/pdf/pdf_to_jsonl.py
+++ b/src/khoj/processor/pdf/pdf_to_jsonl.py
@@ -98,10 +98,14 @@ class PdfToJsonl(TextToJsonl):
         entries = []
         entry_to_location_map = []
         for pdf_file in pdf_files:
-            loader = PyPDFLoader(pdf_file)
-            pdf_entries_per_file = [page.page_content for page in loader.load()]
-            entry_to_location_map += zip(pdf_entries_per_file, [pdf_file] * len(pdf_entries_per_file))
-            entries.extend(pdf_entries_per_file)
+            try:
+                loader = PyPDFLoader(pdf_file)
+                pdf_entries_per_file = [page.page_content for page in loader.load()]
+                entry_to_location_map += zip(pdf_entries_per_file, [pdf_file] * len(pdf_entries_per_file))
+                entries.extend(pdf_entries_per_file)
+            except Exception as e:
+                logger.error(f"Error processing file: {pdf_file}. This file will not be indexed.")
+                logger.error(e)
 
         return entries, dict(entry_to_location_map)
 


### PR DESCRIPTION
# Incoming
- If there's a single PDF file that has an indexing issue, the entire job fails and Khoj setup is killed. Instead, loudly log the error but continue processing.

There are additional details for the reason for this fix [in this Discord thread](https://discord.com/channels/1112065956647284756/1125330945550073876/1125550990997864550). A user was unable to index their vault due to a single failure, but also unable to pinpoint which file was causing the issue.