### PR TITLE
Re-instate the scheduler for the demo instances

### DIFF
--- a/src/khoj/configure.py
+++ b/src/khoj/configure.py
@@ -67,7 +67,7 @@ def configure_routes(app):
     app.include_router(web_client)
 
 
-@schedule.repeat(schedule.every(61).minutes)
+@schedule.repeat(schedule.every(constants.update_cadence_minutes).minutes)
 def update_search_index():
     state.search_index_lock.acquire()
     state.model = configure_search(state.model, state.config, regenerate=False)

--- a/src/khoj/configure.py
+++ b/src/khoj/configure.py
@@ -67,12 +67,14 @@ def configure_routes(app):
     app.include_router(web_client)
 
 
-@schedule.repeat(schedule.every(constants.update_cadence_minutes).minutes)
-def update_search_index():
-    state.search_index_lock.acquire()
-    state.model = configure_search(state.model, state.config, regenerate=False)
-    state.search_index_lock.release()
-    logger.info("📬 Search index updated via Scheduler")
+if not state.demo:
+
+    @schedule.repeat(schedule.every(61).minutes)
+    def update_search_index():
+        state.search_index_lock.acquire()
+        state.model = configure_search(state.model, state.config, regenerate=False)
+        state.search_index_lock.release()
+        logger.info("📬 Search index updated via Scheduler")
 
 
 def configure_search_types(config: FullConfig):

--- a/src/khoj/main.py
+++ b/src/khoj/main.py
@@ -65,9 +65,8 @@ def run():
     logger.info("🌘 Starting Khoj")
 
     if not args.gui:
-        if not state.demo:
-            # Setup task scheduler
-            poll_task_scheduler()
+        # Setup task scheduler
+        poll_task_scheduler()
 
         # Start Server
         configure_server(args, required=False)

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -41,6 +41,7 @@ from fastapi.responses import StreamingResponse
 api = APIRouter()
 logger = logging.getLogger(__name__)
 
+# If it's a demo instance, prevent updating any of the configuration.
 if not state.demo:
 
     @api.get("/config/data", response_model=FullConfig)

--- a/src/khoj/utils/constants.py
+++ b/src/khoj/utils/constants.py
@@ -1,10 +1,13 @@
 from pathlib import Path
+from khoj.utils import state
 
 app_root_directory = Path(__file__).parent.parent.parent
 web_directory = app_root_directory / "khoj/interface/web/"
 empty_escape_sequences = "\n|\r|\t| "
 app_env_filepath = "~/.khoj/env"
 telemetry_server = "https://khoj.beta.haletic.com/v1/telemetry"
+
+update_cadence_minutes = 60 * 24 if state.demo else 60  # 24 hours if demo, 1 hour otherwise
 
 # default app config to use
 default_config = {

--- a/src/khoj/utils/constants.py
+++ b/src/khoj/utils/constants.py
@@ -1,13 +1,10 @@
 from pathlib import Path
-from khoj.utils import state
 
 app_root_directory = Path(__file__).parent.parent.parent
 web_directory = app_root_directory / "khoj/interface/web/"
 empty_escape_sequences = "\n|\r|\t| "
 app_env_filepath = "~/.khoj/env"
 telemetry_server = "https://khoj.beta.haletic.com/v1/telemetry"
-
-update_cadence_minutes = 60 * 24 if state.demo else 60  # 24 hours if demo, 1 hour otherwise
 
 # default app config to use
 default_config = {


### PR DESCRIPTION
# Incoming
- Re-instate the scheduler, but infrequently for index updates
- In constants, determine the cadence based on whether it's a demo instance or not
- This allow us to collect telemetry again. This will also allow us to save the chat session