### PR TITLE
Make Number of Results used to Generate Chat Response Configurable

### DIFF
--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -83,7 +83,7 @@
   :type 'integer)
 
 (defcustom khoj-results-count 5
-  "Number of results to get from Khoj API for each query."
+  "Number of results to show in search and use for chat responses."
   :group 'khoj
   :type 'integer)
 
@@ -766,7 +766,7 @@ Render results in BUFFER-NAME using QUERY, CONTENT-TYPE."
   "Send QUERY to Khoj Chat API."
   (let* ((url-request-method "GET")
          (encoded-query (url-hexify-string query))
-         (query-url (format "%s/api/chat?q=%s&client=emacs" khoj-server-url encoded-query)))
+         (query-url (format "%s/api/chat?q=%s&n=%s&client=emacs" khoj-server-url khoj-results-count encoded-query)))
     (with-temp-buffer
       (condition-case ex
           (progn

--- a/src/interface/obsidian/src/chat_modal.ts
+++ b/src/interface/obsidian/src/chat_modal.ts
@@ -158,7 +158,7 @@ export class KhojChatModal extends Modal {
 
         // Get chat response from Khoj backend
         let encodedQuery = encodeURIComponent(query);
-        let chatUrl = `${this.setting.khojUrl}/api/chat?q=${encodedQuery}&client=obsidian`;
+        let chatUrl = `${this.setting.khojUrl}/api/chat?q=${encodedQuery}&n=${this.setting.resultsCount}&client=obsidian`;
         let responseElement = this.createKhojResponseDiv();
 
         // Temporary status message to indicate that Khoj is thinking

--- a/src/interface/obsidian/src/settings.ts
+++ b/src/interface/obsidian/src/settings.ts
@@ -54,7 +54,7 @@ export class KhojSettingTab extends PluginSettingTab {
                 }));
         new Setting(containerEl)
             .setName('Results Count')
-            .setDesc('The number of search results to show')
+            .setDesc('The number of results to show in search and use for chat')
             .addSlider(slider => slider
                 .setLimits(1, 10, 1)
                 .setValue(this.plugin.settings.resultsCount)

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -436,6 +436,7 @@ def chat_init(
 async def chat(
     request: Request,
     q: Optional[str] = None,
+    n: Optional[int] = 5,
     client: Optional[str] = None,
     user_agent: Optional[str] = Header(None),
     referer: Optional[str] = Header(None),
@@ -495,7 +496,7 @@ async def chat(
             result_list = []
             for query in inferred_queries:
                 result_list.extend(
-                    await search(query, request=request, n=5, r=False, score_threshold=-5.0, dedupe=False)
+                    await search(query, request=request, n=n, r=False, score_threshold=-5.0, dedupe=False)
                 )
             compiled_references = [item.additional["compiled"] for item in result_list]
 


### PR DESCRIPTION
- Update chat API to accept number of results to use
- Update Obsidian and Emacs clients to send number of results to use for chat
  - Both Emacs, Obsidian use the existing client side results count settings