### PR TITLE
[Fix] Obsidian interface setup without PDFs in vault

### DIFF
--- a/src/interface/obsidian/src/utils.ts
+++ b/src/interface/obsidian/src/utils.ts
@@ -51,8 +51,13 @@ export async function configureKhojBackend(vault: Vault, setting: KhojSetting, n
                         "input-files": null,
                         "embeddings-file": `${khojDefaultMdIndexDirectory}/${indexName}.pt`,
                         "compressed-jsonl": `${khojDefaultMdIndexDirectory}/${indexName}.jsonl.gz`,
-                    },
-                    "pdf": {
+                    }
+                }
+
+                const hasPdfFiles = app.vault.getFiles().some(file => file.extension === 'pdf');
+
+                if (hasPdfFiles) {
+                    data["content-type"]["pdf"] = {
                         "input-filter": [pdfInVault],
                         "input-files": null,
                         "embeddings-file": `${khojDefaultPdfIndexDirectory}/${indexName}.pt`,


### PR DESCRIPTION
# Incoming
Even when Khoj is not yet configured, we're initializing the Khoj configuration with PDFs, regardless of whether PDFs are in the vault.

Fix it to only add PDF configuration if `.pdf` files are found in the vault.

Closes #291