### PR TITLE
Encode config as utf-8 during setup in khoj.el

### DIFF
--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -609,7 +609,7 @@ CONFIG is json obtained from Khoj config API."
   ;; POST provided config to khoj server
   (let ((url-request-method "POST")
         (url-request-extra-headers '(("Content-Type" . "application/json")))
-        (url-request-data (json-encode-alist config))
+        (url-request-data (encode-coding-string (json-encode-alist config) 'utf-8))
         (config-url (format "%s/api/config/data" khoj-server-url)))
     (with-current-buffer (url-retrieve-synchronously config-url)
       (buffer-string)))


### PR DESCRIPTION
otherwise it will complain for unicode characters, see https://github.com/magit/ghub/commit/1c855310909340791e5ed0410ffa6b64dbec1fed