### PR TITLE
Reduce size of Docker image and build it from local

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN apt update -y && \
     apt -y install python3-pip python3-pyqt6 git
 
 # Install Application
-RUN pip install --no-cache-dir git+https://github.com/khoj-ai/khoj.git
+COPY . .
+RUN sed -i 's/dynamic = \["version"\]/version = "0.0.0"/' pyproject.toml && \
+    pip install --no-cache-dir .
 
 # Run the Application
 # There are more arguments required for the application to run,


### PR DESCRIPTION
### Improvements
- 6308388 Install Khoj on Docker from local code instead of pulling from Github
- 802472c Reduce Khoj Docker image size by 2Gb by not caching installed pip packages. Refer [issue comment](https://github.com/khoj-ai/khoj/issues/148#issuecomment-1627443570)