### PR TITLE
Reuse Search Models across Content Types to reduce Memory Consumption

### DIFF
--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, HTTPException, Header, Request
 from sentence_transformers import util
 
 # Internal Packages
-from khoj.configure import configure_processor, configure_search
+from khoj.configure import configure_content, configure_processor, configure_search
 from khoj.search_type import image_search, text_search
 from khoj.search_filter.date_filter import DateFilter
 from khoj.search_filter.file_filter import FileFilter
@@ -102,17 +102,17 @@ if not state.demo:
             state.config.content_type[content_type] = None
 
         if content_type == "github":
-            state.model.github_search = None
+            state.content_index.github = None
         elif content_type == "notion":
-            state.model.notion_search = None
+            state.content_index.notion = None
         elif content_type == "plugins":
-            state.model.plugin_search = None
+            state.content_index.plugins = None
         elif content_type == "pdf":
-            state.model.pdf_search = None
+            state.content_index.pdf = None
         elif content_type == "markdown":
-            state.model.markdown_search = None
+            state.content_index.markdown = None
         elif content_type == "org":
-            state.model.org_search = None
+            state.content_index.org = None
 
         try:
             save_config_to_file_updated_state()
@@ -182,7 +182,7 @@ def get_config_types():
         for search_type in SearchType
         if (
             search_type.value in configured_content_types
-            and getattr(state.model, f"{search_type.value}_search") is not None
+            and getattr(state.content_index, search_type.value) is not None
         )
         or ("plugins" in configured_content_types and search_type.name in configured_content_types["plugins"])
         or search_type == SearchType.All
@@ -210,7 +210,7 @@ async def search(
     if q is None or q == "":
         logger.warning(f"No query param (q) passed in API call to initiate search")
         return results
-    if not state.model or not any(state.model.__dict__.values()):
+    if not state.search_models or not any(state.search_models.__dict__.values()):
         logger.warning(f"No search models loaded. Configure a search model before initiating search")
         return results
 
@@ -234,7 +234,7 @@ async def search(
     encoded_asymmetric_query = None
     if t == SearchType.All or t != SearchType.Image:
         text_search_models: List[TextSearchModel] = [
-            model for model in state.model.__dict__.values() if isinstance(model, TextSearchModel)
+            model for model in state.search_models.__dict__.values() if isinstance(model, TextSearchModel)
         ]
         if text_search_models:
             with timer("Encoding query took", logger=logger):
@@ -247,13 +247,14 @@ async def search(
                 )
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        if (t == SearchType.Org or t == SearchType.All) and state.model.org_search:
+        if (t == SearchType.Org or t == SearchType.All) and state.content_index.org and state.search_models.text_search:
             # query org-mode notes
             search_futures += [
                 executor.submit(
                     text_search.query,
                     user_query,
-                    state.model.org_search,
+                    state.search_models.text_search,
+                    state.content_index.org,
                     question_embedding=encoded_asymmetric_query,
                     rank_results=r or False,
                     score_threshold=score_threshold,
@@ -261,13 +262,18 @@ async def search(
                 )
             ]
 
-        if (t == SearchType.Markdown or t == SearchType.All) and state.model.markdown_search:
+        if (
+            (t == SearchType.Markdown or t == SearchType.All)
+            and state.content_index.markdown
+            and state.search_models.text_search
+        ):
             # query markdown notes
             search_futures += [
                 executor.submit(
                     text_search.query,
                     user_query,
-                    state.model.markdown_search,
+                    state.search_models.text_search,
+                    state.content_index.markdown,
                     question_embedding=encoded_asymmetric_query,
                     rank_results=r or False,
                     score_threshold=score_threshold,
@@ -275,13 +281,18 @@ async def search(
                 )
             ]
 
-        if (t == SearchType.Github or t == SearchType.All) and state.model.github_search:
+        if (
+            (t == SearchType.Github or t == SearchType.All)
+            and state.content_index.github
+            and state.search_models.text_search
+        ):
             # query github issues
             search_futures += [
                 executor.submit(
                     text_search.query,
                     user_query,
-                    state.model.github_search,
+                    state.search_models.text_search,
+                    state.content_index.github,
                     question_embedding=encoded_asymmetric_query,
                     rank_results=r or False,
                     score_threshold=score_threshold,
@@ -289,13 +300,14 @@ async def search(
                 )
             ]
 
-        if (t == SearchType.Pdf or t == SearchType.All) and state.model.pdf_search:
+        if (t == SearchType.Pdf or t == SearchType.All) and state.content_index.pdf and state.search_models.text_search:
             # query pdf files
             search_futures += [
                 executor.submit(
                     text_search.query,
                     user_query,
-                    state.model.pdf_search,
+                    state.search_models.text_search,
+                    state.content_index.pdf,
                     question_embedding=encoded_asymmetric_query,
                     rank_results=r or False,
                     score_threshold=score_threshold,
@@ -303,26 +315,38 @@ async def search(
                 )
             ]
 
-        if (t == SearchType.Image) and state.model.image_search:
+        if (t == SearchType.Image) and state.content_index.image and state.search_models.image_search:
             # query images
             search_futures += [
                 executor.submit(
                     image_search.query,
                     user_query,
                     results_count,
-                    state.model.image_search,
+                    state.search_models.image_search,
+                    state.content_index.image,
                     score_threshold=score_threshold,
                 )
             ]
 
-        if (t == SearchType.All or t in SearchType) and state.model.plugin_search:
+        if (
+            (t == SearchType.All or t in SearchType)
+            and state.content_index.plugins
+            and state.search_models.plugin_search
+        ):
             # query specified plugin type
+            # Get plugin content, search model for specified search type, or the first one if none specified
+            plugin_search = state.search_models.plugin_search.get(t.value) or next(
+                iter(state.search_models.plugin_search.values())
+            )
+            plugin_content = state.content_index.plugins.get(t.value) or next(
+                iter(state.content_index.plugins.values())
+            )
             search_futures += [
                 executor.submit(
                     text_search.query,
                     user_query,
-                    # Get plugin search model for specified search type, or the first one if none specified
-                    state.model.plugin_search.get(t.value) or next(iter(state.model.plugin_search.values())),
+                    plugin_search,
+                    plugin_content,
                     question_embedding=encoded_asymmetric_query,
                     rank_results=r or False,
                     score_threshold=score_threshold,
@@ -330,13 +354,18 @@ async def search(
                 )
             ]
 
-        if (t == SearchType.Notion or t == SearchType.All) and state.model.notion_search:
+        if (
+            (t == SearchType.Notion or t == SearchType.All)
+            and state.content_index.notion
+            and state.search_models.text_search
+        ):
             # query notion pages
             search_futures += [
                 executor.submit(
                     text_search.query,
                     user_query,
-                    state.model.notion_search,
+                    state.search_models.text_search,
+                    state.content_index.notion,
                     question_embedding=encoded_asymmetric_query,
                     rank_results=r or False,
                     score_threshold=score_threshold,
@@ -347,13 +376,13 @@ async def search(
         # Query across each requested content types in parallel
         with timer("Query took", logger):
             for search_future in concurrent.futures.as_completed(search_futures):
-                if t == SearchType.Image:
+                if t == SearchType.Image and state.content_index.image:
                     hits = await search_future.result()
                     output_directory = constants.web_directory / "images"
                     # Collate results
                     results += image_search.collate_results(
                         hits,
-                        image_names=state.model.image_search.image_names,
+                        image_names=state.content_index.image.image_names,
                         output_directory=output_directory,
                         image_files_url="/static/images",
                         count=results_count,
@@ -404,7 +433,12 @@ def update(
     try:
         state.search_index_lock.acquire()
         try:
-            state.model = configure_search(state.model, state.config, regenerate=force or False, t=t)
+            if state.config and state.config.search_type:
+                state.search_models = configure_search(state.search_models, state.config.search_type)
+            if state.search_models:
+                state.content_index = configure_content(
+                    state.content_index, state.config.content_type, state.search_models, regenerate=force or False, t=t
+                )
         except Exception as e:
             logger.error(e)
             raise HTTPException(status_code=500, detail=str(e))

--- a/src/khoj/utils/config.py
+++ b/src/khoj/utils/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations  # to avoid quoting type hints
 from enum import Enum
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 # External Packages
 import torch
@@ -30,42 +30,48 @@ class ProcessorType(str, Enum):
     Conversation = "conversation"
 
 
+@dataclass
+class TextContent:
+    entries: List[Entry]
+    corpus_embeddings: torch.Tensor
+    filters: List[BaseFilter]
+
+
+@dataclass
+class ImageContent:
+    image_names: List[str]
+    image_embeddings: torch.Tensor
+    image_metadata_embeddings: torch.Tensor
+
+
+@dataclass
 class TextSearchModel:
-    def __init__(
-        self,
-        entries: List[Entry],
-        corpus_embeddings: torch.Tensor,
-        bi_encoder: BaseEncoder,
-        cross_encoder: CrossEncoder,
-        filters: List[BaseFilter],
-        top_k,
-    ):
-        self.entries = entries
-        self.corpus_embeddings = corpus_embeddings
-        self.bi_encoder = bi_encoder
-        self.cross_encoder = cross_encoder
-        self.filters = filters
-        self.top_k = top_k
+    bi_encoder: BaseEncoder
+    cross_encoder: Optional[CrossEncoder] = None
+    top_k: Optional[int] = 15
 
 
+@dataclass
 class ImageSearchModel:
-    def __init__(self, image_names, image_embeddings, image_metadata_embeddings, image_encoder: BaseEncoder):
-        self.image_encoder = image_encoder
-        self.image_names = image_names
-        self.image_embeddings = image_embeddings
-        self.image_metadata_embeddings = image_metadata_embeddings
-        self.image_encoder = image_encoder
+    image_encoder: BaseEncoder
+
+
+@dataclass
+class ContentIndex:
+    org: Optional[TextContent] = None
+    markdown: Optional[TextContent] = None
+    pdf: Optional[TextContent] = None
+    github: Optional[TextContent] = None
+    notion: Optional[TextContent] = None
+    image: Optional[ImageContent] = None
+    plugins: Optional[Dict[str, TextContent]] = None
 
 
 @dataclass
 class SearchModels:
-    org_search: Union[TextSearchModel, None] = None
-    markdown_search: Union[TextSearchModel, None] = None
-    pdf_search: Union[TextSearchModel, None] = None
-    image_search: Union[ImageSearchModel, None] = None
-    github_search: Union[TextSearchModel, None] = None
-    notion_search: Union[TextSearchModel, None] = None
-    plugin_search: Union[Dict[str, TextSearchModel], None] = None
+    text_search: Optional[TextSearchModel] = None
+    image_search: Optional[ImageSearchModel] = None
+    plugin_search: Optional[Dict[str, TextSearchModel]] = None
 
 
 class ConversationProcessorConfigModel:

--- a/src/khoj/utils/helpers.py
+++ b/src/khoj/utils/helpers.py
@@ -20,7 +20,7 @@ from khoj.utils import constants
 
 if TYPE_CHECKING:
     # External Packages
-    from sentence_transformers import CrossEncoder
+    from sentence_transformers import SentenceTransformer, CrossEncoder
 
     # Internal Packages
     from khoj.utils.models import BaseEncoder
@@ -64,7 +64,9 @@ def merge_dicts(priority_dict: dict, default_dict: dict):
     return merged_dict
 
 
-def load_model(model_name: str, model_type, model_dir=None, device: str = None) -> Union[BaseEncoder, CrossEncoder]:
+def load_model(
+    model_name: str, model_type, model_dir=None, device: str = None
+) -> Union[BaseEncoder, SentenceTransformer, CrossEncoder]:
     "Load model from disk or huggingface"
     # Construct model path
     logger = logging.getLogger(__name__)

--- a/src/khoj/utils/rawconfig.py
+++ b/src/khoj/utils/rawconfig.py
@@ -119,9 +119,9 @@ class AppConfig(ConfigBase):
 
 
 class FullConfig(ConfigBase):
-    content_type: Optional[ContentConfig]
-    search_type: Optional[SearchConfig]
-    processor: Optional[ProcessorConfig]
+    content_type: Optional[ContentConfig] = None
+    search_type: Optional[SearchConfig] = None
+    processor: Optional[ProcessorConfig] = None
     app: Optional[AppConfig] = AppConfig(should_log_telemetry=True)
 
 

--- a/src/khoj/utils/state.py
+++ b/src/khoj/utils/state.py
@@ -9,13 +9,14 @@ from pathlib import Path
 
 # Internal Packages
 from khoj.utils import config as utils_config
-from khoj.utils.config import SearchModels, ProcessorConfigModel
+from khoj.utils.config import ContentIndex, SearchModels, ProcessorConfigModel
 from khoj.utils.helpers import LRU
 from khoj.utils.rawconfig import FullConfig
 
 # Application Global State
 config = FullConfig()
-model = SearchModels()
+search_models = SearchModels()
+content_index = ContentIndex()
 processor_config = ProcessorConfigModel()
 config_file: Path = None
 verbose: int = 0


### PR DESCRIPTION
- Memory consumption now only scales with search models used, not with content types. 
  Previously each content type had it's own copy of the search ML models. 
  That'd result in 300+ Mb per enabled text content type

- Split model state into 2 separate state objects, `search_models` and `content_index`. 
  This allows loading text_search and image_search models first
  and then reusing them across all content_types in content_index

- The change should cut down memory utilization quite a bit for most users.
  I see a >50% drop in memory utilization on my Khoj instance. 
  But this will vary for each user based on the amount of content indexed vs number of plugins enabled.

- This change does not solve the RAM utilization scaling with size of the index,
  as the whole content index is still kept in RAM while Khoj is running

Should help with #195, #301 and #303