### PR TITLE
Create Schema Migrator and Reindex to Apply Index Corruption Fixes

### DIFF
--- a/src/khoj/utils/cli.py
+++ b/src/khoj/utils/cli.py
@@ -5,7 +5,7 @@ from importlib.metadata import version
 
 # Internal Packages
 from khoj.utils.helpers import resolve_absolute_path
-from khoj.utils.yaml import parse_config_from_file
+from khoj.utils.yaml import load_config_from_file, parse_config_from_file, save_config_to_file
 
 
 def cli(args=None):
@@ -34,9 +34,10 @@ def cli(args=None):
 
     args = parser.parse_args(args)
 
+    args.version_no = version("khoj-assistant")
     if args.version:
         # Show version of khoj installed and exit
-        print(version("khoj-assistant"))
+        print(args.version_no)
         exit(0)
 
     # Normalize config_file path to absolute path
@@ -45,6 +46,16 @@ def cli(args=None):
     if not args.config_file.exists():
         args.config = None
     else:
+        migrate_config(args)
         args.config = parse_config_from_file(args.config_file)
 
     return args
+
+
+def migrate_config(args):
+    raw_config = load_config_from_file(args.config_file)
+
+    # Add version to khoj config schema
+    if "version" not in raw_config:
+        raw_config["version"] = args.version_no
+        save_config_to_file(raw_config, args.config_file)

--- a/src/khoj/utils/cli.py
+++ b/src/khoj/utils/cli.py
@@ -46,7 +46,7 @@ def cli(args=None):
     if not args.config_file.exists():
         args.config = None
     else:
-        migrate_config(args)
+        args = migrate_config(args)
         args.config = parse_config_from_file(args.config_file)
 
     return args
@@ -59,3 +59,9 @@ def migrate_config(args):
     if "version" not in raw_config:
         raw_config["version"] = args.version_no
         save_config_to_file(raw_config, args.config_file)
+
+        # regenerate khoj index on first start of this version
+        # this should refresh index and apply index corruption fixes from #325
+        args.regenerate = True
+
+    return args

--- a/src/khoj/utils/rawconfig.py
+++ b/src/khoj/utils/rawconfig.py
@@ -123,6 +123,7 @@ class FullConfig(ConfigBase):
     search_type: Optional[SearchConfig] = None
     processor: Optional[ProcessorConfig] = None
     app: Optional[AppConfig] = AppConfig(should_log_telemetry=True)
+    version: Optional[str] = None
 
 
 class SearchResponse(ConfigBase):


### PR DESCRIPTION
### Updates
- 83e1088 Manage `khoj.yml` config migrations on app start. Version the `khoj.yml` schema
- 429e1b4 Regenerate index to apply corruption fixes on first run of this khoj version
   Otherwise users would need to manually re-index their contents with khoj