### PR TITLE
Replace Falcon 🦅 model with Llama V2 🦙 for offline chat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
     "pypdf >= 3.9.0",
     "requests >= 2.26.0",
     "bs4 >= 0.0.1",
-    "gpt4all==1.0.5",
+    "gpt4all >= 1.0.7",
 ]
 dynamic = ["version"]
 

--- a/src/khoj/interface/web/config.html
+++ b/src/khoj/interface/web/config.html
@@ -229,7 +229,7 @@
                     </h3>
                 </div>
                 <div class="card-description-row">
-                <p class="card-description">Setup offline chat (Falcon 7B)</p>
+                <p class="card-description">Setup offline chat (Llama V2)</p>
                 </div>
                 <div id="clear-enable-offline-chat" class="card-action-row {% if current_config.processor and current_config.processor.conversation and current_config.processor.conversation.enable_offline_chat %}enabled{% else %}disabled{% endif %}">
                     <button class="card-button" onclick="toggleEnableLocalLLLM(false)">

--- a/src/khoj/processor/conversation/gpt4all/chat_model.py
+++ b/src/khoj/processor/conversation/gpt4all/chat_model.py
@@ -14,18 +14,22 @@ from khoj.utils.constants import empty_escape_sequences
 logger = logging.getLogger(__name__)
 
 
-def extract_questions_falcon(
+def extract_questions_llama(
     text: str,
     model: str = "llama-2-7b-chat.ggmlv3.q4_K_S.bin",
     loaded_model: Union[GPT4All, None] = None,
     conversation_log={},
-    use_history: bool = False,
+    use_history: bool = True,
+    should_extract_questions: bool = True,
 ):
     """
     Infer search queries to retrieve relevant notes to answer user query
     """
     all_questions = text.split("? ")
     all_questions = [q + "?" for q in all_questions[:-1]] + [all_questions[-1]]
+
+    if not should_extract_questions:
+        return all_questions
 
     gpt4all_model = loaded_model or GPT4All(model)
 
@@ -43,17 +47,44 @@ def extract_questions_falcon(
                 else:
                     chat_history += prompts.chat_history_llamav2_from_assistant.format(message=chat["intent"]["query"])
 
-    message = prompts.system_prompt_llamav2.format(
+    if use_history:
+        for chat in conversation_log.get("chat", [])[-4:]:
+            if chat["by"] == "khoj":
+                chat_history += prompts.chat_history_llamav2_from_user.format(message=chat["intent"]["query"])
+                if chat["intent"].get("inferred-queries"):
+                    chat_history += prompts.chat_history_llamav2_from_assistant.format(
+                        message=chat["intent"]["inferred-queries"]
+                    )
+                else:
+                    chat_history += prompts.chat_history_llamav2_from_assistant.format(message=chat["intent"]["query"])
+
+    current_date = datetime.now().strftime("%Y-%m-%d")
+    last_year = datetime.now().year - 1
+    last_christmas_date = f"{last_year}-12-25"
+    next_christmas_date = f"{datetime.now().year}-12-25"
+    system_prompt = prompts.extract_questions_system_prompt_llamav2.format(
         message=(prompts.system_prompt_message_extract_questions_llamav2)
-    ) + prompts.extract_questions_llamav2_sample.format(query=text, chat_history=chat_history)
-    response = gpt4all_model.generate(message, max_tokens=200, top_k=2)
+    )
+    example_questions = prompts.extract_questions_llamav2_sample.format(
+        query=text,
+        chat_history=chat_history,
+        current_date=current_date,
+        last_year=last_year,
+        last_christmas_date=last_christmas_date,
+        next_christmas_date=next_christmas_date,
+    )
+    message = system_prompt + example_questions
+    response = gpt4all_model.generate(message, max_tokens=200, top_k=2, temp=0)
 
     # Extract, Clean Message from GPT's Response
     try:
+        # This will expect to be a list with a single string with a list of questions
         questions = (
             str(response)
             .strip(empty_escape_sequences)
             .replace("['", '["')
+            .replace("<s>", "")
+            .replace("</s>", "")
             .replace("']", '"]')
             .replace("', '", '", "')
             .replace('["', "")
@@ -61,14 +92,14 @@ def extract_questions_falcon(
             .split('", "')
         )
     except:
-        logger.warning(f"Falcon returned invalid JSON. Falling back to using user message as search query.\n{response}")
+        logger.warning(f"Llama returned invalid JSON. Falling back to using user message as search query.\n{response}")
         return all_questions
-    logger.debug(f"Extracted Questions by Falcon: {questions}")
+    logger.debug(f"Extracted Questions by Llama: {questions}")
     questions.extend(all_questions)
     return questions
 
 
-def converse_falcon(
+def converse_llama(
     references,
     user_query,
     conversation_log={},
@@ -77,7 +108,7 @@ def converse_falcon(
     completion_func=None,
 ) -> ThreadedGenerator:
     """
-    Converse with user using Falcon
+    Converse with user using Llama
     """
     gpt4all_model = loaded_model or GPT4All(model)
     # Initialize Variables

--- a/src/khoj/processor/conversation/gpt4all/chat_model.py
+++ b/src/khoj/processor/conversation/gpt4all/chat_model.py
@@ -14,7 +14,7 @@ from khoj.utils.constants import empty_escape_sequences
 logger = logging.getLogger(__name__)
 
 
-def extract_questions_llama(
+def extract_questions_offline(
     text: str,
     model: str = "llama-2-7b-chat.ggmlv3.q4_K_S.bin",
     loaded_model: Union[GPT4All, None] = None,
@@ -106,7 +106,7 @@ def filter_questions(questions: List[str]):
     return filtered_questions
 
 
-def converse_llama(
+def converse_offline(
     references,
     user_query,
     conversation_log={},

--- a/src/khoj/processor/conversation/gpt4all/chat_model.py
+++ b/src/khoj/processor/conversation/gpt4all/chat_model.py
@@ -76,12 +76,34 @@ def extract_questions_llama(
             .split("? ")
         )
         questions = [q + "?" for q in questions[:-1]] + [questions[-1]]
+        questions = filter_questions(questions)
     except:
         logger.warning(f"Llama returned invalid JSON. Falling back to using user message as search query.\n{response}")
         return all_questions
     logger.debug(f"Extracted Questions by Llama: {questions}")
     questions.extend(all_questions)
     return questions
+
+
+def filter_questions(questions: List[str]):
+    # Skip questions that seem to be apologizing for not being able to answer the question
+    hint_words = [
+        "sorry",
+        "apologize",
+        "unable",
+        "can't",
+        "cannot",
+        "don't know",
+        "don't understand",
+        "do not know",
+        "do not understand",
+    ]
+    filtered_questions = []
+    for q in questions:
+        if not any([word in q.lower() for word in hint_words]):
+            filtered_questions.append(q)
+
+    return filtered_questions
 
 
 def converse_llama(

--- a/src/khoj/processor/conversation/gpt4all/chat_model.py
+++ b/src/khoj/processor/conversation/gpt4all/chat_model.py
@@ -20,15 +20,12 @@ def extract_questions_falcon(
     loaded_model: Union[GPT4All, None] = None,
     conversation_log={},
     use_history: bool = False,
-    run_extraction: bool = False,
 ):
     """
     Infer search queries to retrieve relevant notes to answer user query
     """
     all_questions = text.split("? ")
     all_questions = [q + "?" for q in all_questions[:-1]] + [all_questions[-1]]
-    # if not run_extraction:
-    # return all_questions
 
     gpt4all_model = loaded_model or GPT4All(model)
 

--- a/src/khoj/processor/conversation/gpt4all/chat_model.py
+++ b/src/khoj/processor/conversation/gpt4all/chat_model.py
@@ -39,24 +39,8 @@ def extract_questions_llama(
     if use_history:
         for chat in conversation_log.get("chat", [])[-4:]:
             if chat["by"] == "khoj":
-                chat_history += prompts.chat_history_llamav2_from_user.format(message=chat["intent"]["query"])
-                if chat["intent"].get("inferred-queries"):
-                    chat_history += prompts.chat_history_llamav2_from_assistant.format(
-                        message=chat["intent"]["inferred-queries"]
-                    )
-                else:
-                    chat_history += prompts.chat_history_llamav2_from_assistant.format(message=chat["intent"]["query"])
-
-    if use_history:
-        for chat in conversation_log.get("chat", [])[-4:]:
-            if chat["by"] == "khoj":
-                chat_history += prompts.chat_history_llamav2_from_user.format(message=chat["intent"]["query"])
-                if chat["intent"].get("inferred-queries"):
-                    chat_history += prompts.chat_history_llamav2_from_assistant.format(
-                        message=chat["intent"]["inferred-queries"]
-                    )
-                else:
-                    chat_history += prompts.chat_history_llamav2_from_assistant.format(message=chat["intent"]["query"])
+                chat_history += f"Q: {chat['intent']['query']}\n"
+                chat_history += f"A: {chat['message']}\n"
 
     current_date = datetime.now().strftime("%Y-%m-%d")
     last_year = datetime.now().year - 1
@@ -89,8 +73,9 @@ def extract_questions_llama(
             .replace("', '", '", "')
             .replace('["', "")
             .replace('"]', "")
-            .split('", "')
+            .split("? ")
         )
+        questions = [q + "?" for q in questions[:-1]] + [questions[-1]]
     except:
         logger.warning(f"Llama returned invalid JSON. Falling back to using user message as search query.\n{response}")
         return all_questions

--- a/src/khoj/processor/conversation/gpt4all/model_metadata.py
+++ b/src/khoj/processor/conversation/gpt4all/model_metadata.py
@@ -1,0 +1,3 @@
+model_name_to_url = {
+    "llama-2-7b-chat.ggmlv3.q4_K_S.bin": "https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGML/resolve/main/llama-2-7b-chat.ggmlv3.q3_K_M.bin"
+}

--- a/src/khoj/processor/conversation/gpt4all/utils.py
+++ b/src/khoj/processor/conversation/gpt4all/utils.py
@@ -1,0 +1,33 @@
+import os
+import logging
+import requests
+from gpt4all import GPT4All
+import tqdm
+
+from khoj.processor.conversation.gpt4all import model_metadata
+
+logger = logging.getLogger(__name__)
+
+
+def download_model(model_name):
+    url = model_metadata.model_name_to_url.get(model_name)
+    if not url:
+        logger.debug(f"Model {model_name} not found in model metadata. Skipping download.")
+        return GPT4All(model_name)
+
+    filename = os.path.expanduser(f"~/.cache/gpt4all/{model_name}")
+    if os.path.exists(filename):
+        return GPT4All(model_name)
+
+    try:
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        logger.debug(f"Downloading model {model_name} from {url} to {filename}...")
+        with requests.get(url, stream=True) as r:
+            r.raise_for_status()
+            with open(filename, "wb") as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    f.write(chunk)
+        return GPT4All(model_name)
+    except Exception as e:
+        logger.error(f"Failed to download model {model_name} from {url} to {filename}. Error: {e}")
+        return None

--- a/src/khoj/processor/conversation/prompts.py
+++ b/src/khoj/processor/conversation/prompts.py
@@ -18,34 +18,37 @@ Question: {query}
 """.strip()
 )
 
-general_conversation_falcon = PromptTemplate.from_template(
-    """
-Using your general knowledge and our past conversations as context, answer the following question.
-### Instruct:
-{query}
-### Response:
-""".strip()
-)
+system_prompt_message_llamav2 = f"""You are Khoj, a friendly, smart and helpful personal assistant.
+Using your general knowledge and our past conversations as context, answer the following question."""
 
-chat_history_falcon_from_user = PromptTemplate.from_template(
+system_prompt_llamav2 = PromptTemplate.from_template(
     """
-### Human:
+<s>[INST] <<SYS>>
 {message}
+<</SYS>>Hi there! [/INST] Hello! How can I help you today? </s>"""
+)
+
+general_conversation_llamav2 = PromptTemplate.from_template(
+    """
+<s>[INST]{query}[/INST]
 """.strip()
 )
 
-chat_history_falcon_from_assistant = PromptTemplate.from_template(
+chat_history_llamav2_from_user = PromptTemplate.from_template(
     """
-### Assistant:
-{message}
+<s>[INST]{message}[/INST]
 """.strip()
 )
 
-conversation_falcon = PromptTemplate.from_template(
+chat_history_llamav2_from_assistant = PromptTemplate.from_template(
     """
-Using our past conversations as context, answer the following question.
+{message}</s>
+""".strip()
+)
 
-Question: {query}
+conversation_llamav2 = PromptTemplate.from_template(
+    """
+<s>[INST]{query}[/INST]
 """.strip()
 )
 
@@ -63,13 +66,10 @@ Question: {query}
 """.strip()
 )
 
-notes_conversation_falcon = PromptTemplate.from_template(
+notes_conversation_llamav2 = PromptTemplate.from_template(
     """
-Using the notes and our past conversations as context, answer the following question. If the answer is not contained within the notes, say "I don't know."
-
 Notes:
 {references}
-
 Question: {query}
 """.strip()
 )

--- a/src/khoj/processor/conversation/prompts.py
+++ b/src/khoj/processor/conversation/prompts.py
@@ -21,6 +21,10 @@ Question: {query}
 system_prompt_message_llamav2 = f"""You are Khoj, a friendly, smart and helpful personal assistant.
 Using your general knowledge and our past conversations as context, answer the following question."""
 
+system_prompt_message_extract_questions_llamav2 = f"""You are Khoj, a friendly, smart and helpful personal assistant.
+When a user supplies you a question, you respond with follow-up question you would need to ask to clarify the information. Here are some examples:
+"""
+
 system_prompt_llamav2 = PromptTemplate.from_template(
     """
 <s>[INST] <<SYS>>
@@ -111,35 +115,21 @@ Answer (in second person):"""
 
 extract_questions_falcon = PromptTemplate.from_template(
     """
-You are Khoj, an extremely smart and helpful search assistant with the ability to retrieve information from the user's notes.
 - The user will provide their questions and answers to you for context.
 - Add as much context from the previous questions and answers as required into your search queries.
 - Break messages into multiple search queries when required to retrieve the relevant information.
-- Add date filters to your search queries from questions and answers when required to retrieve the relevant information.
 
-What searches, if any, will you need to perform to answer the users question?
+What searches, if any, will you need to perform to answer the users' question?
+"""
+)
 
-Q: How was my trip to Cambodia?
-
-["How was my trip to Cambodia?"]
-
-A: The trip was amazing. I went to the Angkor Wat temple and it was beautiful.
-
-Q: Who did i visit that temple with?
-
-["Who did I visit the Angkor Wat Temple in Cambodia with?"]
-
-A: You visited the Angkor Wat Temple in Cambodia with Pablo, Namita and Xi.
-
-Q: How many tennis balls fit in the back of a 2002 Honda Civic?
-
-["What is the size of a tennis ball?", "What is the trunk size of a 2002 Honda Civic?"]
-
-A: 1085 tennis balls will fit in the trunk of a Honda Civic
-
+extract_questions_llamav2_sample = PromptTemplate.from_template(
+    """
+<s>[INST]How was my vacation?[/INST]["What vacations did you take?"]</s>
+<s>[INST]How should I take care of my plants?[/INST]["What kind of plants do I have?", "What issues do my plants have?"]</s>
+<s>[INST]How many tennis balls fit in the back of a 2002 Honda Civic?[/INST]["What is the size of a tennis ball?", "What is the trunk size of a 2002 Honda Civic?"]</s>
 {chat_history}
-Q: {text}
-
+<s>[INST]{query}[/INST]
 """
 )
 

--- a/src/khoj/processor/conversation/prompts.py
+++ b/src/khoj/processor/conversation/prompts.py
@@ -21,8 +21,12 @@ Question: {query}
 system_prompt_message_llamav2 = f"""You are Khoj, a friendly, smart and helpful personal assistant.
 Using your general knowledge and our past conversations as context, answer the following question."""
 
-system_prompt_message_extract_questions_llamav2 = f"""You are Khoj, a friendly, smart and helpful personal assistant.
-When a user supplies you a question, you respond with follow-up question you would need to ask to clarify the information. Here are some examples:
+system_prompt_message_extract_questions_llamav2 = f"""You are Khoj, a kind and intelligent personal assistant.
+- When the user asks you a question, you ask follow-up questions to clarify the necessary information you need in order to answer from the user's perspective.
+- Add as much context from the previous questions and answers as required into your search queries.
+- Add date filters to your search queries from questions and answers when required to retrieve the relevant information.
+- Provide search queries as a list of questions
+What follow-up questions, if any, will you need to ask to answer the user's question?
 """
 
 system_prompt_llamav2 = PromptTemplate.from_template(
@@ -30,6 +34,13 @@ system_prompt_llamav2 = PromptTemplate.from_template(
 <s>[INST] <<SYS>>
 {message}
 <</SYS>>Hi there! [/INST] Hello! How can I help you today? </s>"""
+)
+
+extract_questions_system_prompt_llamav2 = PromptTemplate.from_template(
+    """
+<s>[INST] <<SYS>>
+{message}
+<</SYS>>[/INST]</s>"""
 )
 
 general_conversation_llamav2 = PromptTemplate.from_template(
@@ -113,21 +124,17 @@ Question: {user_query}
 Answer (in second person):"""
 )
 
-extract_questions_falcon = PromptTemplate.from_template(
-    """
-- The user will provide their questions and answers to you for context.
-- Add as much context from the previous questions and answers as required into your search queries.
-- Break messages into multiple search queries when required to retrieve the relevant information.
-
-What searches, if any, will you need to perform to answer the users' question?
-"""
-)
-
 extract_questions_llamav2_sample = PromptTemplate.from_template(
     """
-<s>[INST]How was my vacation?[/INST]["What vacations did you take?"]</s>
-<s>[INST]How should I take care of my plants?[/INST]["What kind of plants do I have?", "What issues do my plants have?"]</s>
-<s>[INST]How many tennis balls fit in the back of a 2002 Honda Civic?[/INST]["What is the size of a tennis ball?", "What is the trunk size of a 2002 Honda Civic?"]</s>
+<s>[INST]<<SYS>>Current Date: {current_date}<</SYS>>[/INST]</s>
+
+<s>[INST]How was my trip to Cambodia?[/INST][]</s>
+<s>[INST]Who did I visit the temple with on that trip?[/INST]Who did I visit the temple with in Cambodia?</s>
+<s>[INST]How should I take care of my plants?[/INST]What kind of plants do I have? What issues do my plants have?</s>
+<s>[INST]How many tennis balls fit in the back of a 2002 Honda Civic?[/INST]What is the size of a tennis ball? What is the trunk size of a 2002 Honda Civic?</s>
+<s>[INST]What did I do for Christmas last year?[/INST]What did I do for Christmas {last_year} dt>='{last_christmas_date}' dt<'{next_christmas_date}'</s>
+<s>[INST]How are you feeling today?[/INST]</s>
+<s>[INST]Is Alice older than Bob?[/INST]When was Alice born? What is Bob's age?</s>
 {chat_history}
 <s>[INST]{query}[/INST]
 """

--- a/src/khoj/processor/conversation/prompts.py
+++ b/src/khoj/processor/conversation/prompts.py
@@ -23,7 +23,9 @@ Using your general knowledge and our past conversations as context, answer the f
 
 system_prompt_message_extract_questions_llamav2 = f"""You are Khoj, a kind and intelligent personal assistant.
 - When the user asks you a question, you ask follow-up questions to clarify the necessary information you need in order to answer from the user's perspective.
-- Add as much context from the previous questions and answers as required into your search queries.
+- Try to be as specific as possible. For example, rather than use "they" or "it", use the name of the person or thing you are referring to.
+- Write the question as if you can search for the answer on the user's personal notes.
+- Add as much context from the previous questions and notes as required into your search queries.
 - Add date filters to your search queries from questions and answers when required to retrieve the relevant information.
 - Provide search queries as a list of questions
 What follow-up questions, if any, will you need to ask to answer the user's question?
@@ -127,6 +129,10 @@ Answer (in second person):"""
 extract_questions_llamav2_sample = PromptTemplate.from_template(
     """
 <s>[INST]<<SYS>>Current Date: {current_date}<</SYS>>[/INST]</s>
+<s>[INST]<<SYS>>
+Use these notes from the user's previous conversations to provide a response:
+{chat_history}
+<</SYS>>[/INST]</s>
 
 <s>[INST]How was my trip to Cambodia?[/INST][]</s>
 <s>[INST]Who did I visit the temple with on that trip?[/INST]Who did I visit the temple with in Cambodia?</s>
@@ -135,7 +141,6 @@ extract_questions_llamav2_sample = PromptTemplate.from_template(
 <s>[INST]What did I do for Christmas last year?[/INST]What did I do for Christmas {last_year} dt>='{last_christmas_date}' dt<'{next_christmas_date}'</s>
 <s>[INST]How are you feeling today?[/INST]</s>
 <s>[INST]Is Alice older than Bob?[/INST]When was Alice born? What is Bob's age?</s>
-{chat_history}
 <s>[INST]{query}[/INST]
 """
 )

--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -13,7 +13,7 @@ import queue
 from khoj.utils.helpers import merge_dicts
 
 logger = logging.getLogger(__name__)
-max_prompt_size = {"gpt-3.5-turbo": 4096, "gpt-4": 8192, "text-davinci-001": 910}
+max_prompt_size = {"gpt-3.5-turbo": 4096, "gpt-4": 8192, "llama-2-7b-chat.ggmlv3.q4_K_S.bin": 2048}
 
 
 class ThreadedGenerator:
@@ -102,7 +102,10 @@ def generate_chatml_messages_with_context(
 
 def truncate_messages(messages, max_prompt_size, model_name):
     """Truncate messages to fit within max prompt size supported by model"""
-    encoder = tiktoken.encoding_for_model(model_name)
+    try:
+        encoder = tiktoken.encoding_for_model(model_name)
+    except KeyError:
+        encoder = tiktoken.encoding_for_model("text-davinci-001")
     tokens = sum([len(encoder.encode(message.content)) for message in messages])
     while tokens > max_prompt_size and len(messages) > 1:
         messages.pop()

--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -13,7 +13,7 @@ import queue
 from khoj.utils.helpers import merge_dicts
 
 logger = logging.getLogger(__name__)
-max_prompt_size = {"gpt-3.5-turbo": 4096, "gpt-4": 8192, "llama-2-7b-chat.ggmlv3.q4_K_S.bin": 2048}
+max_prompt_size = {"gpt-3.5-turbo": 4096, "gpt-4": 8192, "llama-2-7b-chat.ggmlv3.q4_K_S.bin": 850}
 
 
 class ThreadedGenerator:

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -716,7 +716,7 @@ async def extract_references_and_questions(
             else:
                 loaded_model = state.processor_config.conversation.gpt4all_model.loaded_model
                 inferred_queries = extract_questions_llama(
-                    q, loaded_model=loaded_model, conversation_log=meta_log, use_history=True
+                    q, loaded_model=loaded_model, conversation_log=meta_log, should_extract_questions=False
                 )
 
         # Collate search results as context for GPT

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -38,7 +38,7 @@ from khoj.utils.yaml import save_config_to_file_updated_state
 from fastapi.responses import StreamingResponse, Response
 from khoj.routers.helpers import perform_chat_checks, generate_chat_response, update_telemetry_state
 from khoj.processor.conversation.openai.gpt import extract_questions
-from khoj.processor.conversation.gpt4all.chat_model import extract_questions_llama, converse_llama
+from khoj.processor.conversation.gpt4all.chat_model import extract_questions_llama
 from fastapi.requests import Request
 
 

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -715,7 +715,9 @@ async def extract_references_and_questions(
                 inferred_queries = extract_questions(q, model=chat_model, api_key=api_key, conversation_log=meta_log)
             else:
                 loaded_model = state.processor_config.conversation.gpt4all_model.loaded_model
-                inferred_queries = extract_questions_falcon(q, loaded_model=loaded_model, conversation_log=meta_log)
+                inferred_queries = extract_questions_falcon(
+                    q, loaded_model=loaded_model, conversation_log=meta_log, use_history=True
+                )
 
         # Collate search results as context for GPT
         with timer("Searching knowledge base took", logger):

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -38,7 +38,7 @@ from khoj.utils.yaml import save_config_to_file_updated_state
 from fastapi.responses import StreamingResponse, Response
 from khoj.routers.helpers import perform_chat_checks, generate_chat_response, update_telemetry_state
 from khoj.processor.conversation.openai.gpt import extract_questions
-from khoj.processor.conversation.gpt4all.chat_model import extract_questions_llama
+from khoj.processor.conversation.gpt4all.chat_model import extract_questions_offline
 from fastapi.requests import Request
 
 
@@ -715,7 +715,7 @@ async def extract_references_and_questions(
                 inferred_queries = extract_questions(q, model=chat_model, api_key=api_key, conversation_log=meta_log)
             else:
                 loaded_model = state.processor_config.conversation.gpt4all_model.loaded_model
-                inferred_queries = extract_questions_llama(
+                inferred_queries = extract_questions_offline(
                     q, loaded_model=loaded_model, conversation_log=meta_log, should_extract_questions=False
                 )
 

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -38,7 +38,7 @@ from khoj.utils.yaml import save_config_to_file_updated_state
 from fastapi.responses import StreamingResponse, Response
 from khoj.routers.helpers import perform_chat_checks, generate_chat_response, update_telemetry_state
 from khoj.processor.conversation.openai.gpt import extract_questions
-from khoj.processor.conversation.gpt4all.chat_model import extract_questions_falcon, converse_falcon
+from khoj.processor.conversation.gpt4all.chat_model import extract_questions_llama, converse_llama
 from fastapi.requests import Request
 
 
@@ -715,7 +715,7 @@ async def extract_references_and_questions(
                 inferred_queries = extract_questions(q, model=chat_model, api_key=api_key, conversation_log=meta_log)
             else:
                 loaded_model = state.processor_config.conversation.gpt4all_model.loaded_model
-                inferred_queries = extract_questions_falcon(
+                inferred_queries = extract_questions_llama(
                     q, loaded_model=loaded_model, conversation_log=meta_log, use_history=True
                 )
 

--- a/src/khoj/routers/helpers.py
+++ b/src/khoj/routers/helpers.py
@@ -8,7 +8,7 @@ from fastapi import HTTPException, Request
 from khoj.utils import state
 from khoj.utils.helpers import timer, log_telemetry
 from khoj.processor.conversation.openai.gpt import converse
-from khoj.processor.conversation.gpt4all.chat_model import converse_falcon
+from khoj.processor.conversation.gpt4all.chat_model import converse_llama
 from khoj.processor.conversation.utils import reciprocal_conversation_to_chatml, message_to_log, ThreadedGenerator
 
 logger = logging.getLogger(__name__)
@@ -111,7 +111,7 @@ def generate_chat_response(
                 )
             else:
                 loaded_model = state.processor_config.conversation.gpt4all_model.loaded_model
-                chat_response = converse_falcon(
+                chat_response = converse_llama(
                     references=compiled_references,
                     user_query=q,
                     loaded_model=loaded_model,

--- a/src/khoj/routers/helpers.py
+++ b/src/khoj/routers/helpers.py
@@ -8,7 +8,7 @@ from fastapi import HTTPException, Request
 from khoj.utils import state
 from khoj.utils.helpers import timer, log_telemetry
 from khoj.processor.conversation.openai.gpt import converse
-from khoj.processor.conversation.gpt4all.chat_model import converse_llama
+from khoj.processor.conversation.gpt4all.chat_model import converse_offline
 from khoj.processor.conversation.utils import reciprocal_conversation_to_chatml, message_to_log, ThreadedGenerator
 
 logger = logging.getLogger(__name__)
@@ -111,7 +111,7 @@ def generate_chat_response(
                 )
             else:
                 loaded_model = state.processor_config.conversation.gpt4all_model.loaded_model
-                chat_response = converse_llama(
+                chat_response = converse_offline(
                     references=compiled_references,
                     user_query=q,
                     loaded_model=loaded_model,

--- a/src/khoj/utils/config.py
+++ b/src/khoj/utils/config.py
@@ -5,8 +5,7 @@ from enum import Enum
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Union, Any
-
-from gpt4all import GPT4All
+from khoj.processor.conversation.gpt4all.utils import download_model
 
 # External Packages
 import torch
@@ -79,7 +78,7 @@ class SearchModels:
 
 @dataclass
 class GPT4AllProcessorConfig:
-    chat_model: Optional[str] = "ggml-model-gpt4all-falcon-q4_0.bin"
+    chat_model: Optional[str] = "llama-2-7b-chat.ggmlv3.q4_K_S.bin"
     loaded_model: Union[Any, None] = None
 
 
@@ -96,7 +95,7 @@ class ConversationProcessorConfigModel:
         self.meta_log: dict = {}
 
         if not self.openai_model and self.enable_offline_chat:
-            self.gpt4all_model.loaded_model = GPT4All(self.gpt4all_model.chat_model)  # type: ignore
+            self.gpt4all_model.loaded_model = download_model(self.gpt4all_model.chat_model)
         else:
             self.gpt4all_model.loaded_model = None
 

--- a/tests/test_gpt4all_chat_actors.py
+++ b/tests/test_gpt4all_chat_actors.py
@@ -4,7 +4,7 @@ from datetime import datetime
 # External Packages
 import pytest
 
-SKIP_TESTS = False
+SKIP_TESTS = True
 pytestmark = pytest.mark.skipif(
     SKIP_TESTS,
     reason="The GPT4All library has some quirks that make it hard to test in CI. This causes some tests to fail. Hence, disable it in CI.",

--- a/tests/test_gpt4all_chat_actors.py
+++ b/tests/test_gpt4all_chat_actors.py
@@ -16,7 +16,7 @@ from freezegun import freeze_time
 from gpt4all import GPT4All
 
 # Internal Packages
-from khoj.processor.conversation.gpt4all.chat_model import converse_llama, extract_questions_llama, filter_questions
+from khoj.processor.conversation.gpt4all.chat_model import converse_offline, extract_questions_offline, filter_questions
 from khoj.processor.conversation.gpt4all.utils import download_model
 
 from khoj.processor.conversation.utils import message_to_log
@@ -39,7 +39,7 @@ freezegun.configure(extend_ignore_list=["transformers"])
 @freeze_time("1984-04-02")
 def test_extract_question_with_date_filter_from_relative_day(loaded_model):
     # Act
-    response = extract_questions_llama("Where did I go for dinner yesterday?", loaded_model=loaded_model)
+    response = extract_questions_offline("Where did I go for dinner yesterday?", loaded_model=loaded_model)
 
     assert len(response) >= 1
 
@@ -59,7 +59,7 @@ def test_extract_question_with_date_filter_from_relative_day(loaded_model):
 @freeze_time("1984-04-02")
 def test_extract_question_with_date_filter_from_relative_month(loaded_model):
     # Act
-    response = extract_questions_llama("Which countries did I visit last month?", loaded_model=loaded_model)
+    response = extract_questions_offline("Which countries did I visit last month?", loaded_model=loaded_model)
 
     # Assert
     assert len(response) >= 1
@@ -80,7 +80,7 @@ def test_extract_question_with_date_filter_from_relative_month(loaded_model):
 @freeze_time("1984-04-02")
 def test_extract_question_with_date_filter_from_relative_year(loaded_model):
     # Act
-    response = extract_questions_llama("Which countries have I visited this year?", loaded_model=loaded_model)
+    response = extract_questions_offline("Which countries have I visited this year?", loaded_model=loaded_model)
 
     # Assert
     assert len(response) >= 1
@@ -91,7 +91,7 @@ def test_extract_question_with_date_filter_from_relative_year(loaded_model):
 @pytest.mark.chatquality
 def test_extract_multiple_explicit_questions_from_message(loaded_model):
     # Act
-    response = extract_questions_llama("What is the Sun? What is the Moon?", loaded_model=loaded_model)
+    response = extract_questions_offline("What is the Sun? What is the Moon?", loaded_model=loaded_model)
 
     # Assert
     expected_responses = ["What is the Sun?", "What is the Moon?"]
@@ -104,7 +104,7 @@ def test_extract_multiple_explicit_questions_from_message(loaded_model):
 @pytest.mark.chatquality
 def test_extract_multiple_implicit_questions_from_message(loaded_model):
     # Act
-    response = extract_questions_llama("Is Morpheus taller than Neo?", loaded_model=loaded_model)
+    response = extract_questions_offline("Is Morpheus taller than Neo?", loaded_model=loaded_model)
 
     # Assert
     expected_responses = [
@@ -125,7 +125,7 @@ def test_generate_search_query_using_question_from_chat_history(loaded_model):
     ]
 
     # Act
-    response = extract_questions_llama(
+    response = extract_questions_offline(
         "Does he have any sons?",
         conversation_log=populate_chat_history(message_list),
         loaded_model=loaded_model,
@@ -157,7 +157,7 @@ def test_generate_search_query_using_answer_from_chat_history(loaded_model):
     ]
 
     # Act
-    response = extract_questions_llama(
+    response = extract_questions_offline(
         "Is she a Jedi?",
         conversation_log=populate_chat_history(message_list),
         loaded_model=loaded_model,
@@ -173,7 +173,7 @@ def test_generate_search_query_using_answer_from_chat_history(loaded_model):
     # Assert
     assert len(response) >= 1
     assert any([expected_response in response[0] for expected_response in expected_responses]), (
-        "Expected chat actor to ask for clarification in response, but got: " + response[0]
+        "Expected chat actor to mention Darth Vader's daughter, but got: " + response[0]
     )
 
 
@@ -187,7 +187,7 @@ def test_generate_search_query_with_date_and_context_from_chat_history(loaded_mo
     ]
 
     # Act
-    response = extract_questions_llama(
+    response = extract_questions_offline(
         "What was the Pizza place we ate at over there?",
         conversation_log=populate_chat_history(message_list),
         loaded_model=loaded_model,
@@ -211,7 +211,7 @@ def test_generate_search_query_with_date_and_context_from_chat_history(loaded_mo
 @pytest.mark.chatquality
 def test_chat_with_no_chat_history_or_retrieved_content(loaded_model):
     # Act
-    response_gen = converse_llama(
+    response_gen = converse_offline(
         references=[],  # Assume no context retrieved from notes for the user_query
         user_query="Hello, my name is Testatron. Who are you?",
         loaded_model=loaded_model,
@@ -241,7 +241,7 @@ def test_answer_from_chat_history_and_previously_retrieved_content(loaded_model)
     ]
 
     # Act
-    response_gen = converse_llama(
+    response_gen = converse_offline(
         references=[],  # Assume no context retrieved from notes for the user_query
         user_query="Where was I born?",
         conversation_log=populate_chat_history(message_list),
@@ -266,7 +266,7 @@ def test_answer_from_chat_history_and_currently_retrieved_content(loaded_model):
     ]
 
     # Act
-    response_gen = converse_llama(
+    response_gen = converse_offline(
         references=[
             "Testatron was born on 1st April 1984 in Testville."
         ],  # Assume context retrieved from notes for the user_query
@@ -292,7 +292,7 @@ def test_refuse_answering_unanswerable_question(loaded_model):
     ]
 
     # Act
-    response_gen = converse_llama(
+    response_gen = converse_offline(
         references=[],  # Assume no context retrieved from notes for the user_query
         user_query="Where was I born?",
         conversation_log=populate_chat_history(message_list),
@@ -333,7 +333,7 @@ Expenses:Food:Dining  10.00 USD""",
     ]
 
     # Act
-    response_gen = converse_llama(
+    response_gen = converse_offline(
         references=context,  # Assume context retrieved from notes for the user_query
         user_query="What did I have for Dinner today?",
         loaded_model=loaded_model,
@@ -365,7 +365,7 @@ Expenses:Food:Dining  10.00 USD""",
     ]
 
     # Act
-    response_gen = converse_llama(
+    response_gen = converse_offline(
         references=context,  # Assume context retrieved from notes for the user_query
         user_query="How much did I spend on dining this year?",
         loaded_model=loaded_model,
@@ -389,7 +389,7 @@ def test_answer_general_question_not_in_chat_history_or_retrieved_content(loaded
     ]
 
     # Act
-    response_gen = converse_llama(
+    response_gen = converse_offline(
         references=[],  # Assume no context retrieved from notes for the user_query
         user_query="Write a haiku about unit testing in 3 lines",
         conversation_log=populate_chat_history(message_list),
@@ -420,7 +420,7 @@ My sister, Aiyla is married to Tolga. They have 3 kids, Yildiz, Ali and Ahmet.""
     ]
 
     # Act
-    response_gen = converse_llama(
+    response_gen = converse_offline(
         references=context,  # Assume context retrieved from notes for the user_query
         user_query="How many kids does my older sister have?",
         loaded_model=loaded_model,

--- a/tests/test_gpt4all_chat_actors.py
+++ b/tests/test_gpt4all_chat_actors.py
@@ -16,7 +16,7 @@ from freezegun import freeze_time
 from gpt4all import GPT4All
 
 # Internal Packages
-from khoj.processor.conversation.gpt4all.chat_model import converse_llama, extract_questions_llama
+from khoj.processor.conversation.gpt4all.chat_model import converse_llama, extract_questions_llama, filter_questions
 from khoj.processor.conversation.gpt4all.utils import download_model
 
 from khoj.processor.conversation.utils import message_to_log
@@ -432,6 +432,17 @@ My sister, Aiyla is married to Tolga. They have 3 kids, Yildiz, Ali and Ahmet.""
     assert any([expected_response in response for expected_response in expected_responses]), (
         "Expected chat actor to ask for clarification in response, but got: " + response
     )
+
+
+def test_filter_questions():
+    test_questions = [
+        "I don't know how to answer that",
+        "I cannot answer anything about the nuclear secrets",
+        "Who is on the basketball team?",
+    ]
+    filtered_questions = filter_questions(test_questions)
+    assert len(filtered_questions) == 1
+    assert filtered_questions[0] == "Who is on the basketball team?"
 
 
 # Helpers

--- a/tests/test_gpt4all_chat_actors.py
+++ b/tests/test_gpt4all_chat_actors.py
@@ -95,8 +95,9 @@ def test_extract_multiple_explicit_questions_from_message(loaded_model):
 
     # Assert
     expected_responses = ["What is the Sun?", "What is the Moon?"]
-    assert len(response) == 2
-    assert expected_responses == response
+    assert len(response) >= 2
+    assert expected_responses[0] == response[-2]
+    assert expected_responses[1] == response[-1]
 
 
 # ----------------------------------------------------------------------------------------------------
@@ -107,9 +108,9 @@ def test_extract_multiple_implicit_questions_from_message(loaded_model):
 
     # Assert
     expected_responses = [
-        ("morpheus", "neo"),
+        ("morpheus", "neo", "height", "taller", "shorter"),
     ]
-    assert len(response) == 2
+    assert len(response) == 3
     assert any([start in response[0].lower() and end in response[1].lower() for start, end in expected_responses]), (
         "Expected two search queries in response but got: " + response[0]
     )

--- a/tests/test_gpt4all_chat_actors.py
+++ b/tests/test_gpt4all_chat_actors.py
@@ -4,7 +4,7 @@ from datetime import datetime
 # External Packages
 import pytest
 
-SKIP_TESTS = True
+SKIP_TESTS = False
 pytestmark = pytest.mark.skipif(
     SKIP_TESTS,
     reason="The GPT4All library has some quirks that make it hard to test in CI. This causes some tests to fail. Hence, disable it in CI.",
@@ -16,14 +16,18 @@ from freezegun import freeze_time
 from gpt4all import GPT4All
 
 # Internal Packages
-from khoj.processor.conversation.gpt4all.chat_model import converse_falcon, extract_questions_falcon
+from khoj.processor.conversation.gpt4all.chat_model import converse_llama, extract_questions_llama
+from khoj.processor.conversation.gpt4all.utils import download_model
 
 from khoj.processor.conversation.utils import message_to_log
+
+MODEL_NAME = "llama-2-7b-chat.ggmlv3.q4_K_S.bin"
 
 
 @pytest.fixture(scope="session")
 def loaded_model():
-    return GPT4All("ggml-model-gpt4all-falcon-q4_0.bin")
+    download_model(MODEL_NAME)
+    return GPT4All(MODEL_NAME)
 
 
 freezegun.configure(extend_ignore_list=["transformers"])
@@ -35,24 +39,40 @@ freezegun.configure(extend_ignore_list=["transformers"])
 @freeze_time("1984-04-02")
 def test_extract_question_with_date_filter_from_relative_day(loaded_model):
     # Act
-    response = extract_questions_falcon(
-        "Where did I go for dinner yesterday?", loaded_model=loaded_model, run_extraction=True
-    )
+    response = extract_questions_llama("Where did I go for dinner yesterday?", loaded_model=loaded_model)
 
     assert len(response) >= 1
-    assert response[-1] == "Where did I go for dinner yesterday?"
+
+    assert any(
+        [
+            "dt>='1984-04-01'" in response[0] and "dt<'1984-04-02'" in response[0],
+            "dt>='1984-04-01'" in response[0] and "dt<='1984-04-01'" in response[0],
+            'dt>="1984-04-01"' in response[0] and 'dt<"1984-04-02"' in response[0],
+            'dt>="1984-04-01"' in response[0] and 'dt<="1984-04-01"' in response[0],
+        ]
+    )
 
 
 # ----------------------------------------------------------------------------------------------------
+@pytest.mark.xfail(reason="Chat actor still isn't very date aware nor capable of formatting")
 @pytest.mark.chatquality
 @freeze_time("1984-04-02")
 def test_extract_question_with_date_filter_from_relative_month(loaded_model):
     # Act
-    response = extract_questions_falcon("Which countries did I visit last month?", loaded_model=loaded_model)
+    response = extract_questions_llama("Which countries did I visit last month?", loaded_model=loaded_model)
 
     # Assert
-    assert len(response) == 1
-    assert response == ["Which countries did I visit last month?"]
+    assert len(response) >= 1
+    # The user query should be the last question in the response
+    assert response[-1] == ["Which countries did I visit last month?"]
+    assert any(
+        [
+            "dt>='1984-03-01'" in response[0] and "dt<'1984-04-01'" in response[0],
+            "dt>='1984-03-01'" in response[0] and "dt<='1984-03-31'" in response[0],
+            'dt>="1984-03-01"' in response[0] and 'dt<"1984-04-01"' in response[0],
+            'dt>="1984-03-01"' in response[0] and 'dt<="1984-03-31"' in response[0],
+        ]
+    )
 
 
 # ----------------------------------------------------------------------------------------------------
@@ -60,9 +80,7 @@ def test_extract_question_with_date_filter_from_relative_month(loaded_model):
 @freeze_time("1984-04-02")
 def test_extract_question_with_date_filter_from_relative_year(loaded_model):
     # Act
-    response = extract_questions_falcon(
-        "Which countries have I visited this year?", loaded_model=loaded_model, run_extraction=True
-    )
+    response = extract_questions_llama("Which countries have I visited this year?", loaded_model=loaded_model)
 
     # Assert
     assert len(response) >= 1
@@ -73,7 +91,7 @@ def test_extract_question_with_date_filter_from_relative_year(loaded_model):
 @pytest.mark.chatquality
 def test_extract_multiple_explicit_questions_from_message(loaded_model):
     # Act
-    response = extract_questions_falcon("What is the Sun? What is the Moon?", loaded_model=loaded_model)
+    response = extract_questions_llama("What is the Sun? What is the Moon?", loaded_model=loaded_model)
 
     # Assert
     expected_responses = ["What is the Sun?", "What is the Moon?"]
@@ -85,7 +103,7 @@ def test_extract_multiple_explicit_questions_from_message(loaded_model):
 @pytest.mark.chatquality
 def test_extract_multiple_implicit_questions_from_message(loaded_model):
     # Act
-    response = extract_questions_falcon("Is Morpheus taller than Neo?", loaded_model=loaded_model, run_extraction=True)
+    response = extract_questions_llama("Is Morpheus taller than Neo?", loaded_model=loaded_model)
 
     # Assert
     expected_responses = [
@@ -106,18 +124,19 @@ def test_generate_search_query_using_question_from_chat_history(loaded_model):
     ]
 
     # Act
-    response = extract_questions_falcon(
+    response = extract_questions_llama(
         "Does he have any sons?",
         conversation_log=populate_chat_history(message_list),
         loaded_model=loaded_model,
-        run_extraction=True,
         use_history=True,
     )
 
     expected_responses = [
-        "do not have",
-        "clarify",
-        "am sorry",
+        "Vader",
+        "sons",
+        "son",
+        "Darth",
+        "children",
     ]
 
     # Assert
@@ -128,7 +147,7 @@ def test_generate_search_query_using_question_from_chat_history(loaded_model):
 
 
 # ----------------------------------------------------------------------------------------------------
-@pytest.mark.xfail(reason="Chat actor does not consistently follow template instructions.")
+# @pytest.mark.xfail(reason="Chat actor does not consistently follow template instructions.")
 @pytest.mark.chatquality
 def test_generate_search_query_using_answer_from_chat_history(loaded_model):
     # Arrange
@@ -137,17 +156,24 @@ def test_generate_search_query_using_answer_from_chat_history(loaded_model):
     ]
 
     # Act
-    response = extract_questions_falcon(
+    response = extract_questions_llama(
         "Is she a Jedi?",
         conversation_log=populate_chat_history(message_list),
         loaded_model=loaded_model,
-        run_extraction=True,
         use_history=True,
     )
 
+    expected_responses = [
+        "Leia",
+        "Vader",
+        "daughter",
+    ]
+
     # Assert
-    assert len(response) == 1
-    assert "Leia" in response[0]
+    assert len(response) >= 1
+    assert any([expected_response in response[0] for expected_response in expected_responses]), (
+        "Expected chat actor to ask for clarification in response, but got: " + response[0]
+    )
 
 
 # ----------------------------------------------------------------------------------------------------
@@ -160,10 +186,9 @@ def test_generate_search_query_with_date_and_context_from_chat_history(loaded_mo
     ]
 
     # Act
-    response = extract_questions_falcon(
+    response = extract_questions_llama(
         "What was the Pizza place we ate at over there?",
         conversation_log=populate_chat_history(message_list),
-        run_extraction=True,
         loaded_model=loaded_model,
     )
 
@@ -185,7 +210,7 @@ def test_generate_search_query_with_date_and_context_from_chat_history(loaded_mo
 @pytest.mark.chatquality
 def test_chat_with_no_chat_history_or_retrieved_content(loaded_model):
     # Act
-    response_gen = converse_falcon(
+    response_gen = converse_llama(
         references=[],  # Assume no context retrieved from notes for the user_query
         user_query="Hello, my name is Testatron. Who are you?",
         loaded_model=loaded_model,
@@ -201,7 +226,6 @@ def test_chat_with_no_chat_history_or_retrieved_content(loaded_model):
 
 
 # ----------------------------------------------------------------------------------------------------
-@pytest.mark.xfail(reason="Chat actor isn't really good at proper nouns yet.")
 @pytest.mark.chatquality
 def test_answer_from_chat_history_and_previously_retrieved_content(loaded_model):
     "Chat actor needs to use context in previous notes and chat history to answer question"
@@ -216,7 +240,7 @@ def test_answer_from_chat_history_and_previously_retrieved_content(loaded_model)
     ]
 
     # Act
-    response_gen = converse_falcon(
+    response_gen = converse_llama(
         references=[],  # Assume no context retrieved from notes for the user_query
         user_query="Where was I born?",
         conversation_log=populate_chat_history(message_list),
@@ -241,7 +265,7 @@ def test_answer_from_chat_history_and_currently_retrieved_content(loaded_model):
     ]
 
     # Act
-    response_gen = converse_falcon(
+    response_gen = converse_llama(
         references=[
             "Testatron was born on 1st April 1984 in Testville."
         ],  # Assume context retrieved from notes for the user_query
@@ -257,7 +281,6 @@ def test_answer_from_chat_history_and_currently_retrieved_content(loaded_model):
 
 
 # ----------------------------------------------------------------------------------------------------
-@pytest.mark.xfail(reason="Chat actor is rather liable to lying.")
 @pytest.mark.chatquality
 def test_refuse_answering_unanswerable_question(loaded_model):
     "Chat actor should not try make up answers to unanswerable questions."
@@ -268,7 +291,7 @@ def test_refuse_answering_unanswerable_question(loaded_model):
     ]
 
     # Act
-    response_gen = converse_falcon(
+    response_gen = converse_llama(
         references=[],  # Assume no context retrieved from notes for the user_query
         user_query="Where was I born?",
         conversation_log=populate_chat_history(message_list),
@@ -309,7 +332,7 @@ Expenses:Food:Dining  10.00 USD""",
     ]
 
     # Act
-    response_gen = converse_falcon(
+    response_gen = converse_llama(
         references=context,  # Assume context retrieved from notes for the user_query
         user_query="What did I have for Dinner today?",
         loaded_model=loaded_model,
@@ -341,7 +364,7 @@ Expenses:Food:Dining  10.00 USD""",
     ]
 
     # Act
-    response_gen = converse_falcon(
+    response_gen = converse_llama(
         references=context,  # Assume context retrieved from notes for the user_query
         user_query="How much did I spend on dining this year?",
         loaded_model=loaded_model,
@@ -365,7 +388,7 @@ def test_answer_general_question_not_in_chat_history_or_retrieved_content(loaded
     ]
 
     # Act
-    response_gen = converse_falcon(
+    response_gen = converse_llama(
         references=[],  # Assume no context retrieved from notes for the user_query
         user_query="Write a haiku about unit testing in 3 lines",
         conversation_log=populate_chat_history(message_list),
@@ -382,7 +405,6 @@ def test_answer_general_question_not_in_chat_history_or_retrieved_content(loaded
 
 
 # ----------------------------------------------------------------------------------------------------
-@pytest.mark.xfail(reason="Chat actor not consistently capable of asking for clarification yet.")
 @pytest.mark.chatquality
 def test_ask_for_clarification_if_not_enough_context_in_question(loaded_model):
     "Chat actor should ask for clarification if question cannot be answered unambiguously with the provided context"
@@ -397,7 +419,7 @@ My sister, Aiyla is married to Tolga. They have 3 kids, Yildiz, Ali and Ahmet.""
     ]
 
     # Act
-    response_gen = converse_falcon(
+    response_gen = converse_llama(
         references=context,  # Assume context retrieved from notes for the user_query
         user_query="How many kids does my older sister have?",
         loaded_model=loaded_model,


### PR DESCRIPTION
# Incoming
- Rather than release the first local LLM with Falcon, use Llama with the existing `GPT4All` setup.
- Rework the `extract_questions` flow. While Falcon's output wasn't high enough quality to actually use this functionality, Llama generally provides good enough responses (at least able to pass ~50% of the benchmark tests). That being said, query times might be too long to justify using this.
- Rename all references from `Falcon` -> `Llama`
- Update relevant unit tests to match Llama capability

Closes https://github.com/khoj-ai/khoj/issues/347