### PR TITLE
Fix #353: Remove references to localhost:8000

### DIFF
--- a/docs/notion_integration.md
+++ b/docs/notion_integration.md
@@ -8,7 +8,7 @@ We haven't setup a fancy integration with OAuth yet, so this integration still r
 ![setup_new_integration](https://github.com/khoj-ai/khoj/assets/65192171/b056e057-d4dc-47dc-aad3-57b59a22c68b)
 3. Share all the workspaces that you want to integrate with the Khoj integration you just made in the previous step
 ![enable_workspace](https://github.com/khoj-ai/khoj/assets/65192171/98290303-b5b8-4cb0-b32c-f68c6923a3d0)
-4. In the first step, you generated an API key. Use the newly generated API Key in your Khoj settings, by default at http://localhost:8000/config/content_type/notion. Click `Save`.
-5. Click `Configure` in http://localhost:8000/config to index your Notion workspace(s).
+4. In the first step, you generated an API key. Use the newly generated API Key in your Khoj settings, by default at http://localhost:42110/config/content_type/notion. Click `Save`.
+5. Click `Configure` in http://localhost:42110/config to index your Notion workspace(s).
 
 That's it! You should be ready to start searching and chatting. Make sure you've configured your OpenAI API Key for chat.


### PR DESCRIPTION
#### This fixes #353 

Updated the localhost:8000 port references in docs to the new default port localhost:42110.