### PR TITLE
Remove config example from compose command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,4 +25,4 @@ services:
       - ./tests/data/embeddings/:/data/embeddings/
       - ./tests/data/models/:/data/models/
     # Use 0.0.0.0 to explicitly set the host ip for the service on the container. https://pythonspeed.com/articles/docker-connection-refused/
-    command: --host="0.0.0.0" --port=42110 -c=config/khoj_docker.yml -vv
+    command: --host="0.0.0.0" --port=42110 -vv


### PR DESCRIPTION
Running the current docker compose file causes this error : 

``` 
[07:57:39] DEBUG    Extracting search queries took: 0.000 seconds helpers.py:117
           DEBUG    Encoding query took: 0.006 seconds            helpers.py:117
           DEBUG    Total Filter Time: 0.000 seconds on device:   helpers.py:119
                    cpu
           DEBUG    Search Time: 0.000 seconds on device: cpu     helpers.py:119
           DEBUG    Cross-Encoder Predict Time: 0.337 seconds on  helpers.py:119
                    device: cpu
           DEBUG    Rank Time: 0.000 seconds on device: cpu       helpers.py:119
           DEBUG    Deduplication Time: 0.000 seconds on device:  helpers.py:119
                    cpu
           DEBUG    Removed 0 duplicates                      text_search.py:268
           DEBUG    Total Filter Time: 0.000 seconds on device:   helpers.py:119
                    cpu
           DEBUG    Search Time: 0.000 seconds on device: cpu     helpers.py:119
           DEBUG    Cross-Encoder Predict Time: 0.265 seconds on  helpers.py:119
                    device: cpu
           DEBUG    Rank Time: 0.000 seconds on device: cpu       helpers.py:119
           DEBUG    Deduplication Time: 0.000 seconds on device:  helpers.py:119
                    cpu
           DEBUG    Removed 0 duplicates                      text_search.py:268
           DEBUG    Query took: 0.616 seconds                     helpers.py:117
           DEBUG    Searching knowledge base took: 0.625 seconds  helpers.py:117
           INFO     172.19.0.1:49646 - "GET                      h11_impl.py:431
                    /api/chat?q=How%20are%20you%3F&n=5&client=we
                    b&stream=true HTTP/1.1" 500
           ERROR    Exception in ASGI application                h11_impl.py:369
                    FileNotFoundError: [Errno 2] No such file or
                    directory: '/root/.khoj/env'
```

Removing the example config from the compose command allows for a fresh download of the repo to work with compose

