### PR TITLE
Fixed zsh error no matches found

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -13,6 +13,10 @@ python3 -m venv .venv && source .venv/bin/activate
 
 # Install Khoj for Development
 pip install -e .[dev]
+
+# For MacOS or zsh users run this
+pip install -e .'[dev]'
+
 ```
 
 #### 2. Run


### PR DESCRIPTION
Running pip install -e .[dev] in zsh results in following error:

```shell
pip install -e .[dev] 
zsh: no matches found: .[dev]
```

> This is because zsh uses [square brackets for globbing / pattern matching](http://zsh.sourceforge.net/Guide/zshguide05.html#l137).