### PR TITLE
fixed reference link to landing page 

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -13,6 +13,10 @@ python3 -m venv .venv && source .venv/bin/activate
 
 # Install Khoj for Development
 pip install -e .[dev]
+
+# For MacOS or zsh users run this
+pip install -e .'[dev]'
+
 ```
 
 #### 2. Run

--- a/src/khoj/interface/web/base_config.html
+++ b/src/khoj/interface/web/base_config.html
@@ -12,7 +12,7 @@
         <div class="khoj-header-wrapper">
             <div class="filler"></div>
             <div class="khoj-header">
-                <a class="khoj-logo" href="https://lantern.khoj.dev" target="_blank">
+                <a class="khoj-logo" href="https://khoj.dev" target="_blank">
                     <img class="khoj-logo" src="/static/assets/icons/khoj-logo-sideways.svg" alt="Khoj"></img>
                 </a>
                 <nav class="khoj-nav">


### PR DESCRIPTION
changed the home page reference link to `https://khoj.dev` the previous link `https://lantern.khoj.dev` does not exist. 