### PR TITLE
Build Khoj Debian package on Ubuntu 20.04 to work with Glibc 2.31

### DIFF
--- a/.github/workflows/build_desktop.yml
+++ b/.github/workflows/build_desktop.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           extension: deb
         - os: macos-latest
           extension: dmg
@@ -82,12 +82,12 @@ jobs:
             "dist/dmg/"
 
       - uses: ruby/setup-ruby@v1
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
         with:
           ruby-version: '3.0'
 
       - name: 🐧 Create Debian Package
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
         shell: bash
         run: |
           # Install Debian Packager

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   publish:
     name: Publish Python Package to PyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-20.04
           extension: deb
         - os: macos-latest
           extension: dmg
@@ -133,11 +133,11 @@ jobs:
             "dist/dmg/"
 
       - uses: ruby/setup-ruby@v1
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
         with:
           ruby-version: '3.0'
       - name: 🐧 Create Debian Package
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
         shell: bash
         env:
           DEBIAN_PACKAGE_VERSION: ${{ inputs.version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
     "Topic :: Text Processing :: Linguistic",
 ]
 dependencies = [
-    "dateparser == 1.1.1",
+    "dateparser >= 1.1.1",
     "defusedxml == 0.7.1",
     "fastapi == 0.77.1",
     "jinja2 == 3.1.2",


### PR DESCRIPTION
Build the Debian package using Ubuntu 20.04 instead of 22.04 as Ubuntu 20.04 comes pre-installed with `glibc_2.31` unlike Ubuntu 22.04 which uses `glibc_2.35`

Resolves #378