### PR TITLE
Explicitly set Khoj to use the default locale of the user

### DIFF
--- a/src/khoj/main.py
+++ b/src/khoj/main.py
@@ -2,6 +2,7 @@
 import os
 import signal
 import sys
+import locale
 
 if sys.stdout is None:
     sys.stdout = open(os.devnull, "w")
@@ -31,6 +32,9 @@ from khoj.utils.cli import cli
 
 # Initialize the Application Server
 app = FastAPI()
+
+# Set Locale
+locale.setlocale(locale.LC_ALL, "")
 
 # Setup Logger
 rich_handler = RichHandler(rich_tracebacks=True)


### PR DESCRIPTION
# Incoming
- Explicitly set locale using `locale.setLocale(locale.LC_ALL, '')` for localization. Relevant for datetime libraries. See [Python 3 documentation](https://docs.python.org/3/library/locale.html#locale.setlocale).

Should close #419
