### PR TITLE
Sign mac app and gracefully exit GUI

### DIFF
--- a/src/khoj/interface/desktop/main_window.py
+++ b/src/khoj/interface/desktop/main_window.py
@@ -11,8 +11,8 @@ from PySide6.QtCore import QThread
 
 
 class ServerThread(QThread):
-    def __init__(self, start_server_func):
-        super(ServerThread, self).__init__()
+    def __init__(self, start_server_func, parent=None):
+        super(ServerThread, self).__init__(parent)
         self.start_server_func = start_server_func
 
     def __del__(self):

--- a/src/khoj/main.py
+++ b/src/khoj/main.py
@@ -100,7 +100,7 @@ def run():
         # Setup Server
         initialize_server(args.config, args.regenerate, required=False)
         configure_routes(app)
-        server = ServerThread(start_server_func=lambda: start_server(app, host=args.host, port=args.port))
+        server = ServerThread(start_server_func=lambda: start_server(app, host=args.host, port=args.port), parent=gui)
 
         url = f"http://{args.host}:{args.port}"
         logger.info(f"🌗 Khoj is running at {url}")


### PR DESCRIPTION
- Attach the parent to the server thread, allowing the kill signal to trigger a graceful exit. Closes #442
- Investigated, Close #443 as part of this effort as well. Upon further reading, it doesn't seem necessary to use `QThreadPools`. ([see docs](https://doc.qt.io/qtforpython-5/PySide2/QtCore/QThreadPool.html)). These allow you to spin up multiple threads in the GUI layer, but the server spun up on the additional server thread should be able to create as many python threads as it needs. I'll continue evaluating this.
- I also added in support for signing packages locally in my machine, as per #440. There are no code changes, required, but documenting it here for completeness. The command to sign the package is `codesign --force --deep --sign "Developer ID Application: (Name) (ID)" "khoj_<version>_arm64.dmg"`. This will have to be manually run for each release. Close #440.