### PR TITLE
More lenient date searching

### DIFF
--- a/src/khoj/processor/conversation/openai/gpt.py
+++ b/src/khoj/processor/conversation/openai/gpt.py
@@ -70,7 +70,7 @@ def extract_questions(
         bob_age={current_new_year.year - 1984},
         chat_history=chat_history,
         text=text,
-        yesterday_date=(today - timedelta(days=1)).strftime("%A, %Y-%m-%d")
+        yesterday_date=(today - timedelta(days=1)).strftime("%Y-%m-%d")
     )
     messages = [ChatMessage(content=prompt, role="assistant")]
 

--- a/src/khoj/processor/conversation/openai/gpt.py
+++ b/src/khoj/processor/conversation/openai/gpt.py
@@ -1,6 +1,6 @@
 # Standard Packages
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional
 
 # External Packages
@@ -70,6 +70,7 @@ def extract_questions(
         bob_age={current_new_year.year - 1984},
         chat_history=chat_history,
         text=text,
+        yesterday_date=(today - timedelta(days=1)).strftime("%A, %Y-%m-%d")
     )
     messages = [ChatMessage(content=prompt, role="assistant")]
 

--- a/src/khoj/processor/conversation/prompts.py
+++ b/src/khoj/processor/conversation/prompts.py
@@ -207,6 +207,12 @@ Q: What is their age difference?
 
 A: Bob is {bob_tom_age_difference} years older than Tom. As Bob is {bob_age} years old and Tom is 30 years old.
 
+Q: What did yesterday's note say?
+
+["Note from {yesterday_date} dt='{yesterday_date}'"]
+
+A: Yesterday's note, dated {yesterday_date}, contained the following information: ...
+
 {chat_history}
 Q: {text}
 

--- a/src/khoj/processor/conversation/prompts.py
+++ b/src/khoj/processor/conversation/prompts.py
@@ -207,11 +207,11 @@ Q: What is their age difference?
 
 A: Bob is {bob_tom_age_difference} years older than Tom. As Bob is {bob_age} years old and Tom is 30 years old.
 
-Q: What did yesterday's note say?
+Q: What does yesterday's note say?
 
 ["Note from {yesterday_date} dt='{yesterday_date}'"]
 
-A: Yesterday's note, dated {yesterday_date}, contained the following information: ...
+A: Yesterday's note, dated {yesterday_date}, contains the following information: ...
 
 {chat_history}
 Q: {text}

--- a/src/khoj/processor/conversation/prompts.py
+++ b/src/khoj/processor/conversation/prompts.py
@@ -211,7 +211,7 @@ Q: What does yesterday's note say?
 
 ["Note from {yesterday_date} dt='{yesterday_date}'"]
 
-A: Yesterday's note, dated {yesterday_date}, contains the following information: ...
+A: Yesterday's note contains the following information: ...
 
 {chat_history}
 Q: {text}

--- a/src/khoj/search_filter/date_filter.py
+++ b/src/khoj/search_filter/date_filter.py
@@ -26,7 +26,7 @@ class DateFilter(BaseFilter):
     # - dt:"2 years ago"
     date_regex = r"dt([:><=]{1,2})[\"'](.*?)[\"']"
 
-    def __init__(self, entry_key="raw"):
+    def __init__(self, entry_key="compiled"):
         self.entry_key = entry_key
         self.date_to_entry_ids = defaultdict(set)
         self.cache = LRU()


### PR DESCRIPTION
Suppose we have a scenario where we have notes such that the date of the note is in the filename; this is prevalent and is for example the default behavior of the Obsidian Daily Notes feature.
Chatting using a simple chat message such as "what does yesterday's note say" then fails to give relevant results, for 2 reasons:

1. By default the DateFilter uses the raw content of the entry, rather than the compiled content which includes the filename. Given how prevalent naming notes by date is, I think the DateFilter should use the compiled content.
2. The defiltered search query is then something like "Note from yesterday" which is below the score threshold because the note contents itself generally contains nothing about "yesterday" or "note". Information about the actual date should be included (what's the reasoning behind defiltering the search query in the first place? keeping privacy about the full file-path?) 

This PR resolves these such that the simple chat query works as expected.