### PR TITLE
Fix Linux Desktop Application

### DIFF
--- a/src/interface/desktop/config.html
+++ b/src/interface/desktop/config.html
@@ -79,6 +79,8 @@
                     <input id="sync-force" type="checkbox" name="sync-force" value="force">
                     <label for="sync-force">Force Sync</label>
                 </div>
+                <div id="loading-bar" style="display: none;">
+                </div>
                 <div class="card-description-row">
                     <div id="sync-status"></div>
                 </div>
@@ -135,6 +137,34 @@
 
         a.khoj-logo {
             text-align: center;
+        }
+
+        #loading-bar {
+            height: 10px;
+            width: 100%;
+            background-color: #ddd;
+            position: relative;
+            overflow: hidden;
+        }
+
+        #loading-bar:before {
+            content: "";
+            display: block;
+            position: absolute;
+            left: -200px;
+            width: 200px;
+            height: 100%;
+            background-color: #2980b9;
+            animation: loading-bar 2s linear infinite;
+        }
+
+        @keyframes loading-bar {
+            0% {
+                left: -200px;
+            }
+            100% {
+                left: 100%;
+            }
         }
 
         #khoj-host-url {

--- a/src/interface/desktop/config.html
+++ b/src/interface/desktop/config.html
@@ -48,6 +48,12 @@
                 <div class="card-description-row">
                     <div id="current-files"></div>
                 </div>
+                <div class="card-action-row">
+                    <button id="update-file" class="card-button">
+                        Add
+                        <img class="add-files-icon" src="./assets/icons/circular-add.svg" alt="Add">
+                    </button>
+                </div>
                 <div class="card-title-row">
                     <img class="card-icon" src="./assets/icons/folder.svg" alt="Folder">
                     <h3 class="card-title">
@@ -61,7 +67,7 @@
                     <div id="current-folders"></div>
                 </div>
                 <div class="card-action-row">
-                    <button id="update-data" class="card-button">
+                    <button id="update-folder" class="card-button">
                         Add
                         <img class="add-files-icon" src="./assets/icons/circular-add.svg" alt="Add">
                     </button>

--- a/src/interface/desktop/main.js
+++ b/src/interface/desktop/main.js
@@ -193,8 +193,13 @@ function pushDataToKhoj (regenerate = false) {
 
 pushDataToKhoj();
 
-async function handleFileOpen (event, key) {
-    const { canceled, filePaths } = await dialog.showOpenDialog({properties: ['openFile', 'openDirectory'], filters: [{ name: "Valid Khoj Files", extensions: validFileTypes}] });
+async function handleFileOpen (type) {
+    let { canceled, filePaths } = {canceled: true, filePaths: []};
+    if (type === 'file') {
+        ({ canceled, filePaths } = await dialog.showOpenDialog({properties: ['openFile' ], filters: [{ name: "Valid Khoj Files", extensions: validFileTypes}] }));
+    } else if (type === 'folder') {
+        ({ canceled, filePaths } = await dialog.showOpenDialog({properties: ['openDirectory' ]}));
+    }
     if (!canceled) {
         const files = store.get('files') || [];
         const folders = store.get('folders') || [];
@@ -310,7 +315,9 @@ const createWindow = () => {
 app.whenReady().then(() => {
     ipcMain.on('set-title', handleSetTitle);
 
-    ipcMain.handle('getStoreValue', handleFileOpen);
+    ipcMain.handle('handleFileOpen', (event, type) => {
+        return handleFileOpen(type);
+    });
 
     ipcMain.on('update-state', (event, arg) => {
         console.log(arg);

--- a/src/interface/desktop/package.json
+++ b/src/interface/desktop/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "private": false,
   "devDependencies": {
-    "electron": "26.1.0"
+    "electron": "25.0.0"
   },
   "scripts": {
     "start": "yarn electron ."

--- a/src/interface/desktop/package.json
+++ b/src/interface/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "Khoj",
   "homepage": ".",
   "productName": "Khoj",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Scaffolding for the desktop entrypoint to Khoj",
   "main": "main.js",
   "repository": "\"https://github.com/khoj-ai/khoj\"",

--- a/src/interface/desktop/preload.js
+++ b/src/interface/desktop/preload.js
@@ -16,7 +16,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 })
 
 contextBridge.exposeInMainWorld('storeValueAPI', {
-    getStoreValue: (key) => ipcRenderer.invoke('getStoreValue', key)
+    handleFileOpen: (key) => ipcRenderer.invoke('handleFileOpen', key)
 })
 
 contextBridge.exposeInMainWorld('getFilesAPI', {

--- a/src/interface/desktop/renderer.js
+++ b/src/interface/desktop/renderer.js
@@ -1,6 +1,7 @@
 const setFolderButton = document.getElementById('update-folder');
 const setFileButton = document.getElementById('update-file');
 const showKey = document.getElementById('show-key');
+const loadingBar = document.getElementById('loading-bar');
 
 async function removeFile(filePath) {
     const updatedFiles = await window.removeFileAPI.removeFile(filePath);
@@ -149,6 +150,7 @@ async function handleFileOpen(type) {
 
 window.updateStateAPI.onUpdateState((event, state) => {
     console.log("state was updated", state);
+    loadingBar.style.display = 'none';
     let syncStatusElement = document.getElementById("sync-status");
     const currentTime = new Date();
     if (state.completed == false) {
@@ -182,6 +184,7 @@ urlInput.addEventListener('blur', async () => {
 const syncButton = document.getElementById('sync-data');
 const syncForceToggle = document.getElementById('sync-force');
 syncButton.addEventListener('click', async () => {
+    loadingBar.style.display = 'block';
     const regenerate = syncForceToggle.checked;
     await window.syncDataAPI.syncData(regenerate);
 });

--- a/src/interface/desktop/renderer.js
+++ b/src/interface/desktop/renderer.js
@@ -1,4 +1,5 @@
-const getButton = document.getElementById('update-data')
+const setFolderButton = document.getElementById('update-folder');
+const setFileButton = document.getElementById('update-file');
 const showKey = document.getElementById('show-key');
 
 async function removeFile(filePath) {
@@ -115,9 +116,16 @@ function makeFolderElement(folder) {
     }
 })();
 
-getButton.addEventListener('click', async () => {
-    const key = 'foo';
-    const value = await window.storeValueAPI.getStoreValue(key);
+setFolderButton.addEventListener('click', async () => {
+    await handleFileOpen('folder');
+});
+
+setFileButton.addEventListener('click', async () => {
+    await handleFileOpen('file');
+});
+
+async function handleFileOpen(type) {
+    const value = await window.storeValueAPI.handleFileOpen(type);
     console.log(value);
     let currentFilesElement = document.getElementById("current-files");
     let currentFoldersElement = document.getElementById("current-folders");
@@ -137,7 +145,7 @@ getButton.addEventListener('click', async () => {
             currentFoldersElement.appendChild(folderElement);
         });
     }
-});
+}
 
 window.updateStateAPI.onUpdateState((event, state) => {
     console.log("state was updated", state);

--- a/src/interface/desktop/yarn.lock
+++ b/src/interface/desktop/yarn.lock
@@ -379,10 +379,10 @@ electron-updater@^4.6.1:
     lodash.isequal "^4.5.0"
     semver "^7.3.5"
 
-electron@^26.1.0:
-  version "26.1.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-26.1.0.tgz#d26fefba5a5c68069b07a117d87aee1c4e5d172d"
-  integrity sha512-qEh19H09Pysn3ibms5nZ0haIh5pFoOd7/5Ww7gzmAwDQOulRi8Sa2naeueOyIb1GKpf+6L4ix3iceYRAuA5r5Q==
+electron@25.0.0:
+  version "25.0.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-25.0.0.tgz#3c7cb7e74a271ebc183acaeefc4dd09f2eb079e5"
+  integrity sha512-8Bjlpw52XW447RKjYGaaizWI4x0dv4gATNn7ssuonySbDgeJNqUnIJQGBrpXyB3VUROVmhXnTWB9VWRzv6uVlA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"


### PR DESCRIPTION
# Incoming
The Desktop client was not working on Linux machines due to an incompatibility with the latest Electron version.

As it turns out, the dialog box on Windows and Linux machines do not support selection of both files or folders -- it has to be one or the other. To mitigate, add two separate buttons for adding files and folders. See attached screenshot for latest design.

<img width="594" alt="Screenshot 2023-10-03 at 11 08 32 AM" src="https://github.com/khoj-ai/khoj/assets/65192171/05757129-b20a-4260-a327-cf21caa9cd86">

Closes #489 