### PR TITLE
Fix encoding binary files for sync from the Desktop, Obsidian client

### DIFF
--- a/src/interface/desktop/main.js
+++ b/src/interface/desktop/main.js
@@ -135,9 +135,10 @@ function pushDataToKhoj (regenerate = false) {
         }
 
         try {
-            encoding = binaryFileTypes.includes(file.split('.').pop()) ? "binary" : "utf8";
-            mimeType = filenameToMimeType(file) + (encoding === "utf8" ? "; charset=UTF-8" : "");
-            fileObj = new Blob([fs.createReadStream(file, encoding)], { type: mimeType });
+            let encoding = binaryFileTypes.includes(file.split('.').pop()) ? "binary" : "utf8";
+            let mimeType = filenameToMimeType(file) + (encoding === "utf8" ? "; charset=UTF-8" : "");
+            let fileContent = Buffer.from(fs.readFileSync(file, { encoding: encoding }), encoding);
+            let fileObj = new Blob([fileContent], { type: mimeType });
             formData.append('files', fileObj, file);
             state[file] = {
                 success: true,

--- a/src/interface/obsidian/src/utils.ts
+++ b/src/interface/obsidian/src/utils.ts
@@ -62,7 +62,7 @@ export async function updateContentIndex(vault: Vault, setting: KhojSetting, las
         countOfFilesToIndex++;
         const encoding = binaryFileTypes.includes(file.extension) ? "binary" : "utf8";
         const mimeType = fileExtensionToMimeType(file.extension) + (encoding === "utf8" ? "; charset=UTF-8" : "");
-        const fileContent = await vault.read(file);
+        const fileContent = encoding == 'binary' ? await vault.readBinary(file) : await vault.read(file);
         formData.append('files', new Blob([fileContent], { type: mimeType }), file.path);
     }
 


### PR DESCRIPTION
# Incoming
- ba60c86 Fix encoding binary files like PDFs for sync from Desktop client.
   Using `readFileSync` and put content appropriately encoded `Buffer` before pushing the data mitigates the issue.
- c829399 Fix encoding binary files like PDFs for sync from Obsidian client
   Use `readBinary` to read binary files like PDFs instead of plain `read`
