### PR TITLE
Pin pytorch version to 2.0.1 in order to avoid exit code 139 in Docker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,11 @@ services:
       - ./tests/data/embeddings/:/root/.khoj/content/
       - ./tests/data/models/:/root/.khoj/search/
       - khoj_config:/root/.khoj/
+      - sentence_tranformer_models:/root/.cache/torch/sentence_transformers
     # Use 0.0.0.0 to explicitly set the host ip for the service on the container. https://pythonspeed.com/articles/docker-connection-refused/
     command: --host="0.0.0.0" --port=42110 -vv
 
 
 volumes:
   khoj_config:
+  sentence_tranformer_models:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "schedule == 1.1.0",
     "sentence-transformers == 2.2.2",
     "transformers >= 4.28.0",
-    "torch >= 2.0.1",
+    "torch == 2.0.1",
     "uvicorn == 0.17.6",
     "aiohttp == 3.8.5",
     "langchain >= 0.0.187",


### PR DESCRIPTION
# Incoming
Related to https://github.com/pytorch/pytorch/issues/111695, pin the pytorch version to `2.0.1` in order to avoid build issues when running the Khoj image in a Docker container.