### PR TITLE
Allow users to short-circuit LLM response to offline model

### DIFF
--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -72,6 +72,9 @@
         function chat() {
             // Extract required fields for search from form
             let query = document.getElementById("chat-input").value.trim();
+            const abortButton = document.getElementById("abort-button");
+            let controller = new AbortController();
+            let signal = controller.signal;
             let resultsCount = localStorage.getItem("khojResultsCount") || 5;
             console.log(`Query: ${query}`);
 
@@ -111,17 +114,32 @@
             chatInput.classList.remove("option-enabled");
 
             // Call specified Khoj API which returns a streamed response of type text/plain
-            fetch(url)
+            fetch(url, { signal })
                 .then(response => {
                     const reader = response.body.getReader();
                     const decoder = new TextDecoder();
 
+                    abortButton.addEventListener("click", () => {
+                        controller.abort();
+                        console.log("Download aborted");
+                        if (newResponseText.getElementsByClassName("spinner").length > 0) {
+                            newResponseText.removeChild(loadingSpinner);
+                        }
+                        newResponseText.innerHTML += "<b>Aborted.</b>";
+                        document.getElementById("chat-body").scrollTop = document.getElementById("chat-body").scrollHeight;
+                        document.getElementById("chat-input").removeAttribute("disabled");
+                        abortButton.style.display = "none";
+                    });
+
                     function readStream() {
                         reader.read().then(({ done, value }) => {
+
                             if (done) {
                                 // Evaluate the contents of new_response_text.innerHTML after all the data has been streamed
                                 const currentHTML = newResponseText.innerHTML;
                                 newResponseText.innerHTML = formatHTMLMessage(currentHTML);
+
+                                abortButton.style.display = "none";
 
                                 return;
                             }
@@ -145,6 +163,7 @@
                                 // Display response from Khoj
                                 if (newResponseText.getElementsByClassName("spinner").length > 0) {
                                     newResponseText.removeChild(loadingSpinner);
+                                    abortButton.style.display = "block";
                                 }
 
                                 newResponseText.innerHTML += chunk;
@@ -153,10 +172,32 @@
 
                             // Scroll to bottom of chat window as chat response is streamed
                             document.getElementById("chat-body").scrollTop = document.getElementById("chat-body").scrollHeight;
+                        }).catch(error => {
+                            if (error.name === 'AbortError') {
+                                abortButton.style.display = "none";
+
+                                const cancelUrl = `/api/chat/cancel?client=web`;
+
+                                console.log('Fetch aborted');
+                                abortController = new AbortController();
+                                signal = abortController.signal;
+                                fetch(cancelUrl, { method: 'POST'})
+                                    .then(response => {
+                                        return response.json();
+                                    })
+                                    .then(data => {
+                                        console.log(data);
+                                    });
+                            } else {
+                                console.error('Fetch error:', error);
+                            }
                         });
                     }
                     readStream();
                     document.getElementById("chat-input").removeAttribute("disabled");
+                })
+                .catch(error => {
+                    console.error('Fetch error:', error);
                 });
         }
 
@@ -297,6 +338,7 @@
             <div id="chat-tooltip" style="display: none;"></div>
             <textarea id="chat-input" class="option" oninput="onChatInput()" onkeyup=incrementalChat(event) autofocus="autofocus" placeholder="Type / to see a list of commands, or just type your questions and hit enter.">
             </textarea>
+            <button id="abort-button" class="option">Abort</button>
         </div>
     </body>
 
@@ -388,6 +430,9 @@
             border-top-color: var(--primary);
             border-bottom: 0;
             transform: rotate(-60deg);
+        }
+        button#abort-button {
+            display: none;
         }
         /* color chat bubble by you dark grey */
         .chat-message-text.you {

--- a/src/khoj/processor/conversation/gpt4all/utils.py
+++ b/src/khoj/processor/conversation/gpt4all/utils.py
@@ -13,7 +13,7 @@ def download_model(model_name: str):
 
     # Use GPU for Chat Model, if available
     try:
-        model = GPT4All(model_name=model_name, device="gpu")
+        model = GPT4All(model_name=model_name, device="gpu", allow_download=True)
         logger.debug(f"Loaded {model_name} chat model to GPU.")
     except ValueError:
         model = GPT4All(model_name=model_name)

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -648,6 +648,31 @@ def update(
     return {"status": "ok", "message": "khoj reloaded"}
 
 
+@api.post("/chat/cancel")
+def cancel_chat(
+    request: Request,
+    client: Optional[str] = None,
+    user_agent: Optional[str] = Header(None),
+    referer: Optional[str] = Header(None),
+    host: Optional[str] = Header(None),
+):
+    perform_chat_checks()
+
+    state.should_cancel_chat = True
+
+    update_telemetry_state(
+        request=request,
+        telemetry_type="api",
+        api="cancel_chat",
+        client=client,
+        user_agent=user_agent,
+        referer=referer,
+        host=host,
+    )
+
+    return Response(content=json.dumps({"status": "ok"}), media_type="application/json", status_code=200)
+
+
 @api.get("/chat/history")
 def chat_history(
     request: Request,

--- a/src/khoj/utils/state.py
+++ b/src/khoj/utils/state.py
@@ -31,6 +31,7 @@ telemetry: List[Dict[str, str]] = []
 previous_query: str = None
 demo: bool = False
 khoj_version: str = None
+should_cancel_chat: bool = False
 
 if torch.cuda.is_available():
     # Use CUDA GPU


### PR DESCRIPTION
- Add an option in the `chat.html` page to abort the user query if it has started emitting responses.

closes #508 