### PR TITLE
Fix ranking search results on Obsidian

### DIFF
--- a/src/interface/obsidian/src/search_modal.ts
+++ b/src/interface/obsidian/src/search_modal.ts
@@ -106,7 +106,7 @@ export class KhojSearchModal extends SuggestModal<SearchResult> {
 
         // Combine markdown and PDF results and sort them by score
         let results = mdData.concat(pdfData)
-            .sort((a: any, b: any) => b.score - a.score)
+            .sort((a: any, b: any) => a.score - b.score)
             .map((result: any) => { return { entry: result.entry, file: result.file } as SearchResult; })
 
         this.query = query;


### PR DESCRIPTION
This bug was causing the search results on the Obsidian client to be shown in the reverse order of their actual relevance.

It reversed since entry scores returned by Khoj server are a distance metric since the move to Postgres. So lesser distance is better. Previously higher score was better.