### PR TITLE
Render Chat Responses as Markdown in Desktop, Obsidian Client

### DIFF
--- a/src/interface/desktop/chat.html
+++ b/src/interface/desktop/chat.html
@@ -8,6 +8,7 @@
         <link rel="manifest" href="/static/khoj_chat.webmanifest">
         <link rel="stylesheet" href="./assets/khoj.css">
     </head>
+    <script type="text/javascript" src="./assets/markdown-it.min.js"></script>
     <script src="./utils.js"></script>
 
     <script>
@@ -120,8 +121,7 @@
             // Create a new div for the chat message text and append it to the chat message
             let chatMessageText = document.createElement('div');
             chatMessageText.className = `chat-message-text ${by}`;
-            let textNode = document.createTextNode(formattedMessage);
-            chatMessageText.appendChild(textNode);
+            chatMessageText.appendChild(formattedMessage);
             chatMessage.appendChild(chatMessageText);
 
             // Append annotations div to the chat message
@@ -230,16 +230,49 @@
         }
 
         function formatHTMLMessage(htmlMessage) {
-            // Replace any ``` with <div class="programmatic-output">
-            let newHTML = htmlMessage.replace(/```([\s\S]*?)```/g, '<div class="programmatic-output"><button class="copy-button" onclick="copyProgrammaticOutput(event)">Copy</button>$1</div>');
-            // Replace any ** with <b> and __ with <u>
-            newHTML = newHTML.replace(/\*\*([\s\S]*?)\*\*/g, '<b>$1</b>');
-            newHTML = newHTML.replace(/__([\s\S]*?)__/g, '<u>$1</u>');
+            var md = window.markdownit();
+            let newHTML = htmlMessage;
+
             // Remove any text between <s>[INST] and </s> tags. These are spurious instructions for the AI chat model.
             newHTML = newHTML.replace(/<s>\[INST\].+(<\/s>)?/g, '');
-            // For any text that has single backticks, replace them with <code> tags
-            newHTML = newHTML.replace(/`([^`]+)`/g, '<code class="chat-response">$1</code>');
-            return newHTML;
+
+            // Render markdown
+            newHTML = md.render(newHTML);
+            // Get any elements with a class that starts with "language"
+            let element = document.createElement('div');
+            element.innerHTML = newHTML;
+            let codeBlockElements = element.querySelectorAll('[class^="language-"]');
+            // For each element, add a parent div with the class "programmatic-output"
+            codeBlockElements.forEach((codeElement) => {
+                // Create the parent div
+                let parentDiv = document.createElement('div');
+                parentDiv.classList.add("programmatic-output");
+                // Add the parent div before the code element
+                codeElement.parentNode.insertBefore(parentDiv, codeElement);
+                // Move the code element into the parent div
+                parentDiv.appendChild(codeElement);
+                // Add a copy button to each element
+                let copyButton = document.createElement('button');
+                copyButton.classList.add("copy-button");
+                copyButton.innerHTML = "Copy";
+                copyButton.addEventListener('click', copyProgrammaticOutput);
+                codeElement.prepend(copyButton);
+            });
+
+            // Get all code elements that have no class.
+            let codeElements = element.querySelectorAll('code:not([class])');
+            codeElements.forEach((codeElement) => {
+                // Add the class "chat-response" to each element
+                codeElement.classList.add("chat-response");
+            });
+
+            let anchorElements = element.querySelectorAll('a');
+            anchorElements.forEach((anchorElement) => {
+                // Add the class "inline-chat-link" to each element
+                anchorElement.classList.add("inline-chat-link");
+            });
+
+            return element
         }
 
         async function chat() {
@@ -299,8 +332,11 @@
                         reader.read().then(({ done, value }) => {
                             if (done) {
                                 // Append any references after all the data has been streamed
-                                newResponseText.appendChild(references);
+                                if (references != null) {
+                                    newResponseText.appendChild(references);
+                                }
                                 document.getElementById("chat-body").scrollTop = document.getElementById("chat-body").scrollHeight;
+                                document.getElementById("chat-input").removeAttribute("disabled");
                                 return;
                             }
 
@@ -320,7 +356,6 @@
 
                                 let referenceExpandButton = document.createElement('button');
                                 referenceExpandButton.classList.add("reference-expand-button");
-
 
                                 let referenceSection = document.createElement('div');
                                 referenceSection.classList.add("reference-section");
@@ -387,7 +422,6 @@
                         });
                     }
                     readStream();
-                    document.getElementById("chat-input").removeAttribute("disabled");
                 });
         }
 
@@ -935,7 +969,6 @@
             background: var(--primary-hover);
         }
 
-
         .option-enabled:focus {
             outline: none !important;
             border:1px solid #475569;
@@ -946,6 +979,25 @@
             color: #475569;
             text-decoration: none;
             border-bottom: 1px dotted #475569;
+        }
+
+        a.reference-link {
+            color: var(--main-text-color);
+            border-bottom: 1px dotted var(--main-text-color);
+        }
+
+        button.copy-button {
+            display: block;
+            border-radius: 4px;
+            background-color: var(--background-color);
+        }
+        button.copy-button:hover {
+            background: #f5f5f5;
+            cursor: pointer;
+        }
+
+        pre {
+            text-wrap: unset;
         }
 
         div.khoj-empty-container {
@@ -1019,6 +1071,10 @@
 
         a.khoj-logo {
             text-align: center;
+        }
+
+        p {
+            margin: 0;
         }
 
         div.programmatic-output {

--- a/src/interface/desktop/chat.html
+++ b/src/interface/desktop/chat.html
@@ -945,6 +945,7 @@
         }
         button.reference-button.expanded {
             max-height: none;
+            white-space: pre-wrap;
         }
 
         button.reference-button::before {

--- a/src/interface/desktop/chat.html
+++ b/src/interface/desktop/chat.html
@@ -618,6 +618,8 @@
                 });
             } else if (mediaRecorder.state === 'recording') {
                 mediaRecorder.stop();
+                mediaRecorder.stream.getTracks().forEach(track => track.stop());
+                mediaRecorder = null;
                 speakButtonImg.src = './assets/icons/microphone-solid.svg';
                 speakButtonImg.alt = 'Transcribe';
             }

--- a/src/interface/desktop/chat.html
+++ b/src/interface/desktop/chat.html
@@ -15,11 +15,19 @@
         let chatOptions = [];
         function copyProgrammaticOutput(event) {
             // Remove the first 4 characters which are the "Copy" button
+            const originalCopyText = event.target.parentNode.textContent.trim().slice(0, 4);
             const programmaticOutput = event.target.parentNode.textContent.trim().slice(4);
             navigator.clipboard.writeText(programmaticOutput).then(() => {
-                console.log("Programmatic output copied to clipboard");
+                event.target.textContent = "✅ Copied to clipboard!";
+                setTimeout(() => {
+                    event.target.textContent = originalCopyText;
+                }, 1000);
             }).catch((error) => {
                 console.error("Error copying programmatic output to clipboard:", error);
+                event.target.textContent = "⛔️ Failed to copy!";
+                setTimeout(() => {
+                    event.target.textContent = originalCopyText;
+                }, 1000);
             });
         }
 

--- a/src/interface/obsidian/src/chat_modal.ts
+++ b/src/interface/obsidian/src/chat_modal.ts
@@ -1,4 +1,4 @@
-import { App, Modal, RequestUrlParam, request, requestUrl, setIcon } from 'obsidian';
+import { App, Modal, request, requestUrl, setIcon } from 'obsidian';
 import { KhojSetting } from 'src/settings';
 import fetch from "node-fetch";
 
@@ -321,6 +321,8 @@ export class KhojChatModal extends Modal {
                 });
         } else if (this.mediaRecorder.state === 'recording') {
             this.mediaRecorder.stop();
+            this.mediaRecorder.stream.getTracks().forEach(track => track.stop());
+            this.mediaRecorder = undefined;
             setIcon(transcribeButton, "mic");
         }
     }

--- a/src/interface/obsidian/styles.css
+++ b/src/interface/obsidian/styles.css
@@ -169,6 +169,7 @@ button.reference-button {
 button.reference-button.expanded {
     height: auto;
     max-height: none;
+    white-space: pre-wrap;
 }
 button.reference-button::before {
     content: "▶";

--- a/src/interface/obsidian/styles.css
+++ b/src/interface/obsidian/styles.css
@@ -13,6 +13,13 @@ If your plugin does not need CSS, delete this file.
     --khoj-storm-grey: #475569;
  }
 
+.khoj-chat p {
+    margin: 0;
+}
+.khoj-chat pre {
+    text-wrap: unset;
+}
+
 .khoj-chat {
     display: grid;
     background: var(--background-primary);
@@ -103,6 +110,113 @@ If your plugin does not need CSS, delete this file.
     margin-top: -10px;
     transform: rotate(-60deg)
 }
+
+.option-enabled {
+    box-shadow: 0 0 12px rgb(119, 156, 46);
+}
+
+code.chat-response {
+    background: var(--khoj-sun);
+    color: var(--khoj-storm-grey);
+    border-radius: 5px;
+    padding: 5px;
+    font-size: 14px;
+    font-weight: 300;
+    line-height: 1.5em;
+}
+
+div.collapsed {
+    display: none;
+}
+div.expanded {
+    display: block;
+}
+div.reference {
+    display: grid;
+    grid-template-rows: auto;
+    grid-auto-flow: row;
+    grid-column-gap: 10px;
+    grid-row-gap: 10px;
+    margin: 10px;
+}
+div.expanded.reference-section {
+    display: grid;
+    grid-template-rows: auto;
+    grid-auto-flow: row;
+    grid-column-gap: 10px;
+    grid-row-gap: 10px;
+    margin: 10px;
+}
+button.reference-button {
+    background: var(--color-base-00);
+    color: var(--color-base-100);
+    border: 1px solid var(--khoj-storm-grey);
+    border-radius: 5px;
+    padding: 5px;
+    font-size: 14px;
+    font-weight: 300;
+    line-height: 1.5em;
+    cursor: pointer;
+    transition: background 0.2s ease-in-out;
+    text-align: left;
+    max-height: 75px;
+    height: auto;
+    transition: max-height 0.3s ease-in-out;
+    overflow: hidden;
+    display: inline-block;
+    text-wrap: inherit;
+}
+button.reference-button.expanded {
+    height: auto;
+    max-height: none;
+}
+button.reference-button::before {
+    content: "▶";
+    margin-right: 5px;
+    display: inline-block;
+    transition: transform 0.3s ease-in-out;
+}
+button.reference-button:active:before,
+button.reference-button[aria-expanded="true"]::before {
+    transform: rotate(90deg);
+}
+button.reference-expand-button {
+    background: var(--color-base-00);
+    color: var(--color-base-100);
+    border: 1px solid var(--khoj-storm-grey);
+    border-radius: 5px;
+    padding: 5px;
+    font-size: 14px;
+    font-weight: 300;
+    line-height: 1.5em;
+    cursor: pointer;
+    transition: background 0.2s ease-in-out;
+    text-align: left;
+}
+button.reference-expand-button:hover {
+    background: var(--khoj-sun);
+    color: var(--color-base-00);
+}
+a.inline-chat-link {
+    color: #475569;
+    text-decoration: none;
+    border-bottom: 1px dotted #475569;
+}
+a.reference-link {
+    color: var(--khoj-storm-grey);
+    border-bottom: 1px dotted var(--khoj-storm-grey);
+}
+
+button.copy-button {
+    display: block;
+    border-radius: 4px;
+    background-color: var(--color-base-00);
+}
+button.copy-button:hover {
+    background: #f5f5f5;
+    cursor: pointer;
+}
+
 
 #khoj-chat-footer {
     padding: 0;

--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -407,11 +407,14 @@ To get started, just start typing below. You can also type / to see a list of co
                                     try {
                                         const responseAsJson = JSON.parse(chunk);
                                         if (responseAsJson.detail) {
-                                            newResponseText.innerHTML += responseAsJson.detail;
+                                            rawResponse += responseAsJson.detail;
                                         }
                                     } catch (error) {
                                         // If the chunk is not a JSON object, just display it as is
-                                        newResponseText.innerHTML += chunk;
+                                        rawResponse += chunk;
+                                    } finally {
+                                        newResponseText.innerHTML = "";
+                                        newResponseText.appendChild(formatHTMLMessage(rawResponse));
                                     }
                                 } else {
                                     // If the chunk is not a JSON object, just display it as is
@@ -635,6 +638,8 @@ To get started, just start typing below. You can also type / to see a list of co
                 });
             } else if (mediaRecorder.state === 'recording') {
                 mediaRecorder.stop();
+                mediaRecorder.stream.getTracks().forEach(track => track.stop());
+                mediaRecorder = null;
                 speakButtonImg.src = '/static/assets/icons/microphone-solid.svg';
                 speakButtonImg.alt = 'Transcribe';
             }

--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -975,10 +975,13 @@ To get started, just start typing below. You can also type / to see a list of co
             border-radius: 4px;
             background-color: var(--background-color);
         }
-
         button.copy-button:hover {
             background: #f5f5f5;
             cursor: pointer;
+        }
+
+        pre {
+            text-wrap: unset;
         }
 
         @media (pointer: coarse), (hover: none) {

--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -24,11 +24,19 @@ To get started, just start typing below. You can also type / to see a list of co
         let chatOptions = [];
         function copyProgrammaticOutput(event) {
             // Remove the first 4 characters which are the "Copy" button
+            const originalCopyText = event.target.parentNode.textContent.trim().slice(0, 4);
             const programmaticOutput = event.target.parentNode.textContent.trim().slice(4);
             navigator.clipboard.writeText(programmaticOutput).then(() => {
-                console.log("Programmatic output copied to clipboard");
+                event.target.textContent = "✅ Copied to clipboard!";
+                setTimeout(() => {
+                    event.target.textContent = originalCopyText;
+                }, 1000);
             }).catch((error) => {
                 console.error("Error copying programmatic output to clipboard:", error);
+                event.target.textContent = "⛔️ Failed to copy!";
+                setTimeout(() => {
+                    event.target.textContent = originalCopyText;
+                }, 1000);
             });
         }
 

--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -775,6 +775,7 @@ To get started, just start typing below. You can also type / to see a list of co
         }
         button.reference-button.expanded {
             max-height: none;
+            white-space: pre-wrap;
         }
 
         button.reference-button::before {


### PR DESCRIPTION
- 5242a49a Show temporary status message when copied to clipboard
- 6d127ba1 Render chat responses as markdown in Desktop client
- 1a31a2efcf Render chat responses as markdown in chat modal of Obsidian client
- 1a31a2efcf Render references of new responses in chat modal on Obsidian client. Use new style for references
- ac292807 Properly stop mediaRecorder stream to clear microphone in-use state
- 48719ee Render newlines when references expanded in Web, Desktop and Obsidian clients