### PR TITLE
Fix null exception when user does not exist for subscription

### DIFF
--- a/src/khoj/database/adapters/__init__.py
+++ b/src/khoj/database/adapters/__init__.py
@@ -41,7 +41,6 @@ from khoj.search_filter.word_filter import WordFilter
 from khoj.utils import state
 from khoj.utils.config import GPT4AllProcessorModel
 from khoj.utils.helpers import generate_random_name
-from khoj.database.adapters import get_or_create_user_by_email
 
 
 class SubscriptionState(Enum):


### PR DESCRIPTION
If a user subscribes to Khoj with an email address that's not present in the DB, create an account with the corresponding email address and then update the Subscription object.

Bear in mind that this flow will cause some hiccups for users whose email addresses are not associated with Google accounts. So when they try to log in, their account may not be associated with their subscription. We should find better workarounds to avoid this.