### PR TITLE
Fix markdownRenderer arg to allow chat responses in Obsidian plugin

### DIFF
--- a/src/interface/obsidian/src/chat_modal.ts
+++ b/src/interface/obsidian/src/chat_modal.ts
@@ -182,7 +182,7 @@ export class KhojChatModal extends Modal {
             chat_message_body_text_el.innerHTML = message;
         } else {
             // @ts-ignore
-            MarkdownRenderer.renderMarkdown(message, chat_message_body_text_el, null, null);
+            MarkdownRenderer.renderMarkdown(message, chat_message_body_text_el, '', null);
         }
 
         // Remove user-select: none property to make text selectable
@@ -221,7 +221,7 @@ export class KhojChatModal extends Modal {
         this.result += additionalMessage;
         htmlElement.innerHTML = "";
         // @ts-ignore
-        await MarkdownRenderer.renderMarkdown(this.result, htmlElement, null, null);
+        await MarkdownRenderer.renderMarkdown(this.result, htmlElement, '', null);
         // Scroll to bottom of modal, till the send message input box
         this.modalEl.scrollTop = this.modalEl.scrollHeight;
     }

--- a/src/interface/obsidian/src/search_modal.ts
+++ b/src/interface/obsidian/src/search_modal.ts
@@ -124,7 +124,7 @@ export class KhojSearchModal extends SuggestModal<SearchResult> {
         let result_el = el.createEl("div", { cls: 'khoj-result-entry' })
 
         // @ts-ignore
-        MarkdownRenderer.renderMarkdown(snipped_entry + entry_snipped_indicator, result_el, null, null);
+        MarkdownRenderer.renderMarkdown(snipped_entry + entry_snipped_indicator, result_el, result.file, null);
     }
 
     async onChooseSuggestion(result: SearchResult, _: MouseEvent | KeyboardEvent) {


### PR DESCRIPTION
### Issue

Users with Dataview plugin would have error as its markdown
post-processor expects the sourcePath to be a string

This prevents Khoj from responding to chat messages in the Obsidian
chat modal. Search via Obsidian still works but it throws the same
`dataview` plugin error

### Fix
Pass a string as sourcePath to markdownRenderer to fix failing chat response
and stop throwing dataview errors on search

Resolves #614, Resolves #606