### PR TITLE
Scrape results from Serper results using Olostep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "uvicorn == 0.17.6",
     "aiohttp ~= 3.9.0",
     "langchain <= 0.2.0",
+    "langchain-openai >= 0.0.5",
     "requests >= 2.26.0",
     "bs4 >= 0.0.1",
     "anyio == 3.7.1",

--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -16,9 +16,9 @@ Hi, I am Khoj, your open, personal AI 👋🏽. I can help:
 - 🧠 Answer general knowledge questions
 - 💡 Be a sounding board for your ideas
 - 📜 Chat with your notes & documents
-- 🌄 Generate images based on your messages
-- 🔎 Search the web for answers to your questions
-- 🎙️ Listen to your audio messages
+- 🌄 Generate images based on your messages (start your prompt with "/image")
+- 🔎 Search the web for answers to your questions (start your prompt with "/online")
+- 🎙️ Listen to your audio messages (use the mic by the input box to speak your message)
 
 Get the Khoj [Desktop](https://khoj.dev/downloads), [Obsidian](https://docs.khoj.dev/#/obsidian?id=setup) or [Emacs](https://docs.khoj.dev/#/emacs?id=setup) app to search, chat with your 🖥️ computer docs.
 

--- a/src/khoj/processor/conversation/openai/gpt.py
+++ b/src/khoj/processor/conversation/openai/gpt.py
@@ -109,7 +109,6 @@ def send_message_to_model(
     return completion_with_backoff(
         messages=messages,
         model=model,
-        model_kwargs={"stop": ["A: ", "\n"]},
         openai_api_key=api_key,
     )
 

--- a/src/khoj/processor/conversation/openai/gpt.py
+++ b/src/khoj/processor/conversation/openai/gpt.py
@@ -97,21 +97,18 @@ def extract_questions(
 
 
 def send_message_to_model(
-    message,
+    messages,
     api_key,
     model,
 ):
     """
     Send message to model
     """
-    messages = [ChatMessage(content=message, role="assistant")]
 
     # Get Response from GPT
     return completion_with_backoff(
         messages=messages,
-        model_name=model,
-        temperature=0,
-        max_tokens=100,
+        model=model,
         model_kwargs={"stop": ["A: ", "\n"]},
         openai_api_key=api_key,
     )
@@ -120,7 +117,7 @@ def send_message_to_model(
 def converse(
     references,
     user_query,
-    online_results=[],
+    online_results: Optional[dict] = None,
     conversation_log={},
     model: str = "gpt-3.5-turbo",
     api_key: Optional[str] = None,
@@ -145,8 +142,13 @@ def converse(
         completion_func(chat_response=prompts.no_online_results_found.format())
         return iter([prompts.no_online_results_found.format()])
     elif conversation_command == ConversationCommand.Online:
+        simplified_online_results = online_results.copy()
+        for result in online_results:
+            if online_results[result].get("extracted_content"):
+                simplified_online_results[result] = online_results[result]["extracted_content"]
+
         conversation_primer = prompts.online_search_conversation.format(
-            query=user_query, online_results=str(online_results)
+            query=user_query, online_results=str(simplified_online_results)
         )
     elif conversation_command == ConversationCommand.General or is_none_or_empty(compiled_references):
         conversation_primer = prompts.general_conversation.format(query=user_query)

--- a/src/khoj/processor/conversation/openai/utils.py
+++ b/src/khoj/processor/conversation/openai/utils.py
@@ -6,7 +6,7 @@ from typing import Any
 import openai
 from langchain.callbacks.base import BaseCallbackManager
 from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
-from langchain_community.chat_models import ChatOpenAI
+from langchain_openai import ChatOpenAI
 from tenacity import (
     before_sleep_log,
     retry,
@@ -48,7 +48,10 @@ def completion_with_backoff(**kwargs):
     if not "openai_api_key" in kwargs:
         kwargs["openai_api_key"] = os.getenv("OPENAI_API_KEY")
     llm = ChatOpenAI(**kwargs, request_timeout=20, max_retries=1)
-    return llm(messages=messages)
+    aggregated_response = ""
+    for chunk in llm.stream(messages):
+        aggregated_response += chunk.content
+    return aggregated_response
 
 
 @retry(

--- a/src/khoj/processor/conversation/prompts.py
+++ b/src/khoj/processor/conversation/prompts.py
@@ -257,6 +257,26 @@ Q: {text}
 """
 )
 
+system_prompt_extract_relevant_information = """As a professional analyst, create a comprehensive report of the most relevant information from a web page in response to a user's query. The text provided is directly from within the web page. The report you create should be multiple paragraphs, and it should represent the content of the website. Tell the user exactly what the website says in response to their query, while adhering to these guidelines:
+
+1. Answer the user's query as specifically as possible. Be verbose. Include many supporting details from the website.
+2. Craft a report that is detailed, thorough, in-depth, and complex, while maintaining clarity.
+3. Rely strictly on the provided text, without including external information.
+4. Format the report in multiple paragraphs with a clear structure.
+5. Be as specific as possible in your answer to the user's query.
+6. Reproduce as much of the provided text as possible, while maintaining readability.
+""".strip()
+
+extract_relevant_information = PromptTemplate.from_template(
+    """
+Target Query: {query}
+
+Web Pages: {corpus}
+
+Collate the relevant information from the website to answer the target query.
+""".strip()
+)
+
 online_search_conversation_subqueries = PromptTemplate.from_template(
     """
 You are Khoj, an extremely smart and helpful search assistant. You are tasked with constructing a search query for Google to answer the user's question.
@@ -266,9 +286,10 @@ You are Khoj, an extremely smart and helpful search assistant. You are tasked wi
 - You have access to the the whole internet to retrieve information.
 
 What Google searches, if any, will you need to perform to answer the user's question?
-Provide search queries as a JSON list of strings
+Provide search queries as a list of strings
 Current Date: {current_date}
 
+Here are some examples:
 History:
 User: I like to use Hacker News to get my tech news.
 Khoj: Hacker News is an online forum for sharing and discussing the latest tech news. It is a great place to learn about new technologies and startups.
@@ -297,6 +318,7 @@ Khoj: NASA's Saturn V rocket frequently makes lunar trips and has a large cargo 
 Q: How many oranges would fit in NASA's Saturn V rocket?
 A: ["volume of an orange", "volume of saturn v rocket"]
 
+Now it's your turn to construct a search query for Google to answer the user's question.
 History:
 {chat_history}
 

--- a/src/khoj/processor/conversation/prompts.py
+++ b/src/khoj/processor/conversation/prompts.py
@@ -259,7 +259,7 @@ Q: {text}
 
 system_prompt_extract_relevant_information = """As a professional analyst, create a comprehensive report of the most relevant information from a web page in response to a user's query. The text provided is directly from within the web page. The report you create should be multiple paragraphs, and it should represent the content of the website. Tell the user exactly what the website says in response to their query, while adhering to these guidelines:
 
-1. Answer the user's query as specifically as possible. Be verbose. Include many supporting details from the website.
+1. Answer the user's query as specifically as possible. Include many supporting details from the website.
 2. Craft a report that is detailed, thorough, in-depth, and complex, while maintaining clarity.
 3. Rely strictly on the provided text, without including external information.
 4. Format the report in multiple paragraphs with a clear structure.
@@ -279,7 +279,7 @@ Collate the relevant information from the website to answer the target query.
 
 online_search_conversation_subqueries = PromptTemplate.from_template(
     """
-You are Khoj, an extremely smart and helpful search assistant. You are tasked with constructing a search query for Google to answer the user's question.
+You are Khoj, an extremely smart and helpful search assistant. You are tasked with constructing **up to three** search queries for Google to answer the user's question.
 - You will receive the conversation history as context.
 - Add as much context from the previous questions and answers as required into your search queries.
 - Break messages into multiple search queries when required to retrieve the relevant information.

--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -15,8 +15,10 @@ from khoj.utils.helpers import merge_dicts
 
 logger = logging.getLogger(__name__)
 model_to_prompt_size = {
-    "gpt-3.5-turbo": 4096,
-    "gpt-4": 8192,
+    "gpt-3.5-turbo": 3000,
+    "gpt-4": 7000,
+    "gpt-4-1106-preview": 7000,
+    "gpt-4-turbo-preview": 4000,
     "llama-2-7b-chat.ggmlv3.q4_0.bin": 1548,
     "gpt-3.5-turbo-16k": 15000,
     "mistral-7b-instruct-v0.1.Q4_0.gguf": 1548,
@@ -200,7 +202,7 @@ def truncate_messages(
         logger.debug(
             f"Truncate current message to fit within max prompt size of {max_prompt_size} supported by {model_name} model:\n {truncated_message}"
         )
-        messages = [ChatMessage(content=truncated_message + original_question, role=messages[0].role)]
+        messages = [ChatMessage(content=truncated_message + "\n" + original_question, role=messages[0].role)]
 
     return messages + [system_message]
 

--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -196,13 +196,14 @@ def truncate_messages(
         assert type(system_message.content) == str
         current_message = "\n".join(messages[0].content.split("\n")[:-1]) if type(messages[0].content) == str else ""
         original_question = "\n".join(messages[0].content.split("\n")[-1:]) if type(messages[0].content) == str else ""
+        original_question = f"\n{original_question}"
         original_question_tokens = len(encoder.encode(original_question))
         remaining_tokens = max_prompt_size - original_question_tokens - system_message_tokens
         truncated_message = encoder.decode(encoder.encode(current_message)[:remaining_tokens]).strip()
         logger.debug(
             f"Truncate current message to fit within max prompt size of {max_prompt_size} supported by {model_name} model:\n {truncated_message}"
         )
-        messages = [ChatMessage(content=truncated_message + "\n" + original_question, role=messages[0].role)]
+        messages = [ChatMessage(content=truncated_message + original_question, role=messages[0].role)]
 
     return messages + [system_message]
 

--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -18,7 +18,7 @@ model_to_prompt_size = {
     "gpt-3.5-turbo": 3000,
     "gpt-4": 7000,
     "gpt-4-1106-preview": 7000,
-    "gpt-4-turbo-preview": 4000,
+    "gpt-4-turbo-preview": 7000,
     "llama-2-7b-chat.ggmlv3.q4_0.bin": 1548,
     "gpt-3.5-turbo-16k": 15000,
     "mistral-7b-instruct-v0.1.Q4_0.gguf": 1548,

--- a/src/khoj/processor/tools/online_search.py
+++ b/src/khoj/processor/tools/online_search.py
@@ -84,7 +84,7 @@ async def search_with_google(query: str, conversation_history: dict):
                 try:
                     extracted_content[subquery].append(search_with_olostep(result["link"]).strip())
                 except Exception as e:
-                    logger.error(e, exc_info=True)
+                    logger.error(f"Error while searching web page of '{result['link']}': {e}", exc_info=True)
                     continue
             extracted_relevant_content = await extract_relevant_info(subquery, extracted_content)
             response_dict[subquery]["extracted_content"] = extracted_relevant_content

--- a/src/khoj/processor/tools/online_search.py
+++ b/src/khoj/processor/tools/online_search.py
@@ -18,7 +18,6 @@ SERPER_DEV_URL = "https://google.serper.dev/search"
 OLOSTEP_API_URL = "https://agent.olostep.com/olostep-p2p-incomingAPI"
 
 OLOSTEP_QUERY_PARAMS = {
-    "token": OLOSTEP_API_KEY,
     "timeout": 35,  # seconds
     "waitBeforeScraping": 1,  # seconds
     "saveHtml": False,
@@ -97,10 +96,12 @@ def search_with_olostep(web_url: str) -> str:
     if OLOSTEP_API_KEY is None:
         raise ValueError("OLOSTEP_API_KEY is not set")
 
+    headers = {"Authorization": f"Bearer {OLOSTEP_API_KEY}"}
+
     web_scraping_params: Dict[str, Union[str, int, bool]] = OLOSTEP_QUERY_PARAMS.copy()  # type: ignore
     web_scraping_params["url"] = web_url
 
-    response = requests.request("GET", OLOSTEP_API_URL, params=web_scraping_params)
+    response = requests.request("GET", OLOSTEP_API_URL, params=web_scraping_params, headers=headers)
 
     if response.status_code != 200:
         logger.error(response, exc_info=True)

--- a/src/khoj/processor/tools/online_search.py
+++ b/src/khoj/processor/tools/online_search.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from typing import Dict, List, Union
 
 import requests
 
@@ -70,7 +71,7 @@ async def search_with_google(query: str, conversation_history: dict):
         logger.info(f"Searching with Google for '{subquery}'")
         response_dict[subquery] = _search_with_google(subquery)
 
-    extracted_content = {}
+    extracted_content: Dict[str, List] = {}
     if is_none_or_empty(OLOSTEP_API_KEY):
         logger.warning("OLOSTEP_API_KEY is not set. Skipping web scraping.")
         return response_dict
@@ -96,7 +97,7 @@ def search_with_olostep(web_url: str) -> str:
     if OLOSTEP_API_KEY is None:
         raise ValueError("OLOSTEP_API_KEY is not set")
 
-    web_scraping_params = OLOSTEP_QUERY_PARAMS.copy()
+    web_scraping_params: Dict[str, Union[str, int, bool]] = OLOSTEP_QUERY_PARAMS.copy()  # type: ignore
     web_scraping_params["url"] = web_url
 
     response = requests.request("GET", OLOSTEP_API_URL, params=web_scraping_params)

--- a/tests/test_gpt4all_chat_director.py
+++ b/tests/test_gpt4all_chat_director.py
@@ -57,11 +57,11 @@ def test_chat_with_no_chat_history_or_retrieved_content_gpt4all(client_offline_c
 @pytest.mark.skipif(os.getenv("SERPER_DEV_API_KEY") is None, reason="requires SERPER_DEV_API_KEY")
 @pytest.mark.chatquality
 @pytest.mark.django_db(transaction=True)
-def test_chat_with_online_content(chat_client):
+def test_chat_with_online_content(client_offline_chat):
     # Act
     q = "/online give me the link to paul graham's essay how to do great work"
     encoded_q = quote(q, safe="")
-    response = chat_client.get(f"/api/chat?q={encoded_q}&stream=true")
+    response = client_offline_chat.get(f"/api/chat?q={encoded_q}&stream=true")
     response_message = response.content.decode("utf-8")
 
     response_message = response_message.split("### compiled references")[0]
@@ -70,7 +70,31 @@ def test_chat_with_online_content(chat_client):
     expected_responses = ["http://www.paulgraham.com/greatwork.html"]
     assert response.status_code == 200
     assert any([expected_response in response_message for expected_response in expected_responses]), (
-        "Expected assistants name, [K|k]hoj, in response but got: " + response_message
+        "Expected links or serper not setup in response but got: " + response_message
+    )
+
+
+# ----------------------------------------------------------------------------------------------------
+@pytest.mark.skipif(
+    os.getenv("SERPER_DEV_API_KEY") is None or os.getenv("OLOSTEP_API_KEY") is None,
+    reason="requires SERPER_DEV_API_KEY and OLOSTEP_API_KEY",
+)
+@pytest.mark.chatquality
+@pytest.mark.django_db(transaction=True)
+def test_chat_with_online_webpage_content(client_offline_chat):
+    # Act
+    q = "/online how many firefighters were involved in the great chicago fire and which year did it take place?"
+    encoded_q = quote(q, safe="")
+    response = client_offline_chat.get(f"/api/chat?q={encoded_q}&stream=true")
+    response_message = response.content.decode("utf-8")
+
+    response_message = response_message.split("### compiled references")[0]
+
+    # Assert
+    expected_responses = ["185", "1871", "horse"]
+    assert response.status_code == 200
+    assert any([expected_response in response_message for expected_response in expected_responses]), (
+        "Expected links or serper not setup in response but got: " + response_message
     )
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,4 @@
+import os
 import secrets
 
 import numpy as np
@@ -6,6 +7,7 @@ import pytest
 from scipy.stats import linregress
 
 from khoj.processor.embeddings import EmbeddingsModel
+from khoj.processor.tools.online_search import search_with_olostep
 from khoj.utils import helpers
 
 
@@ -80,3 +82,18 @@ def test_encode_docs_memory_leak():
     # If slope is positive memory utilization is increasing
     # Positive threshold of 2, from observing memory usage trend on MPS vs CPU device
     assert slope < 2, f"Memory leak suspected on {device}. Memory usage increased at ~{slope:.2f} MB per iteration"
+
+
+@pytest.mark.skipif(os.getenv("OLOSTEP_API_KEY") is None, reason="OLOSTEP_API_KEY is not set")
+def test_olostep_api():
+    # Arrange
+    website = "https://en.wikipedia.org/wiki/Great_Chicago_Fire"
+
+    # Act
+    response = search_with_olostep(website)
+
+    # Assert
+    assert (
+        "An alarm sent from the area near the fire also failed to register at the courthouse where the fire watchmen were"
+        in response
+    )


### PR DESCRIPTION
- Use [Olostep](https://www.olostep.com/) to go through top results from Serper's google search
- Add an intermediate step that summarizes extracted web results for further response downstream
- If `answerBox` is present in the query results, no need to do the additional scraping
- Add truncation logic to the model wrapper