### PR TITLE
Miscellaneous bugs and fixes for chat sessions

### DIFF
--- a/src/interface/desktop/assets/khoj.css
+++ b/src/interface/desktop/assets/khoj.css
@@ -65,12 +65,18 @@
     font-weight: 300;
 }
 
-.khoj-header {
+div.khoj-header {
     display: grid;
     grid-auto-flow: column;
     gap: 20px;
-    padding: 16px 0;
+    padding: 24px 16px 0px 0px;
     margin: 0 0 16px 0;
+    -webkit-user-select: none;
+    -webkit-app-region: drag;
+}
+
+a.khoj-nav {
+    -webkit-app-region: no-drag;
 }
 
 nav.khoj-nav {
@@ -117,7 +123,7 @@ img.khoj-logo {
         display: grid;
         grid-auto-flow: column;
         gap: 20px;
-        padding: 12px 10px;
+        padding: 24px 10px 10px 10px;
         margin: 0 0 16px 0;
     }
 

--- a/src/interface/desktop/chat.html
+++ b/src/interface/desktop/chat.html
@@ -349,6 +349,7 @@
                 let data = await response.json();
                 conversationID = data.conversation_id;
                 chat_body.dataset.conversationId = conversationID;
+                await refreshChatSessionsPanel();
             }
 
 
@@ -665,6 +666,107 @@
                     return;
                 });
 
+            await refreshChatSessionsPanel();
+
+            fetch(`${hostURL}/api/chat/starters?client=desktop`, { headers })
+                .then(response => response.json())
+                .then(data => {
+                    // Render chat options, if any
+                    if (data.length > 0) {
+                        let questionStarterSuggestions = document.getElementById("question-starters");
+                        for (let index in data) {
+                            let questionStarter = data[index];
+                            let questionStarterButton = document.createElement('button');
+                            questionStarterButton.innerHTML = questionStarter;
+                            questionStarterButton.classList.add("question-starter");
+                            questionStarterButton.addEventListener('click', function() {
+                                questionStarterSuggestions.style.display = "none";
+                                document.getElementById("chat-input").value = questionStarter;
+                                chat();
+                            });
+                            questionStarterSuggestions.appendChild(questionStarterButton);
+                        }
+                        questionStarterSuggestions.style.display = "grid";
+                    }
+                })
+                .catch(err => {
+                    return;
+                });
+
+            fetch(`${hostURL}/api/chat/options`, { headers })
+                .then(response => response.json())
+                .then(data => {
+                    // Render chat options, if any
+                    if (data) {
+                        chatOptions = data;
+                    }
+                })
+                .catch(err => {
+                    return;
+                });
+
+            // Fill query field with value passed in URL query parameters, if any.
+            var query_via_url = new URLSearchParams(window.location.search).get("q");
+            if (query_via_url) {
+                document.getElementById("chat-input").value = query_via_url;
+                chat();
+            }
+        }
+
+        function flashStatusInChatInput(message) {
+            // Get chat input element and original placeholder
+            let chatInput = document.getElementById("chat-input");
+            let originalPlaceholder = chatInput.placeholder;
+            // Set placeholder to message
+            chatInput.placeholder = message;
+            // Reset placeholder after 2 seconds
+            setTimeout(() => {
+                chatInput.placeholder = originalPlaceholder;
+            }, 2000);
+        }
+
+        function createNewConversation() {
+            let chatBody = document.getElementById("chat-body");
+            chatBody.innerHTML = "";
+            flashStatusInChatInput("📝 New conversation started");
+            chatBody.dataset.conversationId = "";
+            chatBody.dataset.conversationTitle = "";
+            renderMessage("Hey 👋🏾, what's up?", "khoj");
+        }
+
+        async function clearConversationHistory() {
+            let chatInput = document.getElementById("chat-input");
+            let originalPlaceholder = chatInput.placeholder;
+            let chatBody = document.getElementById("chat-body");
+            let conversationId = chatBody.dataset.conversationId;
+
+            let deleteURL = `/api/chat/history?client=desktop`;
+            if (conversationId) {
+                deleteURL += `&conversation_id=${conversationId}`;
+            }
+
+            const hostURL = await window.hostURLAPI.getURL();
+            const khojToken = await window.tokenAPI.getToken();
+            const headers = { 'Authorization': `Bearer ${khojToken}` };
+
+            fetch(`${hostURL}${deleteURL}`, { method: "DELETE", headers })
+                .then(response => response.ok ? response.json() : Promise.reject(response))
+                .then(data => {
+                    chatBody.innerHTML = "";
+                    chatBody.dataset.conversationId = "";
+                    chatBody.dataset.conversationTitle = "";
+                    loadChat();
+                    flashStatusInChatInput("🗑 Cleared conversation history");
+                })
+                .catch(err => {
+                    flashStatusInChatInput("⛔️ Failed to clear conversation history");
+                })
+        }
+
+        async function refreshChatSessionsPanel() {
+            const hostURL = await window.hostURLAPI.getURL();
+            const khojToken = await window.tokenAPI.getToken();
+            const headers = { 'Authorization': `Bearer ${khojToken}` };
 
             fetch(`${hostURL}/api/chat/sessions`, { method: "GET", headers })
                 .then(response => response.json())
@@ -799,101 +901,9 @@
                             conversationListBody.appendChild(conversationButton);
                         }
                     }
-                })
-
-            fetch(`${hostURL}/api/chat/starters?client=desktop`, { headers })
-                .then(response => response.json())
-                .then(data => {
-                    // Render chat options, if any
-                    if (data.length > 0) {
-                        let questionStarterSuggestions = document.getElementById("question-starters");
-                        for (let index in data) {
-                            let questionStarter = data[index];
-                            let questionStarterButton = document.createElement('button');
-                            questionStarterButton.innerHTML = questionStarter;
-                            questionStarterButton.classList.add("question-starter");
-                            questionStarterButton.addEventListener('click', function() {
-                                questionStarterSuggestions.style.display = "none";
-                                document.getElementById("chat-input").value = questionStarter;
-                                chat();
-                            });
-                            questionStarterSuggestions.appendChild(questionStarterButton);
-                        }
-                        questionStarterSuggestions.style.display = "grid";
-                    }
-                })
-                .catch(err => {
+                }).catch(err => {
                     return;
-                });
-
-            fetch(`${hostURL}/api/chat/options`, { headers })
-                .then(response => response.json())
-                .then(data => {
-                    // Render chat options, if any
-                    if (data) {
-                        chatOptions = data;
-                    }
-                })
-                .catch(err => {
-                    return;
-                });
-
-            // Fill query field with value passed in URL query parameters, if any.
-            var query_via_url = new URLSearchParams(window.location.search).get("q");
-            if (query_via_url) {
-                document.getElementById("chat-input").value = query_via_url;
-                chat();
-            }
-        }
-
-        function flashStatusInChatInput(message) {
-            // Get chat input element and original placeholder
-            let chatInput = document.getElementById("chat-input");
-            let originalPlaceholder = chatInput.placeholder;
-            // Set placeholder to message
-            chatInput.placeholder = message;
-            // Reset placeholder after 2 seconds
-            setTimeout(() => {
-                chatInput.placeholder = originalPlaceholder;
-            }, 2000);
-        }
-
-        function createNewConversation() {
-            let chatBody = document.getElementById("chat-body");
-            chatBody.innerHTML = "";
-            flashStatusInChatInput("📝 New conversation started");
-            chatBody.dataset.conversationId = "";
-            chatBody.dataset.conversationTitle = "";
-            renderMessage("Hey 👋🏾, what's up?", "khoj");
-        }
-
-        async function clearConversationHistory() {
-            let chatInput = document.getElementById("chat-input");
-            let originalPlaceholder = chatInput.placeholder;
-            let chatBody = document.getElementById("chat-body");
-            let conversationId = chatBody.dataset.conversationId;
-
-            let deleteURL = `/api/chat/history?client=desktop`;
-            if (conversationId) {
-                deleteURL += `&conversation_id=${conversationId}`;
-            }
-
-            const hostURL = await window.hostURLAPI.getURL();
-            const khojToken = await window.tokenAPI.getToken();
-            const headers = { 'Authorization': `Bearer ${khojToken}` };
-
-            fetch(`${hostURL}${deleteURL}`, { method: "DELETE", headers })
-                .then(response => response.ok ? response.json() : Promise.reject(response))
-                .then(data => {
-                    chatBody.innerHTML = "";
-                    chatBody.dataset.conversationId = "";
-                    chatBody.dataset.conversationTitle = "";
-                    loadChat();
-                    flashStatusInChatInput("🗑 Cleared conversation history");
-                })
-                .catch(err => {
-                    flashStatusInChatInput("⛔️ Failed to clear conversation history");
-                })
+            });
         }
 
         let sendMessageTimeout;

--- a/src/interface/desktop/chat.html
+++ b/src/interface/desktop/chat.html
@@ -1065,16 +1065,6 @@
                 <div id="chat-footer">
                     <div id="chat-tooltip" style="display: none;"></div>
                     <div id="input-row">
-                        <button id="clear-chat-button" class="input-row-button" onclick="clearConversationHistory()">
-                            <svg class="input-row-button-img" alt="Clear Chat History" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
-                                <rect width="128" height="128" fill="none"/>
-                                <line x1="216" y1="56" x2="40" y2="56" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="12"/>
-                                <line x1="104" y1="104" x2="104" y2="168" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="12"/>
-                                <line x1="152" y1="104" x2="152" y2="168" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="12"/>
-                                <path d="M200,56V208a8,8,0,0,1-8,8H64a8,8,0,0,1-8-8V56" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="12"/>
-                                <path d="M168,56V40a16,16,0,0,0-16-16H104A16,16,0,0,0,88,40V56" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="12"/>
-                            </svg>
-                        </button>
                         <textarea id="chat-input" class="option" oninput="onChatInput()" onkeydown=incrementalChat(event) autofocus="autofocus" placeholder="Type / to see a list of commands"></textarea>
                         <button id="speak-button" class="input-row-button"
                             ontouchstart="speechToText(event)" ontouchend="speechToText(event)" ontouchcancel="speechToText(event)" onmousedown="speechToText(event)">
@@ -1292,7 +1282,7 @@
         }
         #input-row {
             display: grid;
-            grid-template-columns: 32px auto 32px 40px;
+            grid-template-columns: auto 32px 40px;
             grid-column-gap: 10px;
             grid-row-gap: 10px;
             background: #f9fafc;

--- a/src/interface/desktop/main.js
+++ b/src/interface/desktop/main.js
@@ -356,7 +356,7 @@ const createWindow = (tab = 'chat.html') => {
       width: 800,
       height: 800,
       show: false,
-    //   titleBarStyle: 'hidden',
+      titleBarStyle: 'hidden',
       webPreferences: {
         preload: path.join(__dirname, 'preload.js'),
         nodeIntegration: true,

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -426,7 +426,7 @@ Auto invokes setup steps on calling main entrypoint."
           (url-retrieve (format "%s/api/v1/index/update?%s&force=%s&client=emacs" khoj-server-url type-query (or force "false"))
                         ;; render response from indexing API endpoint on server
                         (lambda (status)
-                          (if (not status)
+                          (if (not (plist-get status :error))
                               (message "khoj.el: %scontent index %supdated" (if content-type (format "%s " content-type) "all ") (if force "force " ""))
                             (progn
                               (khoj--delete-open-network-connections-to-server)

--- a/src/interface/obsidian/src/chat_modal.ts
+++ b/src/interface/obsidian/src/chat_modal.ts
@@ -285,7 +285,7 @@ export class KhojChatModal extends Modal {
 
                 return false;
             } else if (responseJson.response) {
-                let chatLogs = responseJson.response.chat;
+                let chatLogs = responseJson.response?.chat ?? responseJson.response ?? [];
                 chatLogs.forEach((chatLog: any) => {
                     this.renderMessageWithReferences(chatBodyEl, chatLog.message, chatLog.by, chatLog.context, new Date(chatLog.created), chatLog.intent?.type);
                 });

--- a/src/interface/obsidian/src/chat_modal.ts
+++ b/src/interface/obsidian/src/chat_modal.ts
@@ -285,7 +285,7 @@ export class KhojChatModal extends Modal {
 
                 return false;
             } else if (responseJson.response) {
-                let chatLogs = responseJson.response?.chat ?? responseJson.response ?? [];
+                let chatLogs = responseJson.response?.conversation_id ? responseJson.response.chat ?? [] : responseJson.response;
                 chatLogs.forEach((chatLog: any) => {
                     this.renderMessageWithReferences(chatBodyEl, chatLog.message, chatLog.by, chatLog.context, new Date(chatLog.created), chatLog.intent?.type);
                 });

--- a/src/khoj/database/adapters/__init__.py
+++ b/src/khoj/database/adapters/__init__.py
@@ -392,7 +392,7 @@ class ConversationAdapters:
         if conversation_id:
             conversation = Conversation.objects.filter(user=user, client=client_application, id=conversation_id)
         if not conversation_id or not conversation.exists():
-            conversation = Conversation.objects.filter(user=user, client=client_application)
+            conversation = Conversation.objects.filter(user=user, client=client_application).order_by("-updated_at")
         if conversation.exists():
             return conversation.first()
         return Conversation.objects.create(user=user, client=client_application)
@@ -514,7 +514,7 @@ class ConversationAdapters:
         else:
             conversation = Conversation.objects.filter(user=user, client=client_application)
         if conversation.exists():
-            conversation.update(conversation_log=conversation_log, slug=slug)
+            conversation.update(conversation_log=conversation_log, slug=slug, updated_at=datetime.now(tz=timezone.utc))
         else:
             Conversation.objects.create(
                 user=user, conversation_log=conversation_log, client=client_application, slug=slug

--- a/src/khoj/database/migrations/0030_conversation_slug_and_title.py
+++ b/src/khoj/database/migrations/0030_conversation_slug_and_title.py
@@ -3,6 +3,21 @@
 from django.db import migrations, models
 
 
+def set_default_slug(apps, schema_editor):
+    Conversation = apps.get_model("database", "Conversation")
+    for conversation in Conversation.objects.all():
+        formatted_date = conversation.created_at.strftime("%Y-%m-%d")
+        conversation.slug = f"Conversation from {formatted_date}"
+        conversation.save()
+
+
+def reverse_set_default_slug(apps, schema_editor):
+    Conversation = apps.get_model("database", "Conversation")
+    for conversation in Conversation.objects.all():
+        conversation.slug = None
+        conversation.save()
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("database", "0029_userrequests"),
@@ -19,4 +34,5 @@ class Migration(migrations.Migration):
             name="title",
             field=models.CharField(blank=True, default=None, max_length=200, null=True),
         ),
+        migrations.RunPython(set_default_slug, reverse_code=reverse_set_default_slug),
     ]

--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -676,28 +676,6 @@ To get started, just start typing below. You can also type / to see a list of co
                                 let conversationMenu = document.createElement('div');
                                 conversationMenu.classList.add("conversation-menu");
 
-                                let deleteButton = document.createElement('button');
-                                deleteButton.innerHTML = "Delete";
-                                deleteButton.classList.add("delete-conversation-button");
-                                deleteButton.classList.add("three-dot-menu-button-item");
-                                deleteButton.addEventListener('click', function() {
-                                    let deleteURL = `/api/chat/history?client=web&conversation_id=${incomingConversationId}`;
-                                    fetch(deleteURL , { method: "DELETE" })
-                                        .then(response => response.ok ? response.json() : Promise.reject(response))
-                                        .then(data => {
-                                            let chatBody = document.getElementById("chat-body");
-                                            chatBody.innerHTML = "";
-                                            chatBody.dataset.conversationId = "";
-                                            chatBody.dataset.conversationTitle = "";
-                                            loadChat();
-                                        })
-                                        .catch(err => {
-                                            return;
-                                        });
-                                });
-                                conversationMenu.appendChild(deleteButton);
-                                threeDotMenu.appendChild(conversationMenu);
-
                                 let editTitleButton = document.createElement('button');
                                 editTitleButton.innerHTML = "Rename";
                                 editTitleButton.classList.add("edit-title-button");
@@ -752,6 +730,28 @@ To get started, just start typing below. You can also type / to see a list of co
                                     conversationMenu.appendChild(conversationTitleInputBox);
                                 });
                                 conversationMenu.appendChild(editTitleButton);
+                                threeDotMenu.appendChild(conversationMenu);
+
+                                let deleteButton = document.createElement('button');
+                                deleteButton.innerHTML = "Delete";
+                                deleteButton.classList.add("delete-conversation-button");
+                                deleteButton.classList.add("three-dot-menu-button-item");
+                                deleteButton.addEventListener('click', function() {
+                                    let deleteURL = `/api/chat/history?client=web&conversation_id=${incomingConversationId}`;
+                                    fetch(deleteURL , { method: "DELETE" })
+                                        .then(response => response.ok ? response.json() : Promise.reject(response))
+                                        .then(data => {
+                                            let chatBody = document.getElementById("chat-body");
+                                            chatBody.innerHTML = "";
+                                            chatBody.dataset.conversationId = "";
+                                            chatBody.dataset.conversationTitle = "";
+                                            loadChat();
+                                        })
+                                        .catch(err => {
+                                            return;
+                                        });
+                                });
+                                conversationMenu.appendChild(deleteButton);
                                 threeDotMenu.appendChild(conversationMenu);
                             });
                             threeDotMenu.appendChild(threeDotMenuButton);
@@ -1013,16 +1013,6 @@ To get started, just start typing below. You can also type / to see a list of co
                 <div id="chat-footer">
                     <div id="chat-tooltip" style="display: none;"></div>
                     <div id="input-row">
-                        <button id="clear-chat-button" class="input-row-button" onclick="clearConversationHistory()">
-                            <svg class="input-row-button-img" alt="Clear Chat History" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
-                                <rect width="128" height="128" fill="none"/>
-                                <line x1="216" y1="56" x2="40" y2="56" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="12"/>
-                                <line x1="104" y1="104" x2="104" y2="168" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="12"/>
-                                <line x1="152" y1="104" x2="152" y2="168" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="12"/>
-                                <path d="M200,56V208a8,8,0,0,1-8,8H64a8,8,0,0,1-8-8V56" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="12"/>
-                                <path d="M168,56V40a16,16,0,0,0-16-16H104A16,16,0,0,0,88,40V56" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="12"/>
-                            </svg>
-                        </button>
                         <textarea id="chat-input" class="option" oninput="onChatInput()" onkeydown=incrementalChat(event) autofocus="autofocus" placeholder="Type / to see a list of commands"></textarea>
                         <button id="speak-button" class="input-row-button"
                             ontouchstart="speechToText(event)" ontouchend="speechToText(event)" ontouchcancel="speechToText(event)" onmousedown="speechToText(event)">
@@ -1361,7 +1351,7 @@ To get started, just start typing below. You can also type / to see a list of co
         }
         #input-row {
             display: grid;
-            grid-template-columns: 32px auto 32px 40px;
+            grid-template-columns: auto 32px 40px;
             grid-column-gap: 10px;
             grid-row-gap: 10px;
             background: var(--background-color);

--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -358,6 +358,7 @@ To get started, just start typing below. You can also type / to see a list of co
                 let data = await response.json();
                 conversationID = data.conversation_id;
                 chat_body.dataset.conversationId = conversationID;
+                refreshChatSessionsPanel();
             }
 
             // Generate backend API URL to execute query
@@ -626,6 +627,75 @@ To get started, just start typing below. You can also type / to see a list of co
                     return;
                 });
 
+            refreshChatSessionsPanel();
+
+            fetch('/api/chat/options')
+                .then(response => response.json())
+                .then(data => {
+                    // Render chat options, if any
+                    if (data) {
+                        chatOptions = data;
+                    }
+                })
+                .catch(err => {
+                    return;
+                });
+
+            fetch('/api/chat/starters')
+                .then(response => response.json())
+                .then(data => {
+                    // Render chat options, if any
+                    if (data.length > 0) {
+                        let questionStarterSuggestions = document.getElementById("question-starters");
+                        for (let index in data) {
+                            let questionStarter = data[index];
+                            let questionStarterButton = document.createElement('button');
+                            questionStarterButton.innerHTML = questionStarter;
+                            questionStarterButton.classList.add("question-starter");
+                            questionStarterButton.addEventListener('click', function() {
+                                questionStarterSuggestions.style.display = "none";
+                                document.getElementById("chat-input").value = questionStarter;
+                                chat();
+                            });
+                            questionStarterSuggestions.appendChild(questionStarterButton);
+                        }
+                        questionStarterSuggestions.style.display = "grid";
+                    }
+                })
+                .catch(err => {
+                    return;
+                });
+
+            // Fill query field with value passed in URL query parameters, if any.
+            var query_via_url = new URLSearchParams(window.location.search).get("q");
+            if (query_via_url) {
+                document.getElementById("chat-input").value = query_via_url;
+                chat();
+            }
+        }
+
+        function flashStatusInChatInput(message) {
+            // Get chat input element and original placeholder
+            let chatInput = document.getElementById("chat-input");
+            let originalPlaceholder = chatInput.placeholder;
+            // Set placeholder to message
+            chatInput.placeholder = message;
+            // Reset placeholder after 2 seconds
+            setTimeout(() => {
+                chatInput.placeholder = originalPlaceholder;
+            }, 2000);
+        }
+
+        function createNewConversation() {
+            let chatBody = document.getElementById("chat-body");
+            chatBody.innerHTML = "";
+            flashStatusInChatInput("📝 New conversation started");
+            chatBody.dataset.conversationId = "";
+            chatBody.dataset.conversationTitle = "";
+            renderMessage(welcome_message, "khoj");
+        }
+
+        function refreshChatSessionsPanel() {
             fetch('/api/chat/sessions', { method: "GET" })
                 .then(response => response.json())
                 .then(data => {
@@ -764,71 +834,6 @@ To get started, just start typing below. You can also type / to see a list of co
                     console.log(err);
                     return;
                 });
-
-            fetch('/api/chat/options')
-                .then(response => response.json())
-                .then(data => {
-                    // Render chat options, if any
-                    if (data) {
-                        chatOptions = data;
-                    }
-                })
-                .catch(err => {
-                    return;
-                });
-
-            fetch('/api/chat/starters')
-                .then(response => response.json())
-                .then(data => {
-                    // Render chat options, if any
-                    if (data.length > 0) {
-                        let questionStarterSuggestions = document.getElementById("question-starters");
-                        for (let index in data) {
-                            let questionStarter = data[index];
-                            let questionStarterButton = document.createElement('button');
-                            questionStarterButton.innerHTML = questionStarter;
-                            questionStarterButton.classList.add("question-starter");
-                            questionStarterButton.addEventListener('click', function() {
-                                questionStarterSuggestions.style.display = "none";
-                                document.getElementById("chat-input").value = questionStarter;
-                                chat();
-                            });
-                            questionStarterSuggestions.appendChild(questionStarterButton);
-                        }
-                        questionStarterSuggestions.style.display = "grid";
-                    }
-                })
-                .catch(err => {
-                    return;
-                });
-
-            // Fill query field with value passed in URL query parameters, if any.
-            var query_via_url = new URLSearchParams(window.location.search).get("q");
-            if (query_via_url) {
-                document.getElementById("chat-input").value = query_via_url;
-                chat();
-            }
-        }
-
-        function flashStatusInChatInput(message) {
-            // Get chat input element and original placeholder
-            let chatInput = document.getElementById("chat-input");
-            let originalPlaceholder = chatInput.placeholder;
-            // Set placeholder to message
-            chatInput.placeholder = message;
-            // Reset placeholder after 2 seconds
-            setTimeout(() => {
-                chatInput.placeholder = originalPlaceholder;
-            }, 2000);
-        }
-
-        function createNewConversation() {
-            let chatBody = document.getElementById("chat-body");
-            chatBody.innerHTML = "";
-            flashStatusInChatInput("📝 New conversation started");
-            chatBody.dataset.conversationId = "";
-            chatBody.dataset.conversationTitle = "";
-            renderMessage(welcome_message, "khoj");
         }
 
         function clearConversationHistory() {

--- a/src/khoj/interface/web/config.html
+++ b/src/khoj/interface/web/config.html
@@ -13,7 +13,7 @@
                     </h3>
                 </div>
                 <div class="card-description-row">
-                    <input type="text" id="profile_given_name" class="form-control" placeholder="Enter your name here" value="{{ given_name }}">
+                    <input type="text" id="profile_given_name" class="form-control" placeholder="Enter your name here" value="{% if given_name %}{{given_name}}{% endif %}">
                 </div>
                 <div class="card-action-row">
                     <button id="save-model" class="card-button happy" onclick="saveProfileGivenName()">

--- a/src/khoj/processor/conversation/offline/chat_model.py
+++ b/src/khoj/processor/conversation/offline/chat_model.py
@@ -181,7 +181,7 @@ def converse_offline(
                 simplified_online_results[result] = online_results[result]["extracted_content"]
 
         conversation_primer = f"{prompts.online_search_conversation.format(online_results=str(simplified_online_results))}\n{conversation_primer}"
-    if ConversationCommand.Notes in conversation_commands:
+    if not is_none_or_empty(compiled_references_message):
         conversation_primer = f"{prompts.notes_conversation_gpt4all.format(references=compiled_references_message)}\n{conversation_primer}"
 
     # Setup Prompt with Primer or Conversation History

--- a/src/khoj/processor/conversation/openai/gpt.py
+++ b/src/khoj/processor/conversation/openai/gpt.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from datetime import datetime, timedelta
 from typing import Optional
@@ -29,10 +30,6 @@ def extract_questions(
     """
     Infer search queries to retrieve relevant notes to answer user query
     """
-
-    def _valid_question(question: str):
-        return not is_none_or_empty(question) and question != "[]"
-
     location = f"{location_data.city}, {location_data.region}, {location_data.country}" if location_data else "Unknown"
 
     # Extract Past User Message and Inferred Questions from Conversation Log
@@ -75,23 +72,13 @@ def extract_questions(
 
     # Extract, Clean Message from GPT's Response
     try:
-        split_questions = (
-            response.content.strip(empty_escape_sequences)
-            .replace("['", '["')
-            .replace("']", '"]')
-            .replace("', '", '", "')
-            .replace('["', "")
-            .replace('"]', "")
-            .split('", "')
-        )
-        questions = []
-
-        for question in split_questions:
-            if question not in questions and _valid_question(question):
-                questions.append(question)
-
-        if is_none_or_empty(questions):
-            raise ValueError("GPT returned empty JSON")
+        response = response.strip()
+        response = json.loads(response)
+        response = [q.strip() for q in response if q.strip()]
+        if not isinstance(response, list) or not response or len(response) == 0:
+            logger.error(f"Invalid response for constructing subqueries: {response}")
+            return [text]
+        return response
     except:
         logger.warning(f"GPT returned invalid JSON. Falling back to using user message as search query.\n{response}")
         questions = [text]

--- a/src/khoj/processor/conversation/openai/gpt.py
+++ b/src/khoj/processor/conversation/openai/gpt.py
@@ -152,7 +152,7 @@ def converse(
                 simplified_online_results[result] = online_results[result]["extracted_content"]
 
         conversation_primer = f"{prompts.online_search_conversation.format(online_results=str(simplified_online_results))}\n{conversation_primer}"
-    if ConversationCommand.Notes in conversation_commands:
+    if not is_none_or_empty(compiled_references):
         conversation_primer = f"{prompts.notes_conversation.format(query=user_query, references=compiled_references)}\n{conversation_primer}"
 
     # Setup Prompt with Primer or Conversation History

--- a/src/khoj/processor/conversation/prompts.py
+++ b/src/khoj/processor/conversation/prompts.py
@@ -316,7 +316,7 @@ User: I've been having a hard time at work. I'm thinking of quitting.
 AI: I'm sorry to hear that. It's important to take care of your mental health. Have you considered talking to your manager about your concerns?
 
 Q: What are the best ways to quit a job?
-Khoj: ["general"]
+Khoj: ["default"]
 
 Example 3:
 Chat History:
@@ -329,14 +329,14 @@ Khoj: ["notes"]
 Example 4:
 Chat History:
 
-Q: I want to make chocolate cake. What was my recipe?
-Khoj: ["notes"]
+Q: What's the latest news with the first company I worked for?
+Khoj: ["notes", "online"]
 
 Example 5:
 Chat History:
 
-Q: What's the latest news with the first company I worked for?
-Khoj: ["notes", "online"]
+Q: Who is Sandra?
+Khoj: ["default"]
 
 Now it's your turn to pick the tools you would like to use to answer the user's question. Provide your response as a list of strings.
 

--- a/src/khoj/processor/tools/online_search.py
+++ b/src/khoj/processor/tools/online_search.py
@@ -60,7 +60,8 @@ async def search_with_google(query: str, conversation_history: dict, location: L
         return sub_response_dict
 
     if SERPER_DEV_API_KEY is None:
-        raise ValueError("SERPER_DEV_API_KEY is not set")
+        logger.warn("SERPER_DEV_API_KEY is not set")
+        return {}
 
     # Breakdown the query into subqueries to get the correct answer
     subqueries = await generate_online_subqueries(query, conversation_history, location)

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -283,7 +283,10 @@ async def extract_references_and_questions(
     compiled_references: List[Any] = []
     inferred_queries: List[str] = []
 
-    if not ConversationCommand.Notes in conversation_commands:
+    if (
+        not ConversationCommand.Notes in conversation_commands
+        and not ConversationCommand.Default in conversation_commands
+    ):
         return compiled_references, inferred_queries, q
 
     if not await sync_to_async(EntryAdapters.user_has_entries)(user=user):

--- a/src/khoj/routers/api_chat.py
+++ b/src/khoj/routers/api_chat.py
@@ -331,7 +331,8 @@ async def chat(
         user_name,
     )
 
-    chat_metadata.update({"conversation_command": ",".join([cmd.value for cmd in conversation_commands])})
+    cmd_set = set([cmd.value for cmd in conversation_commands])
+    chat_metadata["conversation_command"] = cmd_set
 
     update_telemetry_state(
         request=request,

--- a/src/khoj/routers/helpers.py
+++ b/src/khoj/routers/helpers.py
@@ -36,6 +36,7 @@ from khoj.utils import state
 from khoj.utils.config import GPT4AllProcessorModel
 from khoj.utils.helpers import (
     ConversationCommand,
+    is_none_or_empty,
     log_telemetry,
     tool_descriptions_for_llm,
 )
@@ -175,6 +176,9 @@ async def aget_relevant_information_sources(query: str, conversation_history: di
             if llm_suggested_tool in tool_options.keys():
                 # Check whether the tool exists as a valid ConversationCommand
                 final_response.append(ConversationCommand(llm_suggested_tool))
+
+        if is_none_or_empty(final_response):
+            final_response = [ConversationCommand.Default]
         return final_response
     except Exception as e:
         logger.error(f"Invalid response for determining relevant tools: {response}")

--- a/src/khoj/utils/helpers.py
+++ b/src/khoj/utils/helpers.py
@@ -283,9 +283,9 @@ command_descriptions = {
 }
 
 tool_descriptions_for_llm = {
-    ConversationCommand.Default: "Use this if there might be a mix of general and personal knowledge in the question, or if you can't make sense of the query",
+    ConversationCommand.Default: "Use this if there might be a mix of general and personal knowledge in the question, or if you don't entirely understand the query.",
     ConversationCommand.General: "Use this when you can answer the question without any outside information or personal knowledge",
-    ConversationCommand.Notes: "Use this when you would like to use the user's personal knowledge base to answer the question",
+    ConversationCommand.Notes: "Use this when you would like to use the user's personal knowledge base to answer the question. This is especially helpful if the query seems to be missing context.",
     ConversationCommand.Online: "Use this when you would like to look up information on the internet",
 }
 

--- a/tests/test_gpt4all_chat_director.py
+++ b/tests/test_gpt4all_chat_director.py
@@ -22,15 +22,21 @@ fake = Faker()
 
 # Helpers
 # ----------------------------------------------------------------------------------------------------
-def populate_chat_history(message_list, user):
+def generate_history(message_list):
     # Generate conversation logs
     conversation_log = {"chat": []}
-    for user_message, llm_message, context in message_list:
+    for user_message, gpt_message, context in message_list:
         conversation_log["chat"] += message_to_log(
             user_message,
-            llm_message,
+            gpt_message,
             {"context": context, "intent": {"query": user_message, "inferred-queries": f'["{user_message}"]'}},
         )
+    return conversation_log
+
+
+def populate_chat_history(message_list, user):
+    # Generate conversation logs
+    conversation_log = generate_history(message_list)
 
     # Update Conversation Metadata Logs in Database
     ConversationFactory(user=user, conversation_log=conversation_log)
@@ -515,8 +521,9 @@ async def test_get_correct_tools_with_chat_history(client_offline_chat):
         (
             "Let's talk about the current events around the world.",
             "Sure, let's discuss the current events. What would you like to know?",
+            [],
         ),
-        ("What's up in New York City?", "A Pride parade has recently been held in New York City, on July 31st."),
+        ("What's up in New York City?", "A Pride parade has recently been held in New York City, on July 31st.", []),
     ]
     chat_history = populate_chat_history(chat_log)
 
@@ -526,15 +533,3 @@ async def test_get_correct_tools_with_chat_history(client_offline_chat):
     # Assert
     tools = [tool.value for tool in tools]
     assert tools == ["online"]
-
-
-def populate_chat_history(message_list):
-    # Generate conversation logs
-    conversation_log = {"chat": []}
-    for user_message, gpt_message in message_list:
-        conversation_log["chat"] += message_to_log(
-            user_message,
-            gpt_message,
-            {"context": [], "intent": {"query": user_message, "inferred-queries": f'["{user_message}"]'}},
-        )
-    return conversation_log


### PR DESCRIPTION
# Incoming
- Display `given_name` only if not `None` in config page
- Add default slugs to the migration script
- Ensure `updated_at` is saved appropriately when saving chat history
- Return most recently updated conversation as default history
- Remove bin button from the desktop, web chat interfaces
- Stop generating offline chat message on hitting a stop phrase
- Fix detecting success when indexing update succeeds on Emacs