### PR TITLE
Retrieve, create, and save conversations differently for ClientApplications

### DIFF
--- a/src/interface/desktop/chat.html
+++ b/src/interface/desktop/chat.html
@@ -1246,7 +1246,7 @@
             margin: 0;
         }
         .chat-message-text-response {
-            margin-bottom: -16px;
+            margin-bottom: 0px;
         }
 
         /* Spinner symbol when the chat message is loading */

--- a/src/khoj/database/adapters/__init__.py
+++ b/src/khoj/database/adapters/__init__.py
@@ -396,8 +396,12 @@ class ConversationAdapters:
     def get_conversation_by_user(
         user: KhojUser, client_application: ClientApplication = None, conversation_id: int = None
     ):
+        if client_application:
+            return Conversation.objects.filter(user=user, client=client_application).first()
+
         if conversation_id:
             conversation = Conversation.objects.filter(user=user, client=client_application, id=conversation_id)
+
         if not conversation_id or not conversation.exists():
             conversation = Conversation.objects.filter(user=user, client=client_application).order_by("-updated_at")
         if conversation.exists():
@@ -433,6 +437,9 @@ class ConversationAdapters:
     async def aget_conversation_by_user(
         user: KhojUser, client_application: ClientApplication = None, conversation_id: int = None, slug: str = None
     ):
+        if client_application:
+            return await Conversation.objects.filter(user=user, client=client_application).afirst()
+
         if conversation_id:
             conversation = Conversation.objects.filter(user=user, client=client_application, id=conversation_id)
         else:
@@ -520,6 +527,7 @@ class ConversationAdapters:
             conversation = Conversation.objects.filter(user=user, client=client_application, id=conversation_id)
         else:
             conversation = Conversation.objects.filter(user=user, client=client_application)
+
         if conversation.exists():
             conversation.update(conversation_log=conversation_log, slug=slug, updated_at=datetime.now(tz=timezone.utc))
         else:

--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -1312,7 +1312,7 @@ To get started, just start typing below. You can also type / to see a list of co
             margin: 0;
         }
         .chat-message-text-response {
-            margin-bottom: -16px;
+            margin-bottom: 0px;
         }
 
         /* Spinner symbol when the chat message is loading */


### PR DESCRIPTION
# Incoming
- Change the way conversations are being managed for requests coming from client applications
- Not all of our client apps will necessarily maintain state over the conversation IDs available to a user. For some (single-threaded conversations), it should just use a single conversation. Fix the code to do so.