### PR TITLE
Rerank Search Results by Default on GPU machines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "pyyaml == 6.0",
     "rich >= 13.3.1",
     "schedule == 1.1.0",
-    "sentence-transformers == 2.3.1",
+    "sentence-transformers == 2.5.1",
     "transformers >= 4.28.0",
     "torch == 2.0.1",
     "uvicorn == 0.17.6",

--- a/src/interface/desktop/search.html
+++ b/src/interface/desktop/search.html
@@ -192,16 +192,17 @@
                 });
         }
 
+        let debounceTimeout;
         function incrementalSearch(event) {
-            type = 'all';
-            // Search with reranking on 'Enter'
-            if (event.key === 'Enter') {
-                search(rerank=true);
-            }
-            // Limit incremental search to text types
-            else if (type !== "image") {
-                search(rerank=false);
-            }
+            // Run incremental search only after waitTime passed since the last key press
+            let waitTime = 300;
+            clearTimeout(debounceTimeout);
+            debounceTimeout = setTimeout(() => {
+                type = 'all';
+                // Search with reranking on 'Enter'
+                let should_rerank = event.key === 'Enter';
+                search(rerank=should_rerank);
+            }, waitTime);
         }
 
         async function populate_type_dropdown() {

--- a/src/khoj/interface/web/search.html
+++ b/src/khoj/interface/web/search.html
@@ -193,16 +193,17 @@
                 });
         }
 
+        let debounceTimeout;
         function incrementalSearch(event) {
-            type = document.getElementById("type").value;
-            // Search with reranking on 'Enter'
-            if (event.key === 'Enter') {
-                search(rerank=true);
-            }
-            // Limit incremental search to text types
-            else if (type !== "image") {
-                search(rerank=false);
-            }
+            // Run incremental search only after waitTime passed since the last key press
+            let waitTime = 300;
+            clearTimeout(debounceTimeout);
+            debounceTimeout = setTimeout(() => {
+                type = document.getElementById("type").value;
+                // Search with reranking on 'Enter'
+                let should_rerank = event.key === 'Enter';
+                search(rerank=should_rerank);
+            }, waitTime);
         }
 
         function populate_type_dropdown() {

--- a/src/khoj/search_type/text_search.py
+++ b/src/khoj/search_type/text_search.py
@@ -177,8 +177,9 @@ def deduplicated_search_responses(hits: List[SearchResponse]):
 
 
 def rerank_and_sort_results(hits, query, rank_results, search_model_name):
-    # If we have more than one result and reranking is enabled
-    rank_results = rank_results and len(list(hits)) > 1
+    # Rerank results if explicitly requested or if device has GPU
+    # AND if we have more than one result
+    rank_results = (rank_results or state.device.type != "cpu") and len(list(hits)) > 1
 
     # Score all retrieved entries using the cross-encoder
     if rank_results:

--- a/src/khoj/search_type/text_search.py
+++ b/src/khoj/search_type/text_search.py
@@ -177,9 +177,13 @@ def deduplicated_search_responses(hits: List[SearchResponse]):
 
 
 def rerank_and_sort_results(hits, query, rank_results, search_model_name):
-    # Rerank results if explicitly requested or if device has GPU
+    # Rerank results if explicitly requested, if can use inference server or if device has GPU
     # AND if we have more than one result
-    rank_results = (rank_results or state.device.type != "cpu") and len(list(hits)) > 1
+    rank_results = (
+        rank_results
+        or state.cross_encoder_model[search_model_name].inference_server_enabled()
+        or state.device.type != "cpu"
+    ) and len(list(hits)) > 1
 
     # Score all retrieved entries using the cross-encoder
     if rank_results:

--- a/src/khoj/utils/helpers.py
+++ b/src/khoj/utils/helpers.py
@@ -331,7 +331,12 @@ def batcher(iterable, max_n):
         yield (x for x in chunk if x is not None)
 
 
+def is_env_var_true(env_var: str, default: str = "false") -> bool:
+    """Get state of boolean environment variable"""
+    return os.getenv(env_var, default).lower() == "true"
+
+
 def in_debug_mode():
     """Check if Khoj is running in debug mode.
     Set KHOJ_DEBUG environment variable to true to enable debug mode."""
-    return os.getenv("KHOJ_DEBUG", "false").lower() == "true"
+    return is_env_var_true("KHOJ_DEBUG")


### PR DESCRIPTION
**Trigger**: SentenceTransformer Cross Encoder models now run fast on GPU enabled machines, including Mac ARM devices since UKPLab/sentence-transformers#2463

### Details
- Only call search API when pause in typing search query on web, desktop apps (44c8d093)
- Use cross-encoder to rerank search results by default on GPU machines (1105d881) and when using an inference server (53d40248)