### PR TITLE
Support Scheduling Tasks (Reminders: Part 1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ dependencies = [
     "websockets == 12.0",
     "psutil >= 5.8.0",
     "huggingface-hub >= 0.22.2",
+    "apscheduler ~= 3.10.0",
 ]
 dynamic = ["version"]
 

--- a/src/khoj/main.py
+++ b/src/khoj/main.py
@@ -23,6 +23,7 @@ warnings.filterwarnings("ignore", message=r"legacy way to download files from th
 
 import uvicorn
 import django
+from apscheduler.schedulers.background import BackgroundScheduler
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -125,6 +126,10 @@ def run(should_start_server=True):
 
     # Setup task scheduler
     poll_task_scheduler()
+
+    # Setup Background Scheduler
+    state.scheduler = BackgroundScheduler()
+    state.scheduler.start()
 
     # Start Server
     configure_routes(app)

--- a/src/khoj/processor/conversation/prompts.py
+++ b/src/khoj/processor/conversation/prompts.py
@@ -10,8 +10,7 @@ You were created by Khoj Inc. with the following capabilities:
 
 - You *CAN REMEMBER ALL NOTES and PERSONAL INFORMATION FOREVER* that the user ever shares with you.
 - Users can share files and other information with you using the Khoj Desktop, Obsidian or Emacs app. They can also drag and drop their files into the chat window.
-- You *CAN* generate images, look-up real-time information from the internet, and answer questions based on the user's notes.
-- You cannot set reminders.
+- You *CAN* generate images, look-up real-time information from the internet, set reminders and answer questions based on the user's notes.
 - Say "I don't know" or "I don't understand" if you don't know what to say or if you don't know the answer to a question.
 - Ask crisp follow-up questions to get additional context, when the answer cannot be inferred from the provided notes or past conversations.
 - Sometimes the user will share personal information that needs to be remembered, like an account ID or a residential address. These can be acknowledged with a simple "Got it" or "Okay".
@@ -300,6 +299,22 @@ AI: I can help with that. I see online that there is a new model of the Dell XPS
 Q: What are the specs of the new Dell XPS 15?
 Khoj: default
 
+Example:
+Chat History:
+User: Where did I go on my last vacation?
+AI: You went to Jordan and visited Petra, the Dead Sea, and Wadi Rum.
+
+Q: Remind me who did I go with on that trip?
+Khoj: default
+
+Example:
+Chat History:
+User: How's the weather outside? Current Location: Bali, Indonesia
+AI: It's currently 28°C and partly cloudy in Bali.
+
+Q: Share a painting using the weather for Bali every morning.
+Khoj: reminder
+
 Now it's your turn to pick the mode you would like to use to answer the user's question. Provide your response as a string.
 
 Chat History:
@@ -487,6 +502,42 @@ History:
 {chat_history}
 
 Q: {query}
+Khoj:
+""".strip()
+)
+
+# Schedule task
+# --
+crontime_prompt = PromptTemplate.from_template(
+    """
+You are Khoj, an extremely smart and helpful task scheduling assistant
+- Given a user query, you infer the date, time to run the query at as a cronjob time string (converted to UTC time zone)
+- Convert the cron job time to run in UTC
+- Infer user's time zone from the current location provided in their message
+- Use an approximate time that makes sense, if it not unspecified.
+- Also extract the query to run at the scheduled time. Add any context required from the chat history to improve the query.
+
+# Examples:
+User: Could you share a funny Calvin and Hobbes quote from my notes?
+AI: Here is one I found: "It's not denial. I'm just selective about the reality I accept."
+User: Hahah, nice! Show a new one every morning at 9am. My Current Location: Shanghai, China
+Khoj: ["0 1 * * *", "Share a funny Calvin and Hobbes or Bill Watterson quote from my notes."]
+
+User: Share the top weekly posts on Hacker News on Monday evenings. Format it as a newsletter. My Current Location: Nairobi, Kenya
+Khoj: ["30 15 * * 1", "Top posts last week on Hacker News"]
+
+User: What is the latest version of the Khoj python package?
+AI: The latest released Khoj python package version is 1.5.0.
+User: Notify me when version 2.0.0 is released. My Current Location: Mexico City, Mexico
+Khoj: ["0 16 * * *", "Check if the latest released version of the Khoj python package is >= 2.0.0?"]
+
+User: Tell me the latest local tech news on the first Sunday of every Month. My Current Location: Dublin, Ireland
+Khoj: ["0 9 1-7 * 0", "Latest tech, AI and engineering news from around Dublin, Ireland"]
+
+# Chat History:
+{chat_history}
+
+User: {query}. My Current Location: {user_location}
 Khoj:
 """.strip()
 )

--- a/src/khoj/utils/helpers.py
+++ b/src/khoj/utils/helpers.py
@@ -304,6 +304,7 @@ class ConversationCommand(str, Enum):
     Online = "online"
     Webpage = "webpage"
     Image = "image"
+    Reminder = "reminder"
 
 
 command_descriptions = {
@@ -313,6 +314,7 @@ command_descriptions = {
     ConversationCommand.Online: "Search for information on the internet.",
     ConversationCommand.Webpage: "Get information from webpage links provided by you.",
     ConversationCommand.Image: "Generate images by describing your imagination in words.",
+    ConversationCommand.Reminder: "Schedule your query to run at a specified time or interval.",
     ConversationCommand.Help: "Display a help message with all available commands and other metadata.",
 }
 
@@ -325,7 +327,8 @@ tool_descriptions_for_llm = {
 }
 
 mode_descriptions_for_llm = {
-    ConversationCommand.Image: "Use this if you think the user is requesting an image or visual response to their query.",
+    ConversationCommand.Image: "Use this if the user is requesting an image or visual response to their query.",
+    ConversationCommand.Reminder: "Use this if the user is requesting a response at a scheduled date or time.",
     ConversationCommand.Default: "Use this if the other response modes don't seem to fit the query.",
 }
 

--- a/src/khoj/utils/state.py
+++ b/src/khoj/utils/state.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List
 
+from apscheduler.schedulers.background import BackgroundScheduler
 from openai import OpenAI
 from whisper import Whisper
 
@@ -29,6 +30,7 @@ cli_args: List[str] = None
 query_cache: Dict[str, LRU] = defaultdict(LRU)
 chat_lock = threading.Lock()
 SearchType = utils_config.SearchType
+scheduler: BackgroundScheduler = None
 telemetry: List[Dict[str, str]] = []
 khoj_version: str = None
 device = get_device()


### PR DESCRIPTION
### Minimal Process
1. Detect when user intends to schedule a task, aka reminder
   - Support new `reminder` output mode to the response type chat actor
   - Show examples of selecting the reminder output mode to the response type chat actor
2. Extract schedule time (as cron timestring) and inferred query to run from user message
3. Use APScheduler to call chat with inferred query at scheduled time