### PR TITLE
Add support for rendering math equations in the web view

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   test:
-    name: Run Tests
+    name: Setup Application and Lint
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -42,7 +42,7 @@ jobs:
           python -m pip install --upgrade pip
 
       - name: ⬇️ Install Application
-        run: pip install --upgrade .[dev]
+        run: pip install --no-cache-dir --upgrade .[dev]
 
       - name: 🌡️ Validate Application
         run: pre-commit run --hook-stage manual --all

--- a/src/interface/desktop/chat.html
+++ b/src/interface/desktop/chat.html
@@ -1421,7 +1421,7 @@
             display: inline-block;
             max-width: 80%;
             text-align: left;
-            white-space: pre-line;
+            /* white-space: pre-line; */
         }
         /* color chat bubble by khoj blue */
         .chat-message-text.khoj {

--- a/src/interface/desktop/chat.html
+++ b/src/interface/desktop/chat.html
@@ -1421,7 +1421,7 @@
             display: inline-block;
             max-width: 80%;
             text-align: left;
-            /* white-space: pre-line; */
+            white-space: pre-line;
         }
         /* color chat bubble by khoj blue */
         .chat-message-text.khoj {

--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -10,6 +10,14 @@
         <link rel="icon" type="image/png" sizes="128x128" href="/static/assets/icons/favicon-128x128.png?v={{ khoj_version }}">
         <link rel="apple-touch-icon" href="/static/assets/icons/favicon-128x128.png?v={{ khoj_version }}">
         <link rel="manifest" href="/static/khoj.webmanifest?v={{ khoj_version }}">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css" integrity="sha384-wcIxkf4k558AjM3Yz3BBFQUbk/zgIYC2R0QpeeYb+TwlBVMrlgLqwRjRtGZiK7ww" crossorigin="anonymous">
+
+        <!-- The loading of KaTeX is deferred to speed up page rendering -->
+        <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js" integrity="sha384-hIoBPJpTUs74ddyc4bFZSM1TVlQDA60VBbJS0oA934VSz82sBx1X7kSx2ATBDIyd" crossorigin="anonymous"></script>
+
+        <!-- To automatically render math in text elements, include the auto-render extension: -->
+        <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js" integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous"
+            onload="renderMathInElement(document.body);"></script>
     </head>
     <script type="text/javascript" src="/static/assets/utils.js?v={{ khoj_version }}"></script>
     <script type="text/javascript" src="/static/assets/markdown-it.min.js?v={{ khoj_version }}"></script>
@@ -345,6 +353,10 @@ To get started, just start typing below. You can also type / to see a list of co
             var md = window.markdownit();
             let newHTML = message;
 
+            // Replace LaTeX delimiters with placeholders
+            newHTML = newHTML.replace(/\\\(/g, 'LEFTPAREN').replace(/\\\)/g, 'RIGHTPAREN')
+                                .replace(/\\\[/g, 'LEFTBRACKET').replace(/\\\]/g, 'RIGHTBRACKET');
+
             // Remove any text between <s>[INST] and </s> tags. These are spurious instructions for the AI chat model.
             newHTML = newHTML.replace(/<s>\[INST\].+(<\/s>)?/g, '');
 
@@ -361,6 +373,11 @@ To get started, just start typing below. You can also type / to see a list of co
 
             // Render markdown
             newHTML = raw ? newHTML : md.render(newHTML);
+
+            // Replace placeholders with LaTeX delimiters
+            newHTML = newHTML.replace(/LEFTPAREN/g, '\\(').replace(/RIGHTPAREN/g, '\\)')
+                            .replace(/LEFTBRACKET/g, '\\[').replace(/RIGHTBRACKET/g, '\\]');
+
             // Set rendered markdown to HTML DOM element
             let element = document.createElement('div');
             element.innerHTML = newHTML;
@@ -378,6 +395,19 @@ To get started, just start typing below. You can also type / to see a list of co
                 copyButton.addEventListener('click', createCopyParentText(message));
                 element.append(copyButton);
             }
+
+            renderMathInElement(element, {
+                // customised options
+                // • auto-render specific keys, e.g.:
+                delimiters: [
+                    {left: '$$', right: '$$', display: true},
+                    {left: '$', right: '$', display: false},
+                    {left: '\\(', right: '\\)', display: false},
+                    {left: '\\[', right: '\\]', display: true}
+                ],
+                // • rendering keys, e.g.:
+                throwOnError : false
+            });
 
             // Get any elements with a class that starts with "language"
             let codeBlockElements = element.querySelectorAll('[class^="language-"]');

--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -1988,7 +1988,7 @@ To get started, just start typing below. You can also type / to see a list of co
         }
 
         div#conversation-list {
-            height: 1;
+            height: 1px;
         }
 
         div#side-panel-wrapper {
@@ -2437,14 +2437,14 @@ To get started, just start typing below. You can also type / to see a list of co
         }
 
         .three-dot-menu {
-            display: none;
+            display: block;
             /* background: var(--background-color); */
             /* border: 1px solid var(--main-text-color); */
             border-radius: 5px;
             /* position: relative; */
             position: absolute;
-            right: 4;
-            top: 4;
+            right: 4px;
+            top: 4px;
         }
 
         button.three-dot-menu-button-item {

--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -341,20 +341,6 @@ To get started, just start typing below. You can also type / to see a list of co
             return renderMessage(message, by, dt, references, false, "return");
         }
 
-        // Helper function to get all text nodes in an element
-        function getTextNodesIn(node) {
-            let textNodes = [];
-            if (node.nodeType == 3) {
-                textNodes.push(node);
-            } else {
-                let children = node.childNodes;
-                for (let i = 0; i < children.length; i++) {
-                    textNodes.push(...getTextNodesIn(children[i]));
-                }
-            }
-            return textNodes;
-        }
-
         function formatHTMLMessage(message, raw=false, willReplace=true) {
             var md = window.markdownit();
             let newHTML = message;
@@ -392,22 +378,6 @@ To get started, just start typing below. You can also type / to see a list of co
                 copyButton.addEventListener('click', createCopyParentText(message));
                 element.append(copyButton);
             }
-
-            // Find potential LaTeX strings and render them
-            // let textNodes = getTextNodesIn(element);
-            // for (let node of textNodes) {
-            //     let latexMatch = node.textContent.match(/(\[\s*.*\s*\])/g);
-
-            //     if (latexMatch) {
-            //         for (let latex of latexMatch) {
-            //             let span = document.createElement('span');
-            //             span.classList.add("katex-rendered")
-            //             katex.render(latex.replace(/(\]\n*$|^\n*\[)|(\)$|^\()/g, ''), span);
-            //             node.parentNode.insertBefore(span, node.nextSibling);
-            //         }
-            //         node.parentNode.removeChild(node);
-            //     }
-            // }
 
             // Get any elements with a class that starts with "language"
             let codeBlockElements = element.querySelectorAll('[class^="language-"]');

--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -10,15 +10,6 @@
         <link rel="icon" type="image/png" sizes="128x128" href="/static/assets/icons/favicon-128x128.png?v={{ khoj_version }}">
         <link rel="apple-touch-icon" href="/static/assets/icons/favicon-128x128.png?v={{ khoj_version }}">
         <link rel="manifest" href="/static/khoj.webmanifest?v={{ khoj_version }}">
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css" integrity="sha384-wcIxkf4k558AjM3Yz3BBFQUbk/zgIYC2R0QpeeYb+TwlBVMrlgLqwRjRtGZiK7ww" crossorigin="anonymous">
-
-
-        <!-- The loading of KaTeX is deferred to speed up page rendering -->
-        <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js" integrity="sha384-hIoBPJpTUs74ddyc4bFZSM1TVlQDA60VBbJS0oA934VSz82sBx1X7kSx2ATBDIyd" crossorigin="anonymous"></script>
-
-        <!-- To automatically render math in text elements, include the auto-render extension: -->
-        <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js" integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous"
-            onload="renderMathInElement(document.body);"></script>
     </head>
     <script type="text/javascript" src="/static/assets/utils.js?v={{ khoj_version }}"></script>
     <script type="text/javascript" src="/static/assets/markdown-it.min.js?v={{ khoj_version }}"></script>
@@ -403,20 +394,20 @@ To get started, just start typing below. You can also type / to see a list of co
             }
 
             // Find potential LaTeX strings and render them
-            let textNodes = getTextNodesIn(element);
-            for (let node of textNodes) {
-                let latexMatch = node.textContent.match(/(\[\s*.*\s*\])/g);
+            // let textNodes = getTextNodesIn(element);
+            // for (let node of textNodes) {
+            //     let latexMatch = node.textContent.match(/(\[\s*.*\s*\])/g);
 
-                if (latexMatch) {
-                    for (let latex of latexMatch) {
-                        let span = document.createElement('span');
-                        span.classList.add("katex-rendered")
-                        katex.render(latex.replace(/(\]\n*$|^\n*\[)|(\)$|^\()/g, ''), span);
-                        node.parentNode.insertBefore(span, node.nextSibling);
-                    }
-                    node.parentNode.removeChild(node);
-                }
-            }
+            //     if (latexMatch) {
+            //         for (let latex of latexMatch) {
+            //             let span = document.createElement('span');
+            //             span.classList.add("katex-rendered")
+            //             katex.render(latex.replace(/(\]\n*$|^\n*\[)|(\)$|^\()/g, ''), span);
+            //             node.parentNode.insertBefore(span, node.nextSibling);
+            //         }
+            //         node.parentNode.removeChild(node);
+            //     }
+            // }
 
             // Get any elements with a class that starts with "language"
             let codeBlockElements = element.querySelectorAll('[class^="language-"]');
@@ -1239,19 +1230,6 @@ To get started, just start typing below. You can also type / to see a list of co
                         chatBody.classList.remove("relative-position");
                         setupDropZone();
                     }, 500);
-
-                    renderMathInElement(document.body, {
-                        // customised options
-                        // • auto-render specific keys, e.g.:
-                        delimiters: [
-                            {left: '$$', right: '$$', display: true},
-                            {left: '$', right: '$', display: false},
-                            {left: '\\(', right: '\\)', display: false},
-                            {left: '\\[', right: '\\]', display: true}
-                        ],
-                        // • rendering keys, e.g.:
-                        throwOnError : false
-                    });
 
                 })
                 .catch(err => {
@@ -2126,6 +2104,7 @@ To get started, just start typing below. You can also type / to see a list of co
             display: inline-block;
             max-width: 80%;
             text-align: left;
+            white-space: pre-line;
         }
         /* color chat bubble by khoj blue */
         .chat-message-text.khoj {
@@ -2496,10 +2475,6 @@ To get started, just start typing below. You can also type / to see a list of co
             position: absolute;
             right: 4;
             top: 4;
-        }
-
-        span.katex-rendered {
-            display: flex;
         }
 
         button.three-dot-menu-button-item {

--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <head>
         <meta charset="utf-8">
@@ -9,6 +10,15 @@
         <link rel="icon" type="image/png" sizes="128x128" href="/static/assets/icons/favicon-128x128.png?v={{ khoj_version }}">
         <link rel="apple-touch-icon" href="/static/assets/icons/favicon-128x128.png?v={{ khoj_version }}">
         <link rel="manifest" href="/static/khoj.webmanifest?v={{ khoj_version }}">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css" integrity="sha384-wcIxkf4k558AjM3Yz3BBFQUbk/zgIYC2R0QpeeYb+TwlBVMrlgLqwRjRtGZiK7ww" crossorigin="anonymous">
+
+
+        <!-- The loading of KaTeX is deferred to speed up page rendering -->
+        <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js" integrity="sha384-hIoBPJpTUs74ddyc4bFZSM1TVlQDA60VBbJS0oA934VSz82sBx1X7kSx2ATBDIyd" crossorigin="anonymous"></script>
+
+        <!-- To automatically render math in text elements, include the auto-render extension: -->
+        <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js" integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous"
+            onload="renderMathInElement(document.body);"></script>
     </head>
     <script type="text/javascript" src="/static/assets/utils.js?v={{ khoj_version }}"></script>
     <script type="text/javascript" src="/static/assets/markdown-it.min.js?v={{ khoj_version }}"></script>
@@ -340,6 +350,20 @@ To get started, just start typing below. You can also type / to see a list of co
             return renderMessage(message, by, dt, references, false, "return");
         }
 
+        // Helper function to get all text nodes in an element
+        function getTextNodesIn(node) {
+            let textNodes = [];
+            if (node.nodeType == 3) {
+                textNodes.push(node);
+            } else {
+                let children = node.childNodes;
+                for (let i = 0; i < children.length; i++) {
+                    textNodes.push(...getTextNodesIn(children[i]));
+                }
+            }
+            return textNodes;
+        }
+
         function formatHTMLMessage(message, raw=false, willReplace=true) {
             var md = window.markdownit();
             let newHTML = message;
@@ -376,6 +400,22 @@ To get started, just start typing below. You can also type / to see a list of co
                 copyButton.appendChild(copyIcon);
                 copyButton.addEventListener('click', createCopyParentText(message));
                 element.append(copyButton);
+            }
+
+            // Find potential LaTeX strings and render them
+            let textNodes = getTextNodesIn(element);
+            for (let node of textNodes) {
+                let latexMatch = node.textContent.match(/(\[\s*.*\s*\])/g);
+
+                if (latexMatch) {
+                    for (let latex of latexMatch) {
+                        let span = document.createElement('span');
+                        span.classList.add("katex-rendered")
+                        katex.render(latex.replace(/(\]\n*$|^\n*\[)|(\)$|^\()/g, ''), span);
+                        node.parentNode.insertBefore(span, node.nextSibling);
+                    }
+                    node.parentNode.removeChild(node);
+                }
             }
 
             // Get any elements with a class that starts with "language"
@@ -1199,6 +1239,19 @@ To get started, just start typing below. You can also type / to see a list of co
                         chatBody.classList.remove("relative-position");
                         setupDropZone();
                     }, 500);
+
+                    renderMathInElement(document.body, {
+                        // customised options
+                        // • auto-render specific keys, e.g.:
+                        delimiters: [
+                            {left: '$$', right: '$$', display: true},
+                            {left: '$', right: '$', display: false},
+                            {left: '\\(', right: '\\)', display: false},
+                            {left: '\\[', right: '\\]', display: true}
+                        ],
+                        // • rendering keys, e.g.:
+                        throwOnError : false
+                    });
 
                 })
                 .catch(err => {
@@ -2073,7 +2126,6 @@ To get started, just start typing below. You can also type / to see a list of co
             display: inline-block;
             max-width: 80%;
             text-align: left;
-            white-space: pre-line;
         }
         /* color chat bubble by khoj blue */
         .chat-message-text.khoj {
@@ -2444,6 +2496,10 @@ To get started, just start typing below. You can also type / to see a list of co
             position: absolute;
             right: 4;
             top: 4;
+        }
+
+        span.katex-rendered {
+            display: flex;
         }
 
         button.three-dot-menu-button-item {

--- a/src/khoj/processor/conversation/prompts.py
+++ b/src/khoj/processor/conversation/prompts.py
@@ -12,6 +12,9 @@ You were created by Khoj Inc. with the following capabilities:
 - Users can share files and other information with you using the Khoj Desktop, Obsidian or Emacs app. They can also drag and drop their files into the chat window.
 - You *CAN* generate images, look-up real-time information from the internet, set reminders and answer questions based on the user's notes.
 - Say "I don't know" or "I don't understand" if you don't know what to say or if you don't know the answer to a question.
+- Make sure to use the specific LaTeX math mode delimiters for your response. LaTex math mode specific delimiters as following
+    - inline math mode : `\(` and `\)`
+    - display math mode: insert linebreak after opening `$$`, `\[` and before closing `$$`, `\]`
 - Ask crisp follow-up questions to get additional context, when the answer cannot be inferred from the provided notes or past conversations.
 - Sometimes the user will share personal information that needs to be remembered, like an account ID or a residential address. These can be acknowledged with a simple "Got it" or "Okay".
 - Provide inline references to quotes from the user's notes or any web pages you refer to in your responses in markdown format. For example, "The farmer had ten sheep. [1](https://example.com)". *ALWAYS CITE YOUR SOURCES AND PROVIDE REFERENCES*. Add them inline to directly support your claim.

--- a/src/khoj/processor/conversation/prompts.py
+++ b/src/khoj/processor/conversation/prompts.py
@@ -13,8 +13,8 @@ You were created by Khoj Inc. with the following capabilities:
 - You *CAN* generate images, look-up real-time information from the internet, set reminders and answer questions based on the user's notes.
 - Say "I don't know" or "I don't understand" if you don't know what to say or if you don't know the answer to a question.
 - Make sure to use the specific LaTeX math mode delimiters for your response. LaTex math mode specific delimiters as following
-    - inline math mode : `\(` and `\)`
-    - display math mode: insert linebreak after opening `$$`, `\[` and before closing `$$`, `\]`
+    - inline math mode : `\\(` and `\\)`
+    - display math mode: insert linebreak after opening `$$`, `\\[` and before closing `$$`, `\\]`
 - Ask crisp follow-up questions to get additional context, when the answer cannot be inferred from the provided notes or past conversations.
 - Sometimes the user will share personal information that needs to be remembered, like an account ID or a residential address. These can be acknowledged with a simple "Got it" or "Okay".
 - Provide inline references to quotes from the user's notes or any web pages you refer to in your responses in markdown format. For example, "The farmer had ten sheep. [1](https://example.com)". *ALWAYS CITE YOUR SOURCES AND PROVIDE REFERENCES*. Add them inline to directly support your claim.
@@ -33,6 +33,9 @@ You were created by Khoj Inc. with the following capabilities:
 - You *CAN REMEMBER ALL NOTES and PERSONAL INFORMATION FOREVER* that the user ever shares with you.
 - Users can share files and other information with you using the Khoj Desktop, Obsidian or Emacs app. They can also drag and drop their files into the chat window.
 - Say "I don't know" or "I don't understand" if you don't know what to say or if you don't know the answer to a question.
+- Make sure to use the specific LaTeX math mode delimiters for your response. LaTex math mode specific delimiters as following
+    - inline math mode : `\\(` and `\\)`
+    - display math mode: insert linebreak after opening `$$`, `\\[` and before closing `$$`, `\\]`
 - Ask crisp follow-up questions to get additional context, when the answer cannot be inferred from the provided notes or past conversations.
 - Sometimes the user will share personal information that needs to be remembered, like an account ID or a residential address. These can be acknowledged with a simple "Got it" or "Okay".
 


### PR DESCRIPTION
- Add parsing logic for LaTeX-format math equations in the web chat
- Add placeholder delimiters when converting the markdown to HTML in order to avoid removing the escaped characters
- Add the `<!DOCTYPE html>` specification to the page