### PR TITLE
Improve Intermediate Steps in Formulating Chat Response

### DIFF
--- a/src/khoj/processor/content/org_mode/org_to_entries.py
+++ b/src/khoj/processor/content/org_mode/org_to_entries.py
@@ -182,7 +182,7 @@ class OrgToEntries(TextToEntries):
                 # Children nodes do not need ancestors trail as root parent node will have it
                 if not entry_heading:
                     ancestors_trail = " / ".join(parsed_entry.ancestors) or Path(entry_to_file_map[parsed_entry])
-                    heading = f"* Path: {ancestors_trail}\n{heading}" if heading else f"* Path: {ancestors_trail}."
+                    heading = f"* {ancestors_trail}\n{heading}" if heading else f"* {ancestors_trail}."
 
                 compiled = heading
 

--- a/src/khoj/routers/api_chat.py
+++ b/src/khoj/routers/api_chat.py
@@ -590,9 +590,7 @@ async def websocket_endpoint(
         )
 
         if compiled_references:
-            headings = "\n- " + "\n- ".join(
-                set([" ".join(c.get("compiled", c).split("Path: ")[1:]).split("\n ")[0] for c in compiled_references])
-            )
+            headings = "\n- " + "\n- ".join(set([c.get("compiled", c).split("\n")[0] for c in compiled_references]))
             await send_status_update(f"**📜 Found Relevant Notes**: {headings}")
 
         online_results: Dict = dict()

--- a/src/khoj/routers/helpers.py
+++ b/src/khoj/routers/helpers.py
@@ -287,16 +287,16 @@ async def aget_relevant_output_modes(query: str, conversation_history: dict, is_
         response = response.strip()
 
         if is_none_or_empty(response):
-            return ConversationCommand.Default
+            return ConversationCommand.Text
 
         if response in mode_options.keys():
             # Check whether the tool exists as a valid ConversationCommand
             return ConversationCommand(response)
 
-        return ConversationCommand.Default
-    except Exception as e:
+        return ConversationCommand.Text
+    except Exception:
         logger.error(f"Invalid response for determining relevant mode: {response}")
-        return ConversationCommand.Default
+        return ConversationCommand.Text
 
 
 async def infer_webpage_urls(q: str, conversation_history: dict, location_data: LocationData) -> List[str]:

--- a/src/khoj/utils/helpers.py
+++ b/src/khoj/utils/helpers.py
@@ -304,6 +304,7 @@ class ConversationCommand(str, Enum):
     Online = "online"
     Webpage = "webpage"
     Image = "image"
+    Text = "text"
     Automation = "automation"
     AutomatedTask = "automated_task"
 
@@ -330,7 +331,7 @@ tool_descriptions_for_llm = {
 mode_descriptions_for_llm = {
     ConversationCommand.Image: "Use this if the user is requesting an image or visual response to their query.",
     ConversationCommand.Automation: "Use this if the user is requesting a response at a scheduled date or time.",
-    ConversationCommand.Default: "Use this if the other response modes don't seem to fit the query.",
+    ConversationCommand.Text: "Use this if the other response modes don't seem to fit the query.",
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -301,7 +301,7 @@ def chat_client_builder(search_config, user, index_content=True, require_auth=Fa
     # Initialize Processor from Config
     if os.getenv("OPENAI_API_KEY"):
         chat_model = ChatModelOptionsFactory(chat_model="gpt-3.5-turbo", model_type="openai")
-        OpenAIProcessorConversationConfigFactory()
+        chat_model.openai_config = OpenAIProcessorConversationConfigFactory()
         UserConversationProcessorConfigFactory(user=user, setting=chat_model)
 
     state.anonymous_mode = not require_auth

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -36,6 +36,13 @@ class ApiUserFactory(factory.django.DjangoModelFactory):
     token = factory.Faker("password")
 
 
+class OpenAIProcessorConversationConfigFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = OpenAIProcessorConversationConfig
+
+    api_key = os.getenv("OPENAI_API_KEY")
+
+
 class ChatModelOptionsFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = ChatModelOptions
@@ -44,6 +51,7 @@ class ChatModelOptionsFactory(factory.django.DjangoModelFactory):
     tokenizer = None
     chat_model = "NousResearch/Hermes-2-Pro-Mistral-7B-GGUF"
     model_type = "offline"
+    openai_config = factory.SubFactory(OpenAIProcessorConversationConfigFactory)
 
 
 class UserConversationProcessorConfigFactory(factory.django.DjangoModelFactory):
@@ -52,13 +60,6 @@ class UserConversationProcessorConfigFactory(factory.django.DjangoModelFactory):
 
     user = factory.SubFactory(UserFactory)
     setting = factory.SubFactory(ChatModelOptionsFactory)
-
-
-class OpenAIProcessorConversationConfigFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = OpenAIProcessorConversationConfig
-
-    api_key = os.getenv("OPENAI_API_KEY")
 
 
 class ConversationFactory(factory.django.DjangoModelFactory):

--- a/tests/test_openai_chat_director.py
+++ b/tests/test_openai_chat_director.py
@@ -516,7 +516,7 @@ async def test_get_correct_tools_online(chat_client):
     user_query = "What's the weather in Patagonia this week?"
 
     # Act
-    tools = await aget_relevant_information_sources(user_query, {})
+    tools = await aget_relevant_information_sources(user_query, {}, False)
 
     # Assert
     tools = [tool.value for tool in tools]
@@ -531,7 +531,7 @@ async def test_get_correct_tools_notes(chat_client):
     user_query = "Where did I go for my first battleship training?"
 
     # Act
-    tools = await aget_relevant_information_sources(user_query, {})
+    tools = await aget_relevant_information_sources(user_query, {}, False)
 
     # Assert
     tools = [tool.value for tool in tools]
@@ -546,7 +546,7 @@ async def test_get_correct_tools_online_or_general_and_notes(chat_client):
     user_query = "What's the highest point in Patagonia and have I been there?"
 
     # Act
-    tools = await aget_relevant_information_sources(user_query, {})
+    tools = await aget_relevant_information_sources(user_query, {}, False)
 
     # Assert
     tools = [tool.value for tool in tools]
@@ -563,7 +563,7 @@ async def test_get_correct_tools_general(chat_client):
     user_query = "How many noble gases are there?"
 
     # Act
-    tools = await aget_relevant_information_sources(user_query, {})
+    tools = await aget_relevant_information_sources(user_query, {}, False)
 
     # Assert
     tools = [tool.value for tool in tools]
@@ -587,7 +587,7 @@ async def test_get_correct_tools_with_chat_history(chat_client):
     chat_history = generate_history(chat_log)
 
     # Act
-    tools = await aget_relevant_information_sources(user_query, chat_history)
+    tools = await aget_relevant_information_sources(user_query, chat_history, False)
 
     # Assert
     tools = [tool.value for tool in tools]

--- a/tests/test_org_to_entries.py
+++ b/tests/test_org_to_entries.py
@@ -50,14 +50,14 @@ def test_entry_split_when_exceeds_max_tokens():
     data = {
         f"{tmp_path}": entry,
     }
-    expected_heading = f"* Path: {tmp_path}\n** Heading"
+    expected_heading = f"* {tmp_path}\n** Heading"
 
     # Act
     # Extract Entries from specified Org files
     entries = OrgToEntries.extract_org_entries(org_files=data)
 
     # Split each entry from specified Org files by max tokens
-    entries = TextToEntries.split_entries_by_max_tokens(entries, max_tokens=6)
+    entries = TextToEntries.split_entries_by_max_tokens(entries, max_tokens=5)
 
     # Assert
     assert len(entries) == 2
@@ -139,7 +139,7 @@ longer body line 2.1
         f"{tmp_path}": entry,
     }
     first_expected_entry = f"""
-* Path: {tmp_path}
+* {tmp_path}
 ** Heading 1.
  body line 1
 
@@ -148,13 +148,13 @@ longer body line 2.1
 
 """.lstrip()
     second_expected_entry = f"""
-* Path: {tmp_path}
+* {tmp_path}
 ** Heading 2.
  body line 2
 
 """.lstrip()
     third_expected_entry = f"""
-* Path: {tmp_path} / Heading 2
+* {tmp_path} / Heading 2
 ** Subheading 2.1.
  longer body line 2.1
 
@@ -192,7 +192,7 @@ body line 3.1
         f"{tmp_path}": entry,
     }
     first_expected_entry = f"""
-* Path: {tmp_path}
+* {tmp_path}
 ** Heading 1.
  body line 1
 
@@ -201,7 +201,7 @@ body line 3.1
 
 """.lstrip()
     second_expected_entry = f"""
-* Path: {tmp_path}
+* {tmp_path}
 ** Heading 2.
  body line 2
 
@@ -210,7 +210,7 @@ body line 3.1
 
 """.lstrip()
     third_expected_entry = f"""
-* Path: {tmp_path}
+* {tmp_path}
 ** Heading 3.
  body line 3
 


### PR DESCRIPTION
## Major
- f91cdf8e Fix showing headings in intermediate step in generating chat response
- 18f7e6e7 Remove "Path" prefix from org ancestor heading in compiled entry
- dd2225b1 Use Text output mode to disambiguate from Default data source lookup
  Previously if default output was selected by Khoj, we'd end up doing
  a documents search as well, even when Khoj selected internet or
  general data source to lookup.
  
  This update disambiguates the default information mode from the text
  output mode. To avoid doing documents search when not deemed necessary
  by Khoj

## Minor
- Fix openai chat actor, director unit tests