### PR TITLE
Add system dependencies required by RapidOCR to fix Khoj Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt update && apt -y install yarn
 
+# Install RapidOCR dependencies
+RUN apt -y install libgl1 libgl1-mesa-glx libglib2.0-0
+
 # Install Application
 WORKDIR /app
 COPY pyproject.toml .


### PR DESCRIPTION
### Issue
The Khoj docker build would fail with `ImportError: libGL.so.1: cannot open shared object file: No such file or directory`. This was required by the Khoj RapidOCR python package dependency. 

<details><summary>Stacktrace</summary>

```
khoj-server-1    | Traceback (most recent call last):
khoj-server-1    |   File "/app/src/khoj/main.py", line 93, in <module>
khoj-server-1    |     from khoj.configure import configure_routes, initialize_server, configure_middleware
khoj-server-1    |   File "/app/src/khoj/configure.py", line 40, in <module>
khoj-server-1    |     from khoj.routers.indexer import configure_content, configure_search
khoj-server-1    |   File "/app/src/khoj/routers/indexer.py", line 12, in <module>
khoj-server-1    |     from khoj.processor.content.images.image_to_entries import ImageToEntries
khoj-server-1    |   File "/app/src/khoj/processor/content/images/image_to_entries.py", line 7, in <module>
khoj-server-1    |     from rapidocr_onnxruntime import RapidOCR
khoj-server-1    |   File "/usr/local/lib/python3.10/dist-packages/rapidocr_onnxruntime/__init__.py", line 4, in <module>
khoj-server-1    |     from .main import RapidOCR
khoj-server-1    |   File "/usr/local/lib/python3.10/dist-packages/rapidocr_onnxruntime/main.py", line 8, in <module>
khoj-server-1    |     import cv2
khoj-server-1    |   File "/usr/local/lib/python3.10/dist-packages/cv2/__init__.py", line 181, in <module>
khoj-server-1    |     bootstrap()
khoj-server-1    |   File "/usr/local/lib/python3.10/dist-packages/cv2/__init__.py", line 153, in bootstrap
khoj-server-1    |     native_module = importlib.import_module("cv2")
khoj-server-1    |   File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
khoj-server-1    |     return _bootstrap._gcd_import(name[level:], package, level)
khoj-server-1    | ImportError: libGL.so.1: cannot open shared object file: No such file or directory
khoj-server-1 exited with code 1
```

</details> 

### Fix
A minimal set of system packages have been added to resolve this issue.
