### PR TITLE
Fix indexing content from Emacs

### DIFF
--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -424,7 +424,7 @@ Auto invokes setup steps on calling main entrypoint."
   "Send multi-part form `BODY' of `CONTENT-TYPE' in request to khoj server.
 Append 'TYPE-QUERY' as query parameter in request url.
 Specify `BOUNDARY' used to separate files in request header."
-  (let ((url-request-method ((if force) "PUT" "PATCH"))
+  (let ((url-request-method (if force "PUT" "PATCH"))
         (url-request-data body)
           (url-request-extra-headers `(("content-type" . ,(format "multipart/form-data; boundary=%s" boundary))
                                        ("Authorization" . ,(format "Bearer %s" khoj-api-key)))))

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -1265,7 +1265,7 @@ Paragraph only starts at first text after blank line."
   (transient-define-suffix khoj--update-command (&optional args)
     "Call khoj API to update index of specified content type."
     (interactive (list (transient-args transient-current-command)))
-    (let* ((force-update (if (member "--force-update" args) "true" "false"))
+    (let* ((force-update (if (member "--force-update" args) t nil))
            ;; set content type to: specified > last used > based on current buffer > default type
            (content-type (or (transient-arg-value "--content-type=" args) (khoj--buffer-name-to-content-type (buffer-name))))
            (url-request-method "GET"))


### PR DESCRIPTION
Previously `force` was passed as a query param to the single indexing API. After the recent API updates, it is meant to select the API method to use (PATCH vs PATCH). Converting `force` argument to a bool fixes implementing this new behavior