### PR TITLE
Improve search model config display for admin

### DIFF
--- a/src/khoj/database/admin.py
+++ b/src/khoj/database/admin.py
@@ -94,7 +94,6 @@ admin.site.register(KhojUser, KhojUserAdmin)
 
 admin.site.register(ProcessLock)
 admin.site.register(SpeechToTextModelOptions)
-admin.site.register(SearchModelConfig)
 admin.site.register(ReflectiveQuestion)
 admin.site.register(UserSearchModelConfig)
 admin.site.register(ClientApplication)
@@ -176,6 +175,17 @@ class OpenAIProcessorConversationConfigAdmin(admin.ModelAdmin):
         "api_base_url",
     )
     search_fields = ("id", "name", "api_key", "api_base_url")
+
+
+@admin.register(SearchModelConfig)
+class SearchModelConfigAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "name",
+        "bi_encoder",
+        "cross_encoder",
+    )
+    search_fields = ("id", "name", "bi_encoder", "cross_encoder")
 
 
 @admin.register(ServerChatSettings)


### PR DESCRIPTION
Currently, the search model config display for admins only shows the `id` of the search model config, which is not very informative. This commit enhances the admin console by displaying the name of the search model config (`name`), as well as the bi-encoder model (`bi_encoder`) and cross-encoder model (`cross_encoder`) along the `id`.