### PR TITLE
Add user conversation config to admin console

### DIFF
--- a/src/khoj/database/admin.py
+++ b/src/khoj/database/admin.py
@@ -26,6 +26,7 @@ from khoj.database.models import (
     SpeechToTextModelOptions,
     Subscription,
     TextToImageModelConfig,
+    UserConversationConfig,
     UserSearchModelConfig,
     UserVoiceModelConfig,
     VoiceModelOption,
@@ -96,6 +97,7 @@ admin.site.register(ProcessLock)
 admin.site.register(SpeechToTextModelOptions)
 admin.site.register(SearchModelConfig)
 admin.site.register(ReflectiveQuestion)
+admin.site.register(UserConversationConfig)
 admin.site.register(UserSearchModelConfig)
 admin.site.register(ClientApplication)
 admin.site.register(GithubConfig)


### PR DESCRIPTION
The user can't select the chat model under settings because user conversation model is not set. This commit add an option for the user to configure the conversation model.

![Screenshot from 2024-08-11 22-26-55](https://github.com/user-attachments/assets/24cef902-134e-42f8-afce-ec019d39ef70)
