### PR TITLE
Set File Types to Sync from Obsidian via Khoj Plugin Settings Page

### DIFF
--- a/src/interface/obsidian/src/settings.ts
+++ b/src/interface/obsidian/src/settings.ts
@@ -189,9 +189,8 @@ export class KhojSettingTab extends PluginSettingTab {
                     this.plugin.registerInterval(progress_indicator);
 
                     this.plugin.settings.lastSync = await updateContentIndex(
-                        this.app.vault, this.plugin.settings, this.plugin.settings.lastSync, true
+                        this.app.vault, this.plugin.settings, this.plugin.settings.lastSync, true, true
                     );
-                    new Notice('✅ Updated Khoj index.');
 
                     // Reset button once index is updated
                     window.clearInterval(progress_indicator);

--- a/src/interface/obsidian/src/settings.ts
+++ b/src/interface/obsidian/src/settings.ts
@@ -10,6 +10,11 @@ export interface UserInfo {
     email?: string;
 }
 
+interface SyncFileTypes {
+    markdown: boolean;
+    images: boolean;
+    pdf: boolean;
+}
 export interface KhojSetting {
     resultsCount: number;
     khojUrl: string;
@@ -17,6 +22,7 @@ export interface KhojSetting {
     connectedToBackend: boolean;
     autoConfigure: boolean;
     lastSync: Map<TFile, number>;
+    syncFileType: SyncFileTypes;
     userInfo: UserInfo | null;
 }
 
@@ -27,6 +33,11 @@ export const DEFAULT_SETTINGS: KhojSetting = {
     connectedToBackend: false,
     autoConfigure: true,
     lastSync: new Map(),
+    syncFileType: {
+        markdown: true,
+        images: true,
+        pdf: true,
+    },
     userInfo: null,
 }
 
@@ -96,6 +107,43 @@ export class KhojSettingTab extends PluginSettingTab {
                     this.plugin.settings.resultsCount = value;
                     await this.plugin.saveSettings();
                 }));
+
+        // Add new "Sync" heading
+        containerEl.createEl('h3', {text: 'Sync'});
+
+        // Add setting to sync markdown notes
+        new Setting(containerEl)
+            .setName('Sync Notes')
+            .setDesc('Index Markdown files in your vault with Khoj.')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.syncFileType.markdown)
+                .onChange(async (value) => {
+                    this.plugin.settings.syncFileType.markdown = value;
+                    await this.plugin.saveSettings();
+                }));
+
+        // Add setting to sync images
+        new Setting(containerEl)
+            .setName('Sync Images')
+            .setDesc('Index images in your vault with Khoj.')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.syncFileType.images)
+                .onChange(async (value) => {
+                    this.plugin.settings.syncFileType.images = value;
+                    await this.plugin.saveSettings();
+                }));
+
+        // Add setting to sync PDFs
+        new Setting(containerEl)
+            .setName('Sync PDFs')
+            .setDesc('Index PDF files in your vault with Khoj.')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.syncFileType.pdf)
+                .onChange(async (value) => {
+                    this.plugin.settings.syncFileType.pdf = value;
+                    await this.plugin.saveSettings();
+                }));
+
         new Setting(containerEl)
             .setName('Auto Sync')
             .setDesc('Automatically index your vault with Khoj.')

--- a/src/interface/obsidian/src/utils.ts
+++ b/src/interface/obsidian/src/utils.ts
@@ -57,7 +57,7 @@ export const supportedImageFilesTypes = fileTypeToExtension.image;
 export const supportedBinaryFileTypes = fileTypeToExtension.pdf.concat(supportedImageFilesTypes);
 export const supportedFileTypes = fileTypeToExtension.markdown.concat(supportedBinaryFileTypes);
 
-export async function updateContentIndex(vault: Vault, setting: KhojSetting, lastSync: Map<TFile, number>, regenerate: boolean = false): Promise<Map<TFile, number>> {
+export async function updateContentIndex(vault: Vault, setting: KhojSetting, lastSync: Map<TFile, number>, regenerate: boolean = false, userTriggered: boolean = false): Promise<Map<TFile, number>> {
     // Get all markdown, pdf files in the vault
     console.log(`Khoj: Updating Khoj content index...`)
     const files = vault.getFiles()
@@ -179,6 +179,7 @@ export async function updateContentIndex(vault: Vault, setting: KhojSetting, las
     if (error_message) {
         new Notice(error_message);
     } else {
+        if (userTriggered) new Notice('✅ Updated Khoj index.');
         console.log(`✅ Refreshed Khoj content index. Updated: ${countOfFilesToIndex} files, Deleted: ${countOfFilesToDelete} files.`);
     }
 


### PR DESCRIPTION
Limit file types to sync with Khoj from Obsidian to:
- Avoid hitting per user index-able data limits, especially for folks on the Khoj cloud free tier. E.g by excluding images in Obsidian vault from being synced
- Improve context used by Khoj to generate responses

<img width="600" alt="Khoj_Obsidian_Sync_Files_Types_Settings" src="https://github.com/user-attachments/assets/9a51c609-884a-400b-957e-c97fc3656db2">



Closes #893