### PR TITLE
Only Live Scrolling when at Page Bottom and Add Button to Scroll to Page Bottom on Web App

### DIFF
--- a/src/interface/web/app/components/chatHistory/chatHistory.tsx
+++ b/src/interface/web/app/components/chatHistory/chatHistory.tsx
@@ -76,6 +76,7 @@ export default function ChatHistory(props: ChatHistoryProps) {
     >(null);
     const [fetchingData, setFetchingData] = useState(false);
     const [isNearBottom, setIsNearBottom] = useState(true);
+    const [scrollPosition, setScrollPosition] = useState(0);
     const isMobileWidth = useIsMobileWidth();
     const scrollAreaSelector = "[data-radix-scroll-area-viewport]";
 
@@ -118,6 +119,12 @@ export default function ChatHistory(props: ChatHistoryProps) {
         const observer = new IntersectionObserver(
             (entries) => {
                 if (entries[0].isIntersecting && hasMoreMessages) {
+                    const scrollArea = scrollAreaRef.current?.querySelector(
+                        scrollAreaSelector,
+                    ) as HTMLElement;
+                    if (scrollArea) {
+                        setScrollPosition(scrollArea.scrollHeight - scrollArea.scrollTop);
+                    }
                     setFetchingData(true);
                     fetchMoreMessages(currentPage);
                     setCurrentPage((prev) => prev + 1);
@@ -148,6 +155,12 @@ export default function ChatHistory(props: ChatHistoryProps) {
             }
         }
     }, [props.incomingMessages]);
+
+    const adjustScrollPosition = () => {
+        const scrollArea = scrollAreaRef.current?.querySelector(scrollAreaSelector) as HTMLElement;
+        if (!scrollArea) return;
+        scrollArea.scrollTo({ top: scrollArea.scrollHeight - scrollPosition, behavior: "auto" });
+    };
 
     function fetchMoreMessages(currentPage: number) {
         if (!hasMoreMessages || fetchingData) return;
@@ -183,6 +196,8 @@ export default function ChatHistory(props: ChatHistoryProps) {
                     setFetchingData(false);
                     if (currentPage === 0) {
                         scrollToBottom(true);
+                    } else {
+                        setTimeout(adjustScrollPosition, 0);
                     }
                 } else {
                     if (chatData.response.agent && chatData.response.conversation_id) {

--- a/src/interface/web/app/components/chatHistory/chatHistory.tsx
+++ b/src/interface/web/app/components/chatHistory/chatHistory.tsx
@@ -87,7 +87,7 @@ export default function ChatHistory(props: ChatHistoryProps) {
 
         const detectIsNearBottom = () => {
             const { scrollTop, scrollHeight, clientHeight } = scrollAreaEl;
-            const bottomThreshold = 100; // pixels from bottom
+            const bottomThreshold = 50; // pixels from bottom
             const distanceFromBottom = scrollHeight - (scrollTop + clientHeight);
             const isNearBottom = distanceFromBottom <= bottomThreshold;
             setIsNearBottom(isNearBottom);

--- a/src/interface/web/app/components/chatHistory/chatHistory.tsx
+++ b/src/interface/web/app/components/chatHistory/chatHistory.tsx
@@ -69,6 +69,7 @@ export default function ChatHistory(props: ChatHistoryProps) {
     const [hasMoreMessages, setHasMoreMessages] = useState(true);
     const sentinelRef = useRef<HTMLDivElement | null>(null);
     const scrollAreaRef = useRef<HTMLDivElement | null>(null);
+    const latestUserMessageRef = useRef<HTMLDivElement | null>(null);
 
     const [incompleteIncomingMessageIndex, setIncompleteIncomingMessageIndex] = useState<
         number | null
@@ -101,10 +102,12 @@ export default function ChatHistory(props: ChatHistoryProps) {
         }
     }, [props.incomingMessages, isNearBottom]);
 
-    // Scroll to bottom after the first data fetch on chat history load.
+    // Scroll to most recent user message after the first page of chat messages is loaded.
     useEffect(() => {
-        if (data && data.chat && data.chat.length > 0 && currentPage === 0) {
-            scrollToBottom(true);
+        if (data && data.chat && data.chat.length > 0 && currentPage < 2) {
+            setTimeout(() => {
+                latestUserMessageRef.current?.scrollIntoView({ behavior: "auto", block: "start" });
+            }, 0);
         }
     }, [data, currentPage]);
 
@@ -249,6 +252,7 @@ export default function ChatHistory(props: ChatHistoryProps) {
                         data.chat.map((chatMessage, index) => (
                             <ChatMessage
                                 key={`${index}fullHistory`}
+                                ref={index === data.chat.length - 2 ? latestUserMessageRef : null}
                                 isMobileWidth={isMobileWidth}
                                 chatMessage={chatMessage}
                                 customClassName="fullHistory"

--- a/src/interface/web/app/components/chatHistory/chatHistory.tsx
+++ b/src/interface/web/app/components/chatHistory/chatHistory.tsx
@@ -101,20 +101,10 @@ export default function ChatHistory(props: ChatHistoryProps) {
         }
     }, [props.incomingMessages, isNearBottom]);
 
+    // Scroll to bottom after the first data fetch on chat history load.
     useEffect(() => {
-        // This function ensures that scrolling to bottom happens after the data (chat messages) has been updated and rendered the first time.
-        const scrollToBottomAfterDataLoad = () => {
-            // Assume the data is loading in this scenario.
-            if (!data?.chat.length) {
-                setTimeout(() => {
-                    scrollToBottom();
-                }, 500);
-            }
-        };
-
-        if (currentPage < 2) {
-            // Call the function defined above.
-            scrollToBottomAfterDataLoad();
+        if (data && data.chat && data.chat.length > 0 && currentPage === 0) {
+            scrollToBottom(true);
         }
     }, [data, currentPage]);
 
@@ -188,8 +178,8 @@ export default function ChatHistory(props: ChatHistoryProps) {
                     props.setAgent(chatData.response.agent);
                     setData(chatData.response);
                     setFetchingData(false);
-                    if (currentPage < 2) {
-                        scrollToBottom();
+                    if (currentPage === 0) {
+                        scrollToBottom(true);
                     }
                 } else {
                     if (chatData.response.agent && chatData.response.conversation_id) {
@@ -213,14 +203,16 @@ export default function ChatHistory(props: ChatHistoryProps) {
             });
     }
 
-    const scrollToBottom = () => {
+    const scrollToBottom = (instant: boolean = false) => {
         const scrollArea = scrollAreaRef.current?.querySelector(scrollAreaSelector);
         if (!scrollArea) return;
 
-        const scrollAreaEl = scrollArea as HTMLElement;
-        scrollAreaEl.scrollTo({
-            top: scrollAreaEl.scrollHeight,
-            behavior: "smooth",
+        requestAnimationFrame(() => {
+            const scrollAreaEl = scrollArea as HTMLElement;
+            scrollAreaEl.scrollTo({
+                top: scrollAreaEl.scrollHeight,
+                behavior: instant ? "auto" : "smooth",
+            });
         });
         setIsNearBottom(true);
     };

--- a/src/interface/web/app/components/chatHistory/chatHistory.tsx
+++ b/src/interface/web/app/components/chatHistory/chatHistory.tsx
@@ -346,7 +346,7 @@ export default function ChatHistory(props: ChatHistoryProps) {
                 {!isNearBottom && (
                     <button
                         title="Scroll to bottom"
-                        className="absolute bottom-4 right-5 bg-white dark:bg-[hsl(var(--background))] text-neutral-500 p-2 rounded-full shadow-lg"
+                        className="absolute bottom-4 right-5 bg-white dark:bg-[hsl(var(--background))] text-neutral-500 dark:text-white p-2 rounded-full shadow-xl"
                         onClick={() => {
                             setIsNearBottom(true);
                             scrollToBottom();

--- a/src/interface/web/app/components/chatHistory/chatHistory.tsx
+++ b/src/interface/web/app/components/chatHistory/chatHistory.tsx
@@ -82,7 +82,7 @@ export default function ChatHistory(props: ChatHistoryProps) {
         const scrollArea = scrollAreaRef.current?.querySelector(scrollAreaSelector);
         if (!scrollArea) return;
 
-        const handleScroll = () => {
+        const detectIsNearBottom = () => {
             const { scrollTop, scrollHeight, clientHeight } = scrollArea as HTMLElement;
             const bottomThreshold = 100; // pixels from bottom
             const distanceFromBottom = scrollHeight - (scrollTop + clientHeight);
@@ -90,10 +90,11 @@ export default function ChatHistory(props: ChatHistoryProps) {
             setIsNearBottom(isNearBottom);
         };
 
-        scrollArea.addEventListener("scroll", handleScroll);
-        return () => scrollArea.removeEventListener("scroll", handleScroll);
+        scrollArea.addEventListener("scroll", detectIsNearBottom);
+        return () => scrollArea.removeEventListener("scroll", detectIsNearBottom);
     }, []);
 
+    // Auto scroll while incoming message is streamed
     useEffect(() => {
         if (props.incomingMessages && props.incomingMessages.length > 0 && isNearBottom) {
             setTimeout(scrollToBottom, 0);
@@ -185,13 +186,11 @@ export default function ChatHistory(props: ChatHistoryProps) {
                         return;
                     }
                     props.setAgent(chatData.response.agent);
-
                     setData(chatData.response);
-
+                    setFetchingData(false);
                     if (currentPage < 2) {
                         scrollToBottom();
                     }
-                    setFetchingData(false);
                 } else {
                     if (chatData.response.agent && chatData.response.conversation_id) {
                         const chatMetadata = {
@@ -219,7 +218,10 @@ export default function ChatHistory(props: ChatHistoryProps) {
         if (!scrollArea) return;
 
         const scrollAreaEl = scrollArea as HTMLElement;
-        scrollAreaEl.scrollTop = scrollAreaEl.scrollHeight;
+        scrollAreaEl.scrollTo({
+            top: scrollAreaEl.scrollHeight,
+            behavior: "smooth",
+        });
         setIsNearBottom(true);
     };
 
@@ -348,8 +350,8 @@ export default function ChatHistory(props: ChatHistoryProps) {
                         title="Scroll to bottom"
                         className="absolute bottom-4 right-5 bg-white dark:bg-[hsl(var(--background))] text-neutral-500 dark:text-white p-2 rounded-full shadow-xl"
                         onClick={() => {
-                            setIsNearBottom(true);
                             scrollToBottom();
+                            setIsNearBottom(true);
                         }}
                     >
                         <ArrowDown size={24} />

--- a/src/interface/web/app/components/chatMessage/chatMessage.module.css
+++ b/src/interface/web/app/components/chatMessage/chatMessage.module.css
@@ -53,6 +53,10 @@ div.khojChatMessage {
     padding-left: 16px;
 }
 
+div.emptyChatMessage {
+    display: none;
+}
+
 div.chatMessageContainer img {
     width: 50%;
 }

--- a/src/interface/web/app/components/chatMessage/chatMessage.tsx
+++ b/src/interface/web/app/components/chatMessage/chatMessage.tsx
@@ -4,7 +4,7 @@ import styles from "./chatMessage.module.css";
 
 import markdownIt from "markdown-it";
 import mditHljs from "markdown-it-highlightjs";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, forwardRef } from "react";
 import { createRoot } from "react-dom/client";
 
 import "katex/dist/katex.min.css";
@@ -275,7 +275,7 @@ export function TrainOfThought(props: TrainOfThoughtProps) {
     );
 }
 
-export default function ChatMessage(props: ChatMessageProps) {
+const ChatMessage = forwardRef<HTMLDivElement, ChatMessageProps>((props, ref) => {
     const [copySuccess, setCopySuccess] = useState<boolean>(false);
     const [isHovering, setIsHovering] = useState<boolean>(false);
     const [textRendered, setTextRendered] = useState<string>("");
@@ -478,17 +478,8 @@ export default function ChatMessage(props: ChatMessageProps) {
         const sentenceRegex = /[^.!?]+[.!?]*/g;
         const chunks = props.chatMessage.message.match(sentenceRegex) || [];
 
-        if (!chunks) {
-            return;
-        }
+        if (!chunks || chunks.length === 0 || !chunks[0]) return;
 
-        if (chunks.length === 0) {
-            return;
-        }
-
-        if (!chunks[0]) {
-            return;
-        }
         setIsPlaying(true);
 
         let nextBlobPromise = fetchBlob(chunks[0]);
@@ -548,6 +539,7 @@ export default function ChatMessage(props: ChatMessageProps) {
 
     return (
         <div
+            ref={ref}
             className={constructClasses(props.chatMessage)}
             onMouseLeave={(event) => setIsHovering(false)}
             onMouseEnter={(event) => setIsHovering(true)}
@@ -640,4 +632,8 @@ export default function ChatMessage(props: ChatMessageProps) {
             </div>
         </div>
     );
-}
+});
+
+ChatMessage.displayName = "ChatMessage";
+
+export default ChatMessage;

--- a/src/interface/web/app/components/chatMessage/chatMessage.tsx
+++ b/src/interface/web/app/components/chatMessage/chatMessage.tsx
@@ -406,10 +406,6 @@ const ChatMessage = forwardRef<HTMLDivElement, ChatMessageProps>((props, ref) =>
         }
     }, [markdownRendered, isHovering, messageRef]);
 
-    if (!props.chatMessage.message) {
-        return null;
-    }
-
     function formatDate(timestamp: string) {
         // Format date in HH:MM, DD MMM YYYY format
         let date = new Date(timestamp + "Z");
@@ -449,6 +445,9 @@ const ChatMessage = forwardRef<HTMLDivElement, ChatMessageProps>((props, ref) =>
     function constructClasses(chatMessage: SingleChatMessage) {
         let classes = [styles.chatMessageContainer, "shadow-md"];
         classes.push(styles[chatMessage.by]);
+        if (!chatMessage.message) {
+            classes.push(styles.emptyChatMessage);
+        }
 
         if (props.customClassName) {
             classes.push(styles[`${chatMessage.by}${props.customClassName}`]);


### PR DESCRIPTION
### Overview
i have modified the ```chatHistory.tsx``` and added the following things:
1. `useEffect` to monitor if auto-scroll is needed
2. a button to scroll down 

### Details
1. Only auto scroll Khoj's streamed response when scroll is near bottom of page
   Allows scrolling to other messages in conversation while Khoj is formulating and streaming its response
2. Add button to scroll to bottom of the chat page
3. Scroll to most recent conversation turn on conversation first load
   It's a better default to anchor to most recent conversation turn (i.e most recent user message)
4. Smooth scroll when Khoj's chat response is streamed
   Previously the scroll would jitter during response streaming
5. Anchor scroll position when fetch and render older messages in conversation
   Allow users to keep their scroll position when older messages are fetched from server and rendered

Resolves #758