### PR TITLE
Reduce tooltip popup delay duration for Create Agent button on Web app

### DIFF
--- a/src/interface/web/app/agents/page.tsx
+++ b/src/interface/web/app/agents/page.tsx
@@ -295,7 +295,7 @@ export default function Agents() {
                         <h1 className="text-3xl flex items-center">Agents</h1>
                         <div className="ml-auto float-right border p-2 pt-3 rounded-xl font-bold hover:bg-stone-100 dark:hover:bg-neutral-900">
                             <TooltipProvider>
-                                <Tooltip>
+                                <Tooltip delayDuration={10}>
                                     <TooltipTrigger>
                                         <div className="flex flex-row">
                                             <Plus className="pr-2 w-6 h-6" />


### PR DESCRIPTION
Resolves #915
So the problem was the tool tip was visible on hover, but it was slow, so before the tool tip popped up, the user would click on the button and this stopped the tool tip from popping up.

so i reduced the popup delay to 10ms. now as soon as user hovers over the button , he will see that its a feature coming soon!