### PR TITLE
Simplify switching chat model when self-hosting

### DIFF
--- a/src/khoj/configure.py
+++ b/src/khoj/configure.py
@@ -244,7 +244,7 @@ def configure_server(
 
         state.SearchType = configure_search_types()
         state.search_models = configure_search(state.search_models, state.config.search_type)
-        setup_default_agent()
+        setup_default_agent(user)
 
         message = "📡 Telemetry disabled" if telemetry_disabled(state.config.app) else "📡 Telemetry enabled"
         logger.info(message)
@@ -256,8 +256,8 @@ def configure_server(
         raise e
 
 
-def setup_default_agent():
-    AgentAdapters.create_default_agent()
+def setup_default_agent(user: KhojUser):
+    AgentAdapters.create_default_agent(user)
 
 
 def initialize_content(regenerate: bool, search_type: Optional[SearchType] = None, user: KhojUser = None):

--- a/src/khoj/processor/image/generate.py
+++ b/src/khoj/processor/image/generate.py
@@ -25,7 +25,6 @@ async def text_to_image(
     location_data: LocationData,
     references: List[Dict[str, Any]],
     online_results: Dict[str, Any],
-    subscribed: bool = False,
     send_status_func: Optional[Callable] = None,
     uploaded_image_url: Optional[str] = None,
     agent: Agent = None,
@@ -66,8 +65,8 @@ async def text_to_image(
         note_references=references,
         online_results=online_results,
         model_type=text_to_image_config.model_type,
-        subscribed=subscribed,
         uploaded_image_url=uploaded_image_url,
+        user=user,
         agent=agent,
     )
 

--- a/src/khoj/processor/tools/online_search.py
+++ b/src/khoj/processor/tools/online_search.py
@@ -102,7 +102,7 @@ async def search_online(
             async for event in send_status_func(f"**Reading web pages**: {webpage_links_str}"):
                 yield {ChatEvent.STATUS: event}
     tasks = [
-        read_webpage_and_extract_content(subquery, link, content, subscribed=subscribed, agent=agent)
+        read_webpage_and_extract_content(subquery, link, content, subscribed=subscribed, user=user, agent=agent)
         for link, subquery, content in webpages
     ]
     results = await asyncio.gather(*tasks)
@@ -158,7 +158,9 @@ async def read_webpages(
         webpage_links_str = "\n- " + "\n- ".join(list(urls))
         async for event in send_status_func(f"**Reading web pages**: {webpage_links_str}"):
             yield {ChatEvent.STATUS: event}
-    tasks = [read_webpage_and_extract_content(query, url, subscribed=subscribed, agent=agent) for url in urls]
+    tasks = [
+        read_webpage_and_extract_content(query, url, subscribed=subscribed, user=user, agent=agent) for url in urls
+    ]
     results = await asyncio.gather(*tasks)
 
     response: Dict[str, Dict] = defaultdict(dict)
@@ -169,14 +171,14 @@ async def read_webpages(
 
 
 async def read_webpage_and_extract_content(
-    subquery: str, url: str, content: str = None, subscribed: bool = False, agent: Agent = None
+    subquery: str, url: str, content: str = None, subscribed: bool = False, user: KhojUser = None, agent: Agent = None
 ) -> Tuple[str, Union[None, str], str]:
     try:
         if is_none_or_empty(content):
             with timer(f"Reading web page at '{url}' took", logger):
                 content = await read_webpage_with_olostep(url) if OLOSTEP_API_KEY else await read_webpage_with_jina(url)
         with timer(f"Extracting relevant information from web page at '{url}' took", logger):
-            extracted_info = await extract_relevant_info(subquery, content, subscribed=subscribed, agent=agent)
+            extracted_info = await extract_relevant_info(subquery, content, user=user, agent=agent)
         return subquery, extracted_info, url
     except Exception as e:
         logger.error(f"Failed to read web page at '{url}' with {e}")

--- a/src/khoj/processor/tools/online_search.py
+++ b/src/khoj/processor/tools/online_search.py
@@ -102,7 +102,7 @@ async def search_online(
             async for event in send_status_func(f"**Reading web pages**: {webpage_links_str}"):
                 yield {ChatEvent.STATUS: event}
     tasks = [
-        read_webpage_and_extract_content(subquery, link, content, subscribed=subscribed, user=user, agent=agent)
+        read_webpage_and_extract_content(subquery, link, content, user=user, agent=agent)
         for link, subquery, content in webpages
     ]
     results = await asyncio.gather(*tasks)
@@ -158,9 +158,7 @@ async def read_webpages(
         webpage_links_str = "\n- " + "\n- ".join(list(urls))
         async for event in send_status_func(f"**Reading web pages**: {webpage_links_str}"):
             yield {ChatEvent.STATUS: event}
-    tasks = [
-        read_webpage_and_extract_content(query, url, subscribed=subscribed, user=user, agent=agent) for url in urls
-    ]
+    tasks = [read_webpage_and_extract_content(query, url, user=user, agent=agent) for url in urls]
     results = await asyncio.gather(*tasks)
 
     response: Dict[str, Dict] = defaultdict(dict)
@@ -171,7 +169,7 @@ async def read_webpages(
 
 
 async def read_webpage_and_extract_content(
-    subquery: str, url: str, content: str = None, subscribed: bool = False, user: KhojUser = None, agent: Agent = None
+    subquery: str, url: str, content: str = None, user: KhojUser = None, agent: Agent = None
 ) -> Tuple[str, Union[None, str], str]:
     try:
         if is_none_or_empty(content):

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -395,7 +395,7 @@ async def extract_references_and_questions(
     # Infer search queries from user message
     with timer("Extracting search queries took", logger):
         # If we've reached here, either the user has enabled offline chat or the openai model is enabled.
-        conversation_config = await ConversationAdapters.aget_default_conversation_config()
+        conversation_config = await ConversationAdapters.aget_default_conversation_config(user)
         vision_enabled = conversation_config.vision_enabled
 
         if conversation_config.model_type == ChatModelOptions.ModelType.OFFLINE:

--- a/src/khoj/routers/api_chat.py
+++ b/src/khoj/routers/api_chat.py
@@ -194,7 +194,7 @@ def chat_history(
     n: Optional[int] = None,
 ):
     user = request.user.object
-    validate_conversation_config()
+    validate_conversation_config(user)
 
     # Load Conversation History
     conversation = ConversationAdapters.get_conversation_by_user(
@@ -694,7 +694,7 @@ async def chat(
                 q,
                 meta_log,
                 is_automated_task,
-                subscribed=subscribed,
+                user=user,
                 uploaded_image_url=uploaded_image_url,
                 agent=agent,
             )
@@ -704,7 +704,7 @@ async def chat(
             ):
                 yield result
 
-            mode = await aget_relevant_output_modes(q, meta_log, is_automated_task, uploaded_image_url, agent)
+            mode = await aget_relevant_output_modes(q, meta_log, is_automated_task, user, uploaded_image_url, agent)
             async for result in send_event(ChatEvent.STATUS, f"**Decided Response Mode:** {mode.value}"):
                 yield result
             if mode not in conversation_commands:
@@ -767,8 +767,8 @@ async def chat(
                         q,
                         contextual_data,
                         conversation_history=meta_log,
-                        subscribed=subscribed,
                         uploaded_image_url=uploaded_image_url,
+                        user=user,
                         agent=agent,
                     )
                     response_log = str(response)
@@ -957,7 +957,6 @@ async def chat(
                 location_data=location,
                 references=compiled_references,
                 online_results=online_results,
-                subscribed=subscribed,
                 send_status_func=partial(send_event, ChatEvent.STATUS),
                 uploaded_image_url=uploaded_image_url,
                 agent=agent,
@@ -1192,7 +1191,7 @@ async def get_chat(
 
         if conversation_commands == [ConversationCommand.Default] or is_automated_task:
             conversation_commands = await aget_relevant_information_sources(
-                q, meta_log, is_automated_task, subscribed=subscribed, uploaded_image_url=uploaded_image_url
+                q, meta_log, is_automated_task, user=user, uploaded_image_url=uploaded_image_url
             )
             conversation_commands_str = ", ".join([cmd.value for cmd in conversation_commands])
             async for result in send_event(
@@ -1200,7 +1199,7 @@ async def get_chat(
             ):
                 yield result
 
-            mode = await aget_relevant_output_modes(q, meta_log, is_automated_task, uploaded_image_url)
+            mode = await aget_relevant_output_modes(q, meta_log, is_automated_task, user, uploaded_image_url)
             async for result in send_event(ChatEvent.STATUS, f"**Decided Response Mode:** {mode.value}"):
                 yield result
             if mode not in conversation_commands:
@@ -1252,7 +1251,7 @@ async def get_chat(
                         q,
                         contextual_data,
                         conversation_history=meta_log,
-                        subscribed=subscribed,
+                        user=user,
                         uploaded_image_url=uploaded_image_url,
                     )
                     response_log = str(response)
@@ -1438,7 +1437,6 @@ async def get_chat(
                 location_data=location,
                 references=compiled_references,
                 online_results=online_results,
-                subscribed=subscribed,
                 send_status_func=partial(send_event, ChatEvent.STATUS),
                 uploaded_image_url=uploaded_image_url,
             ):

--- a/src/khoj/routers/api_model.py
+++ b/src/khoj/routers/api_model.py
@@ -40,7 +40,7 @@ def get_user_chat_model(
     chat_model = ConversationAdapters.get_conversation_config(user)
 
     if chat_model is None:
-        chat_model = ConversationAdapters.get_default_conversation_config()
+        chat_model = ConversationAdapters.get_default_conversation_config(user)
 
     return Response(status_code=200, content=json.dumps({"id": chat_model.id, "chat_model": chat_model.chat_model}))
 

--- a/src/khoj/utils/initialization.py
+++ b/src/khoj/utils/initialization.py
@@ -129,9 +129,6 @@ def initialization(interactive: bool = True):
             if user_chat_model_name and ChatModelOptions.objects.filter(chat_model=user_chat_model_name).exists():
                 default_chat_model_name = user_chat_model_name
 
-            # Create a server chat settings object with the default chat model
-            default_chat_model = ChatModelOptions.objects.filter(chat_model=default_chat_model_name).first()
-            ServerChatSettings.objects.create(chat_default=default_chat_model)
             logger.info("🗣️ Chat model configuration complete")
 
         # Set up offline speech to text model


### PR DESCRIPTION
### Overview
- Default to use user chat models for train of thought when no server chat settings created by admins
- Default to not create server chat settings on first run

### Details
This change simplifies switching chat models for self-hosted setups 
by just changing the chat model on the user settings page.

It falls back to use the user chat model for train of thought 
if server chat settings have not been created on the admin panel.

Server chat settings, when set, controls the chat model used 
for Khoj's train of thought and the default user chat model.

Previously a self-hosted user had to update
1. the server chat settings in the admin panel and
2. their own user chat model in the user settings panel

to completely switch to a different chat model 
for both train of thought & response generation respectively

You can still set server chat settings via the admin panel 
to use a different chat model for train of thought vs response generation. 
But this is only useful for advanced, multi-user setups.