### PR TITLE
Fix database connections leakage (#980)

### DIFF
--- a/src/khoj/database/adapters/__init__.py
+++ b/src/khoj/database/adapters/__init__.py
@@ -27,6 +27,7 @@ from django.contrib.sessions.backends.db import SessionStore
 from django.db.models import Prefetch, Q
 from django.db.models.manager import BaseManager
 from django.db.utils import IntegrityError
+from django_apscheduler import util
 from django_apscheduler.models import DjangoJob, DjangoJobExecution
 from fastapi import HTTPException
 from pgvector.django import CosineDistance
@@ -606,6 +607,7 @@ class ProcessLockAdapters:
                 logger.debug(f"Skip removing {operation} process lock as it was not set")
 
 
+@util.close_old_connections
 def run_with_process_lock(*args, **kwargs):
     """Wrapper function used for scheduling jobs.
     Required as APScheduler can't discover the `ProcessLockAdapter.run_with_lock' method on its own.


### PR DESCRIPTION
## Description
This pull request addresses a database connection leak caused by `django-apscheduler` not closing stale connections after task execution. The solution involves wrapping `run_with_process_lock` with the `@close_old_connections` decorator provided by `django-apscheduler`.

For more details, refer to the [django-apscheduler documentation on database connections and timeouts](https://github.com/jcass77/django-apscheduler#database-connections-and-timeouts).

## Changes
- Added `@close_old_connections` decorator to `run_with_process_lock` to ensure database connections are properly closed after each scheduled task.

## Related Issue
- Fixes #980: Database connections not closed after scheduled tasks, leading to connection leakage.
