### PR TITLE
Restart code sandbox on crash in eval github workflow

### DIFF
--- a/.github/workflows/run_evals.yml
+++ b/.github/workflows/run_evals.yml
@@ -114,7 +114,7 @@ jobs:
 
           # Start code sandbox
           npm install -g pm2
-          pm2 start src/index.ts --interpreter ts-node --exp-backoff-restart-delay=100 --name sandbox --cwd terrarium
+          npm run ci --prefix terrarium
 
           # Wait for server to be ready
           timeout=120


### PR DESCRIPTION
This allows code tool to be used in eval runs across sandbox crashes.

See https://github.com/khoj-ai/terrarium/commit/e3fed3750b4c9a766b2231bfc8c57a751ad0bd44 for corresponding changes to use pm2 to auto-restart code sandbox on crash. 

