### PR TITLE
Allow research mode and other conversation commands in automations

### DIFF
--- a/src/interface/web/app/automations/page.tsx
+++ b/src/interface/web/app/automations/page.tsx
@@ -165,7 +165,7 @@ const suggestedAutomationsMetadata: AutomationsData[] = [
     {
         subject: "Weekly Newsletter",
         query_to_run:
-            "Compile a message including: 1. A recap of news from last week 2. An at-home workout I can do before work 3. A quote to inspire me for the week ahead",
+            "/research Compile a message including: 1. A recap of news from last week 2. An at-home workout I can do before work 3. A quote to inspire me for the week ahead",
         schedule: "9AM every Monday",
         next: "Next run at 9AM on Monday",
         crontime: "0 9 * * 1",
@@ -185,7 +185,7 @@ const suggestedAutomationsMetadata: AutomationsData[] = [
     {
         subject: "Front Page of Hacker News",
         query_to_run:
-            "Summarize the top 5 posts from https://news.ycombinator.com/best and share them with me, including links",
+            "/research Summarize the top 5 posts from https://news.ycombinator.com/best and share them with me, including links",
         schedule: "9PM on every Wednesday",
         next: "Next run at 9PM on Wednesday",
         crontime: "0 21 * * 3",
@@ -195,7 +195,7 @@ const suggestedAutomationsMetadata: AutomationsData[] = [
     {
         subject: "Market Summary",
         query_to_run:
-            "Get the market summary for today and share it with me. Focus on tech stocks and the S&P 500.",
+            "/research Get the market summary for today and share it with me. Focus on tech stocks and the S&P 500.",
         schedule: "9AM on every weekday",
         next: "Next run at 9AM on Monday",
         crontime: "0 9 * * *",
@@ -214,7 +214,7 @@ const suggestedAutomationsMetadata: AutomationsData[] = [
     {
         subject: "Round-up of research papers about AI in healthcare",
         query_to_run:
-            "Summarize the top 3 research papers about AI in healthcare that were published in the last week. Include links to the full papers.",
+            "/research Summarize the top 3 research papers about AI in healthcare that were published in the last week. Include links to the full papers.",
         schedule: "9AM every Friday",
         next: "Next run at 9AM on Friday",
         crontime: "0 9 * * 5",


### PR DESCRIPTION
Previously we couldn't use research mode or use other slash commands 
in automated tasks.

This change separates determining if a chat query is triggered via
automated task from (other) conversation commands to run the query with.

This unlocks the ability to enable research mode in automations 
apart from other variations like  /image or /diagram etc