### PR TITLE
Use the configured OpenAI Base URL for Automations

### DIFF
--- a/src/khoj/routers/helpers.py
+++ b/src/khoj/routers/helpers.py
@@ -1135,6 +1135,7 @@ def send_message_to_model_wrapper_sync(
 
     elif chat_model.model_type == ChatModel.ModelType.OPENAI:
         api_key = chat_model.ai_model_api.api_key
+        api_base_url = chat_model.ai_model_api.api_base_url
         truncated_messages = generate_chatml_messages_with_context(
             user_message=message,
             system_message=system_message,
@@ -1149,6 +1150,7 @@ def send_message_to_model_wrapper_sync(
         openai_response = send_message_to_model(
             messages=truncated_messages,
             api_key=api_key,
+            api_base_url=api_base_url,
             model=chat_model_name,
             response_type=response_type,
             tracer=tracer,


### PR DESCRIPTION
This change makes Automations (and possibly other entrypoints) use the configured OpenAI-compatible server if that has been set. Without this change it tries to use the hardcoded OpenAI provider.

All the other calls in this file use a similar method to pass in the base URL.

**I have not been able to manually test this because the docker build is taking an extremely long time to build locally.**