### PR TITLE
Resolve datetime utcnow deprecation warnings

### DIFF
--- a/src/khoj/processor/content/images/image_to_entries.py
+++ b/src/khoj/processor/content/images/image_to_entries.py
@@ -1,7 +1,7 @@
 import base64
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Tuple
 
 from khoj.database.models import Entry as DbEntry
@@ -58,7 +58,7 @@ class ImageToEntries(TextToEntries):
             try:
                 bytes = image_files[image_file]
                 # write the image to a temporary file
-                timestamp_now = datetime.utcnow().timestamp()
+                timestamp_now = datetime.now(timezone.utc).timestamp()
                 # use either png or jpg
                 if image_file.endswith(".png"):
                     tmp_file = f"tmp_image_file_{timestamp_now}.png"

--- a/src/khoj/routers/helpers.py
+++ b/src/khoj/routers/helpers.py
@@ -480,7 +480,7 @@ async def infer_webpage_urls(
     username = prompts.user_name.format(name=user.get_full_name()) if user.get_full_name() else ""
     chat_history = construct_chat_history(conversation_history)
 
-    utc_date = datetime.utcnow().strftime("%Y-%m-%d")
+    utc_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     personality_context = (
         prompts.personality_context.format(personality=agent.personality) if agent and agent.personality else ""
     )
@@ -545,7 +545,7 @@ async def generate_online_subqueries(
     chat_history = construct_chat_history(conversation_history)
 
     max_queries = 3
-    utc_date = datetime.utcnow().strftime("%Y-%m-%d")
+    utc_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     personality_context = (
         prompts.personality_context.format(personality=agent.personality) if agent and agent.personality else ""
     )


### PR DESCRIPTION
# PR Summary
This small PR resolves the deprecation warnings on `datetime` in Python3.12+. You can find them in the [CI logs](https://github.com/khoj-ai/khoj/actions/runs/14538833837/job/40792624987#step:9:134):
```python
  /__w/khoj/khoj/src/khoj/processor/content/images/image_to_entries.py:61: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    timestamp_now = datetime.utcnow().timestamp()
```