### PR TITLE
Simplify AI Chat Response Streaming

### DIFF
--- a/src/khoj/processor/conversation/anthropic/utils.py
+++ b/src/khoj/processor/conversation/anthropic/utils.py
@@ -19,7 +19,7 @@ from khoj.processor.conversation.utils import (
     get_image_from_url,
 )
 from khoj.utils.helpers import (
-    get_ai_api_info,
+    get_anthropic_client,
     get_chat_usage_metrics,
     is_none_or_empty,
     is_promptrace_enabled,
@@ -31,19 +31,6 @@ anthropic_clients: Dict[str, anthropic.Anthropic | anthropic.AnthropicVertex] = 
 
 DEFAULT_MAX_TOKENS_ANTHROPIC = 8000
 MAX_REASONING_TOKENS_ANTHROPIC = 12000
-
-
-def get_anthropic_client(api_key, api_base_url=None) -> anthropic.Anthropic | anthropic.AnthropicVertex:
-    api_info = get_ai_api_info(api_key, api_base_url)
-    if api_info.api_key:
-        client = anthropic.Anthropic(api_key=api_info.api_key)
-    else:
-        client = anthropic.AnthropicVertex(
-            region=api_info.region,
-            project_id=api_info.project,
-            credentials=api_info.credentials,
-        )
-    return client
 
 
 @retry(

--- a/src/khoj/processor/conversation/google/utils.py
+++ b/src/khoj/processor/conversation/google/utils.py
@@ -25,8 +25,8 @@ from khoj.processor.conversation.utils import (
     get_image_from_url,
 )
 from khoj.utils.helpers import (
-    get_ai_api_info,
     get_chat_usage_metrics,
+    get_gemini_client,
     is_none_or_empty,
     is_promptrace_enabled,
 )
@@ -60,17 +60,6 @@ SAFETY_SETTINGS = [
         threshold=gtypes.HarmBlockThreshold.BLOCK_ONLY_HIGH,
     ),
 ]
-
-
-def get_gemini_client(api_key, api_base_url=None) -> genai.Client:
-    api_info = get_ai_api_info(api_key, api_base_url)
-    return genai.Client(
-        location=api_info.region,
-        project=api_info.project,
-        credentials=api_info.credentials,
-        api_key=api_info.api_key,
-        vertexai=api_info.api_key is None,
-    )
 
 
 @retry(

--- a/src/khoj/processor/conversation/offline/chat_model.py
+++ b/src/khoj/processor/conversation/offline/chat_model.py
@@ -1,9 +1,10 @@
-import json
+import asyncio
 import logging
 import os
 from datetime import datetime, timedelta
 from threading import Thread
-from typing import Any, Dict, Iterator, List, Optional, Union
+from time import perf_counter
+from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
 import pyjson5
 from langchain.schema import ChatMessage
@@ -13,7 +14,6 @@ from khoj.database.models import Agent, ChatModel, KhojUser
 from khoj.processor.conversation import prompts
 from khoj.processor.conversation.offline.utils import download_model
 from khoj.processor.conversation.utils import (
-    ThreadedGenerator,
     clean_json,
     commit_conversation_trace,
     generate_chatml_messages_with_context,
@@ -147,7 +147,7 @@ def filter_questions(questions: List[str]):
     return list(filtered_questions)
 
 
-def converse_offline(
+async def converse_offline(
     user_query,
     references=[],
     online_results={},
@@ -167,9 +167,9 @@ def converse_offline(
     additional_context: List[str] = None,
     generated_asset_results: Dict[str, Dict] = {},
     tracer: dict = {},
-) -> Union[ThreadedGenerator, Iterator[str]]:
+) -> AsyncGenerator[str, None]:
     """
-    Converse with user using Llama
+    Converse with user using Llama (Async Version)
     """
     # Initialize Variables
     assert loaded_model is None or isinstance(loaded_model, Llama), "loaded_model must be of type Llama, if configured"
@@ -200,10 +200,17 @@ def converse_offline(
 
     # Get Conversation Primer appropriate to Conversation Type
     if conversation_commands == [ConversationCommand.Notes] and is_none_or_empty(references):
-        return iter([prompts.no_notes_found.format()])
+        response = prompts.no_notes_found.format()
+        if completion_func:
+            await completion_func(chat_response=response)
+        yield response
+        return
     elif conversation_commands == [ConversationCommand.Online] and is_none_or_empty(online_results):
-        completion_func(chat_response=prompts.no_online_results_found.format())
-        return iter([prompts.no_online_results_found.format()])
+        response = prompts.no_online_results_found.format()
+        if completion_func:
+            await completion_func(chat_response=response)
+        yield response
+        return
 
     context_message = ""
     if not is_none_or_empty(references):
@@ -240,33 +247,77 @@ def converse_offline(
 
     logger.debug(f"Conversation Context for {model_name}: {messages_to_print(messages)}")
 
-    g = ThreadedGenerator(references, online_results, completion_func=completion_func)
-    t = Thread(target=llm_thread, args=(g, messages, offline_chat_model, max_prompt_size, tracer))
-    t.start()
-    return g
-
-
-def llm_thread(g, messages: List[ChatMessage], model: Any, max_prompt_size: int = None, tracer: dict = {}):
+    # Use asyncio.Queue and a thread to bridge sync iterator
+    queue: asyncio.Queue = asyncio.Queue()
     stop_phrases = ["<s>", "INST]", "Notes:"]
-    aggregated_response = ""
+    aggregated_response_container = {"response": ""}
 
-    state.chat_lock.acquire()
-    try:
-        response_iterator = send_message_to_model_offline(
-            messages, loaded_model=model, stop=stop_phrases, max_prompt_size=max_prompt_size, streaming=True
-        )
-        for response in response_iterator:
-            response_delta = response["choices"][0]["delta"].get("content", "")
-            aggregated_response += response_delta
-            g.send(response_delta)
+    def _sync_llm_thread():
+        """Synchronous function to run in a separate thread."""
+        aggregated_response = ""
+        start_time = perf_counter()
+        state.chat_lock.acquire()
+        try:
+            response_iterator = send_message_to_model_offline(
+                messages,
+                loaded_model=offline_chat_model,
+                stop=stop_phrases,
+                max_prompt_size=max_prompt_size,
+                streaming=True,
+                tracer=tracer,
+            )
+            for response in response_iterator:
+                response_delta = response["choices"][0]["delta"].get("content", "")
+                # Log the time taken to start response
+                if aggregated_response == "" and response_delta != "":
+                    logger.info(f"First response took: {perf_counter() - start_time:.3f} seconds")
+                # Handle response chunk
+                aggregated_response += response_delta
+                # Put chunk into the asyncio queue (non-blocking)
+                try:
+                    queue.put_nowait(response_delta)
+                except asyncio.QueueFull:
+                    # Should not happen with default queue size unless consumer is very slow
+                    logger.warning("Asyncio queue full during offline LLM streaming.")
+                    # Potentially block here or handle differently if needed
+                    asyncio.run(queue.put(response_delta))
 
-        # Save conversation trace
-        if is_promptrace_enabled():
-            commit_conversation_trace(messages, aggregated_response, tracer)
+            # Log the time taken to stream the entire response
+            logger.info(f"Chat streaming took: {perf_counter() - start_time:.3f} seconds")
 
-    finally:
-        state.chat_lock.release()
-        g.close()
+            # Save conversation trace
+            tracer["chat_model"] = model_name
+            if is_promptrace_enabled():
+                commit_conversation_trace(messages, aggregated_response, tracer)
+
+        except Exception as e:
+            logger.error(f"Error in offline LLM thread: {e}", exc_info=True)
+        finally:
+            state.chat_lock.release()
+            # Signal end of stream
+            queue.put_nowait(None)
+            aggregated_response_container["response"] = aggregated_response
+
+    # Start the synchronous thread
+    thread = Thread(target=_sync_llm_thread)
+    thread.start()
+
+    # Asynchronously consume from the queue
+    while True:
+        chunk = await queue.get()
+        if chunk is None:  # End of stream signal
+            queue.task_done()
+            break
+        yield chunk
+        queue.task_done()
+
+    # Wait for the thread to finish (optional, ensures cleanup)
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, thread.join)
+
+    # Call the completion function after streaming is done
+    if completion_func:
+        await completion_func(chat_response=aggregated_response_container["response"])
 
 
 def send_message_to_model_offline(

--- a/src/khoj/processor/conversation/openai/utils.py
+++ b/src/khoj/processor/conversation/openai/utils.py
@@ -1,7 +1,7 @@
 import logging
 import os
-from threading import Thread
-from typing import Dict, List
+from time import perf_counter
+from typing import AsyncGenerator, Dict, List
 from urllib.parse import urlparse
 
 import openai
@@ -16,13 +16,10 @@ from tenacity import (
     wait_random_exponential,
 )
 
-from khoj.processor.conversation.utils import (
-    JsonSupport,
-    ThreadedGenerator,
-    commit_conversation_trace,
-)
+from khoj.processor.conversation.utils import JsonSupport, commit_conversation_trace
 from khoj.utils.helpers import (
     get_chat_usage_metrics,
+    get_openai_async_client,
     get_openai_client,
     is_promptrace_enabled,
 )
@@ -30,6 +27,7 @@ from khoj.utils.helpers import (
 logger = logging.getLogger(__name__)
 
 openai_clients: Dict[str, openai.OpenAI] = {}
+openai_async_clients: Dict[str, openai.AsyncOpenAI] = {}
 
 
 @retry(
@@ -124,45 +122,22 @@ def completion_with_backoff(
     before_sleep=before_sleep_log(logger, logging.DEBUG),
     reraise=True,
 )
-def chat_completion_with_backoff(
+async def chat_completion_with_backoff(
     messages,
-    compiled_references,
-    online_results,
     model_name,
-    temperature,
-    openai_api_key=None,
-    api_base_url=None,
-    completion_func=None,
-    deepthought=False,
-    model_kwargs=None,
-    tracer: dict = {},
-):
-    g = ThreadedGenerator(compiled_references, online_results, completion_func=completion_func)
-    t = Thread(
-        target=llm_thread,
-        args=(g, messages, model_name, temperature, openai_api_key, api_base_url, deepthought, model_kwargs, tracer),
-    )
-    t.start()
-    return g
-
-
-def llm_thread(
-    g,
-    messages,
-    model_name: str,
     temperature,
     openai_api_key=None,
     api_base_url=None,
     deepthought=False,
     model_kwargs: dict = {},
     tracer: dict = {},
-):
+) -> AsyncGenerator[str, None]:
     try:
         client_key = f"{openai_api_key}--{api_base_url}"
-        client = openai_clients.get(client_key)
+        client = openai_async_clients.get(client_key)
         if not client:
-            client = get_openai_client(openai_api_key, api_base_url)
-            openai_clients[client_key] = client
+            client = get_openai_async_client(openai_api_key, api_base_url)
+            openai_async_clients[client_key] = client
 
         formatted_messages = [{"role": message.role, "content": message.content} for message in messages]
 
@@ -207,53 +182,58 @@ def llm_thread(
         if os.getenv("KHOJ_LLM_SEED"):
             model_kwargs["seed"] = int(os.getenv("KHOJ_LLM_SEED"))
 
-        chat: ChatCompletion | openai.Stream[ChatCompletionChunk] = client.chat.completions.create(
-            messages=formatted_messages,
-            model=model_name,  # type: ignore
+        aggregated_response = ""
+        final_chunk = None
+        start_time = perf_counter()
+        chat_stream: openai.AsyncStream[ChatCompletionChunk] = await client.chat.completions.create(
+            messages=formatted_messages,  # type: ignore
+            model=model_name,
             stream=stream,
             temperature=temperature,
             timeout=20,
             **model_kwargs,
         )
+        async for chunk in chat_stream:
+            # Log the time taken to start response
+            if final_chunk is None:
+                logger.info(f"First response took: {perf_counter() - start_time:.3f} seconds")
+            # Keep track of the last chunk for usage data
+            final_chunk = chunk
+            # Handle streamed response chunk
+            if len(chunk.choices) == 0:
+                continue
+            delta_chunk = chunk.choices[0].delta
+            text_chunk = ""
+            if isinstance(delta_chunk, str):
+                text_chunk = delta_chunk
+            elif delta_chunk and delta_chunk.content:
+                text_chunk = delta_chunk.content
+            if text_chunk:
+                aggregated_response += text_chunk
+                yield text_chunk
 
-        aggregated_response = ""
-        if not stream:
-            chunk = chat
-            aggregated_response = chunk.choices[0].message.content
-            g.send(aggregated_response)
-        else:
-            for chunk in chat:
-                if len(chunk.choices) == 0:
-                    continue
-                delta_chunk = chunk.choices[0].delta
-                text_chunk = ""
-                if isinstance(delta_chunk, str):
-                    text_chunk = delta_chunk
-                elif delta_chunk.content:
-                    text_chunk = delta_chunk.content
-                if text_chunk:
-                    aggregated_response += text_chunk
-                    g.send(text_chunk)
+        # Log the time taken to stream the entire response
+        logger.info(f"Chat streaming took: {perf_counter() - start_time:.3f} seconds")
 
-        # Calculate cost of chat
-        input_tokens = chunk.usage.prompt_tokens if hasattr(chunk, "usage") and chunk.usage else 0
-        output_tokens = chunk.usage.completion_tokens if hasattr(chunk, "usage") and chunk.usage else 0
-        cost = (
-            chunk.usage.model_extra.get("estimated_cost", 0) if hasattr(chunk, "usage") and chunk.usage else 0
-        )  # Estimated costs returned by DeepInfra API
-        tracer["usage"] = get_chat_usage_metrics(
-            model_name, input_tokens, output_tokens, usage=tracer.get("usage"), cost=cost
-        )
+        # Calculate cost of chat after stream finishes
+        input_tokens, output_tokens, cost = 0, 0, 0
+        if final_chunk and hasattr(final_chunk, "usage") and final_chunk.usage:
+            input_tokens = final_chunk.usage.prompt_tokens
+            output_tokens = final_chunk.usage.completion_tokens
+            # Estimated costs returned by DeepInfra API
+            if final_chunk.usage.model_extra and "estimated_cost" in final_chunk.usage.model_extra:
+                cost = final_chunk.usage.model_extra.get("estimated_cost", 0)
 
         # Save conversation trace
         tracer["chat_model"] = model_name
         tracer["temperature"] = temperature
+        tracer["usage"] = get_chat_usage_metrics(
+            model_name, input_tokens, output_tokens, usage=tracer.get("usage"), cost=cost
+        )
         if is_promptrace_enabled():
             commit_conversation_trace(messages, aggregated_response, tracer)
     except Exception as e:
-        logger.error(f"Error in llm_thread: {e}", exc_info=True)
-    finally:
-        g.close()
+        logger.error(f"Error in chat_completion_with_backoff stream: {e}", exc_info=True)
 
 
 def get_openai_api_json_support(model_name: str, api_base_url: str = None) -> JsonSupport:

--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -77,42 +77,6 @@ model_to_prompt_size = {
 model_to_tokenizer: Dict[str, str] = {}
 
 
-class ThreadedGenerator:
-    def __init__(self, compiled_references, online_results, completion_func=None):
-        self.queue = queue.Queue()
-        self.compiled_references = compiled_references
-        self.online_results = online_results
-        self.completion_func = completion_func
-        self.response = ""
-        self.start_time = perf_counter()
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        item = self.queue.get()
-        if item is StopIteration:
-            time_to_response = perf_counter() - self.start_time
-            logger.info(f"Chat streaming took: {time_to_response:.3f} seconds")
-            if self.completion_func:
-                # The completion func effectively acts as a callback.
-                # It adds the aggregated response to the conversation history.
-                self.completion_func(chat_response=self.response)
-            raise StopIteration
-        return item
-
-    def send(self, data):
-        if self.response == "":
-            time_to_first_response = perf_counter() - self.start_time
-            logger.info(f"First response took: {time_to_first_response:.3f} seconds")
-
-        self.response += data
-        self.queue.put(data)
-
-    def close(self):
-        self.queue.put(StopIteration)
-
-
 class InformationCollectionIteration:
     def __init__(
         self,

--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -254,7 +254,7 @@ def message_to_log(
     return conversation_log
 
 
-def save_to_conversation_log(
+async def save_to_conversation_log(
     q: str,
     chat_response: str,
     user: KhojUser,
@@ -306,7 +306,7 @@ def save_to_conversation_log(
         khoj_message_metadata=khoj_message_metadata,
         conversation_log=meta_log.get("chat", []),
     )
-    ConversationAdapters.save_conversation(
+    await ConversationAdapters.save_conversation(
         user,
         {"chat": updated_conversation},
         client_application=client_application,

--- a/src/khoj/routers/helpers.py
+++ b/src/khoj/routers/helpers.py
@@ -1534,10 +1534,9 @@ async def agenerate_chat_response(
             )
 
         elif chat_model.model_type == ChatModel.ModelType.ANTHROPIC:
-            # Assuming converse_anthropic remains sync or is refactored separately
             api_key = chat_model.ai_model_api.api_key
             api_base_url = chat_model.ai_model_api.api_base_url
-            chat_response_generator = converse_anthropic(  # Needs adaptation if it becomes async
+            chat_response_generator = converse_anthropic(
                 compiled_references,
                 query_to_run,
                 query_images=query_images,

--- a/src/khoj/routers/helpers.py
+++ b/src/khoj/routers/helpers.py
@@ -1563,10 +1563,9 @@ async def agenerate_chat_response(
                 tracer=tracer,
             )
         elif chat_model.model_type == ChatModel.ModelType.GOOGLE:
-            # Assuming converse_gemini remains sync or is refactored separately
             api_key = chat_model.ai_model_api.api_key
             api_base_url = chat_model.ai_model_api.api_base_url
-            chat_response_generator = converse_gemini(  # Needs adaptation if it becomes async
+            chat_response_generator = converse_gemini(
                 compiled_references,
                 query_to_run,
                 online_results,

--- a/src/khoj/routers/helpers.py
+++ b/src/khoj/routers/helpers.py
@@ -93,7 +93,6 @@ from khoj.processor.conversation.openai.gpt import (
 )
 from khoj.processor.conversation.utils import (
     ChatEvent,
-    ThreadedGenerator,
     clean_json,
     clean_mermaidjs,
     construct_chat_history,
@@ -1480,16 +1479,14 @@ async def agenerate_chat_response(
                 vision_available = True
 
         if chat_model.model_type == "offline":
-            # Assuming converse_offline remains sync or is refactored separately
             loaded_model = state.offline_chat_processor_config.loaded_model
-            # If converse_offline returns an iterator, wrap it if needed, or refactor it to async generator
-            chat_response_generator = converse_offline(  # Needs adaptation if it becomes async
+            chat_response_generator = converse_offline(
                 user_query=query_to_run,
                 references=compiled_references,
                 online_results=online_results,
                 loaded_model=loaded_model,
                 conversation_log=meta_log,
-                completion_func=partial_completion,  # Pass the async wrapper
+                completion_func=partial_completion,
                 conversation_commands=conversation_commands,
                 model_name=chat_model.name,
                 max_prompt_size=chat_model.max_prompt_size,


### PR DESCRIPTION
### Reason
- Simplify code and logic to stream chat response by solely relying on asyncio event loop. 
- Reduce overhead of managing threads to increase efficiency and throughput (where possible).

### Details
- Use async/await with no threading when generating chat response via OpenAI, Gemini, Anthropic AI model APIs 
- Use threading for offline chat model as llama-cpp doesn't support async streaming yet