### PR TITLE
docs: Added AI/ML API Integration

### DIFF
--- a/documentation/docs/advanced/admin.md
+++ b/documentation/docs/advanced/admin.md
@@ -19,7 +19,7 @@ Add all the agents you want to use for your different use-cases like Writer, Res
 
 ### Chat Model Options
 Add all the chat models you want to try, use and switch between for your different use-cases. For each chat model you add:
-- `Chat model`: The name of an [OpenAI](https://platform.openai.com/docs/models), [Anthropic](https://docs.anthropic.com/en/docs/about-claude/models#model-names), [Gemini](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#gemini-models) or [Offline](https://huggingface.co/models?pipeline_tag=text-generation&library=gguf) chat model.
+- `Chat model`: The name of an [AI/ML API](https://aimlapi.com/app/?utm_source=khoj&utm_medium=github&utm_campaign=integration), [OpenAI](https://platform.openai.com/docs/models), [Anthropic](https://docs.anthropic.com/en/docs/about-claude/models#model-names), [Gemini](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#gemini-models) or [Offline](https://huggingface.co/models?pipeline_tag=text-generation&library=gguf) chat model.
 - `Model type`: The chat model provider like `OpenAI`, `Offline`.
 - `Vision enabled`: Set to `true` if your model supports vision. This is currently only supported for vision capable OpenAI models like `gpt-4o`
 - `Max prompt size`, `Subscribed max prompt size`: These are optional fields. They are used to truncate the context to the maximum context size that can be passed to the model. This can help with accuracy and cost-saving.<br />
@@ -41,7 +41,7 @@ To add a server chat setting:
 ### AI Model API
 These settings configure APIs to interact with AI models.
 For each AI Model API you [add](http://localhost:42110/server/admin/database/aimodelapi/add):
-- `Api key`: Set to your [OpenAI](https://platform.openai.com/api-keys), [Anthropic](https://console.anthropic.com/account/keys) or [Gemini](https://aistudio.google.com/app/apikey) API keys.
+- `Api key`: Set to your [AI/ML API](https://aimlapi.com/app/?utm_source=khoj&utm_medium=github&utm_campaign=integration), [OpenAI](https://platform.openai.com/api-keys), [Anthropic](https://console.anthropic.com/account/keys) or [Gemini](https://aistudio.google.com/app/apikey) API keys.
 - `Name`: Give the configuration any friendly name like `OpenAI`, `Gemini`, `Anthropic`.
 - `Api base url`: Set the API base URL. This is only relevant to set if you're using another OpenAI-compatible proxy server like [Ollama](/advanced/ollama) or [LMStudio](/advanced/lmstudio).
   ![example configuration for ai model api](/img/example_openai_processor_config.png)
@@ -53,7 +53,7 @@ Search models are used to generate vector embeddings of your documents for natur
 
 ### Text to Image Model Options
 Add text to image generation models with these settings. Khoj currently supports text to image models available via OpenAI, Stability or Replicate API
-- `api-key`: Set to your OpenAI, Stability or Replicate API key
+- `api-key`: Set to your AI/ML API, OpenAI, Stability or Replicate API key
 - `model`: Set the model name available over the selected model provider
 - `model-type`: Set to the appropriate model provider
 - `openai-config`: For image generation models available via OpenAI (compatible) API you can set the appropriate OpenAI Processor Conversation Settings instead of specifying the `api-key` field above

--- a/documentation/docs/advanced/aimlapi.md
+++ b/documentation/docs/advanced/aimlapi.md
@@ -1,0 +1,50 @@
+# AI/ML API  
+:::info  
+This integration works for both self-hosted and cloud-hosted deployments. Simply configure your AI/ML API credentials and endpoint in Khoj, and you’ll have instant access to 300+ models—including Deepseek, Gemini, ChatGPT—backed by enterprise-grade rate limits and uptime.  
+:::
+
+AI/ML API provides a unified REST interface to over 300 cutting-edge models. Point your client at our endpoint, supply your API key, and start using any model in our catalog—no GCP setup required.
+
+## Setup
+
+1. **Obtain your API Key**  
+   - Sign in to the AI/ML API dashboard at [website](https://aimlapi.com/app/?utm_source=khoj&utm_medium=github&utm_campaign=integration)  
+   - Copy your secret API key.
+
+2. **Create an “API Model API” in Khoj**  
+   Go to **Admin → Database → AIModelAPI → Add** and enter:  
+   - **Name**: `AI/ML API`  
+   - **API Key**: your secret key from step 1  
+   - **API Base URL**:  
+     ```
+     https://api.aimlapi.com/v1
+     ```
+
+3. **Add a Chat Model**  
+   Go to **Admin → Database → ChatModel → Add** and configure:  
+   - **Name**: any model identifier from our catalog (e.g. `chatgpt-3.5-turbo`, `gemini-pro-v1`)  
+   - **Model Type**: choose `OpenAI-compatible`  
+   - **AI Model API**: select the **AI/ML API** entry you created  
+   - **Max prompt size**: set according to the model’s limits (e.g. `8192`)  
+   - **Tokenizer**: leave blank  
+
+4. **Select your Chat Model**  
+   In **Settings**, choose your new AI/ML API chat model and start chatting!
+
+## Troubleshooting & Tips
+
+- **Authentication Errors?**  
+  Ensure you pasted the API key correctly and didn’t include extra spaces or line breaks.
+
+- **Rate Limit Exceeded?**  
+  Check your dashboard for usage metrics. Contact support if you need higher throughput.
+
+- **Unsupported Model Name?**  
+  Verify the exact model ID in our [Model Explorer.](https://docs.aimlapi.com/?utm_source=khoj&utm_medium=github&utm_campaign=integration#model-list)
+
+- **Environment Variables**  
+  For security, store your API key in an environment variable and reference it in your Khoj config:  
+  ```bash
+  export AIMLAPI_KEY="xxxxxxxxxxxxxxxxxxxx"
+
+If you hit any snags, join our Discord for real-time help: [AI/ML API](https://discord.gg/fgCwSRvazH)

--- a/documentation/docs/advanced/use-openai-proxy.md
+++ b/documentation/docs/advanced/use-openai-proxy.md
@@ -11,7 +11,7 @@ This is only helpful for self-hosted users. If you're using [Khoj Cloud](https:/
 Khoj natively supports local LLMs [available on HuggingFace in GGUF format](https://huggingface.co/models?library=gguf). Using an OpenAI API proxy with Khoj maybe useful for ease of setup, trying new models or using commercial LLMs via API.
 :::
 
-Khoj can use any OpenAI API compatible server including local providers like [Ollama](/advanced/ollama), [LMStudio](/advanced/lmstudio) and [LiteLLM](/advanced/litellm) and commercial providers like [HuggingFace](https://huggingface.co/docs/api-inference/tasks/chat-completion#using-the-api), [OpenRouter](https://openrouter.ai/docs/quick-start) etc.
+Khoj can use any OpenAI API compatible server including local providers like [Ollama](/advanced/ollama), [LMStudio](/advanced/lmstudio) and [LiteLLM](/advanced/litellm) and commercial providers like [HuggingFace](https://huggingface.co/docs/api-inference/tasks/chat-completion#using-the-api), [OpenRouter](https://openrouter.ai/docs/quick-start), [AI/ML API](https://aimlapi.com/app/?utm_source=khoj&utm_medium=github&utm_campaign=integration) etc.
 Configuring this allows you to use non-standard, open or commercial, local or hosted LLM models for Khoj.
 
 Combine them with Khoj can turn your favorite LLM into an AI agent. Allowing you to chat with your docs, find answers from the internet, build custom agents and run automations.

--- a/documentation/docs/features/image_generation.md
+++ b/documentation/docs/features/image_generation.md
@@ -24,3 +24,30 @@ We support most state of the art image generation models, including Ideogram, Fl
 1. Get [an OpenAI API key](https://platform.openai.com/settings/organization/api-keys).
 2. Setup your OpenAI API key, if you haven't already. See instructions [here](/get-started/setup#add-chat-models)
 3. Create a text to image config at http://localhost:42110/server/admin/database/texttoimagemodelconfig/. Use `model name` `dall-e-3` to use openai for image generation. Make sure to set the `Ai model api` field to the OpenAI AI model api you setup in step 2.
+
+### AI/ML API
+
+1. Get [an AI/ML API key](https://aimlapi.com/app/?utm_source=khoj&utm_medium=github&utm_campaign=integration).
+2. Setup your AI/ML API key, if you haven’t already. See instructions [here](https://aimlapi.com/app/keys).
+3. Create a text to image config at `http://localhost:42110/server/admin/database/texttoimagemodelconfig/`.
+
+      * **Model name**: choose one of the following IDs from our catalog:
+
+     ```
+     dall-e-3
+     dall-e-2
+     openai/gpt-image-1
+     imagen-3.0-generate-002
+     flux/schnell
+     flux-pro
+     flux-pro/v1.1
+     flux-pro/v1.1-ultra
+     flux/dev
+     flux/dev/image-to-image
+     stable-diffusion-v3-medium
+     stable-diffusion-v35-large
+     ```
+   * **AI Model API**: select the “AI/ML API” entry you created in step 2.
+   * Leave all other fields at their defaults.
+
+Now your Khoj instance will route any image-generation prompt through AI/ML API’s high-quality models—just reference the model ID above when configuring.

--- a/documentation/docs/features/search.md
+++ b/documentation/docs/features/search.md
@@ -28,7 +28,7 @@ You are **not required** to configure the search model config when self-hosting.
 
 You may want to configure this if you need better multi-lingual search, want to experiment with different, newer models or the default models do not work for your use-case.
 
-You can use bi-encoder models downloaded locally [from Huggingface](https://huggingface.co/models?library=sentence-transformers), served via the [HuggingFace Inference API](https://endpoints.huggingface.co/), OpenAI API, Azure OpenAI API or any OpenAI Compatible API like Ollama, LiteLLM etc. Follow the steps below to configure your search model:
+You can use bi-encoder models downloaded locally [from Huggingface](https://huggingface.co/models?library=sentence-transformers), served via the [HuggingFace Inference API](https://endpoints.huggingface.co/), OpenAI API, Azure OpenAI API or any OpenAI Compatible API like [AI/ML API](https://aimlapi.com/app/?utm_source=khoj&utm_medium=github&utm_campaign=integration), Ollama, LiteLLM etc. Follow the steps below to configure your search model:
 
 1. Open the [SearchModelConfig](http://localhost:42110/server/admin/database/searchmodelconfig/) page on your Khoj admin panel.
 2. Hit the Plus button to add a new model config or click the id of an existing model config to edit it.

--- a/documentation/docs/get-started/setup.mdx
+++ b/documentation/docs/get-started/setup.mdx
@@ -264,7 +264,7 @@ Using Ollama? See the [Ollama Integration](/advanced/ollama) section for more cu
 1. Create a new [AI Model Api](http://localhost:42110/server/admin/database/aimodelapi/add) in the server admin settings.
    - Add your [OpenAI API key](https://platform.openai.com/api-keys)
    - Give the configuration a friendly name like `OpenAI`
-   - (Optional) Set the API base URL. It is only relevant if you're using another OpenAI-compatible proxy server like [Ollama](/advanced/ollama) or [LMStudio](/advanced/lmstudio).<br />
+   - (Optional) Set the API base URL. It is only relevant if you're using another OpenAI-compatible proxy server like [AI/ML API](/advanced/aimlapi) [Ollama](/advanced/ollama) or [LMStudio](/advanced/lmstudio).<br />
 ![example configuration for ai model api](/img/example_openai_processor_config.png)
 2. Create a new [chat model](http://localhost:42110/server/admin/database/chatmodel/add)
     - Set the `chat-model` field to an [OpenAI chat model](https://platform.openai.com/docs/models). Example: `gpt-4o`.


### PR DESCRIPTION
Adds comprehensive integration of AI/ML API across the docs:

* **Enhanced Chat Model Options**: Updated the “Chat Model” section to include AI/ML API as a supported provider alongside OpenAI, Anthropic, and Gemini.
* **AI Model API Config**: Expanded instructions in `admin.md` to show how to register AI/ML API credentials and endpoint; updated the OpenAI-proxy guide to list AI/ML API among compatible providers.
* **New AI/ML API Reference**: Introduced `advanced/aimlapi.md`, a standalone setup guide covering key steps—API key retrieval, Khoj admin configuration, chat model setup, and troubleshooting tips.
* **Image Generation**: Added a “AI/ML API” section to `image_generation.md`, listing supported model IDs and simple config steps for text-to-image within Khoj.
* **Search Configuration**: Updated `search.md` to include AI/ML API as an option for embedding models.
* **Get-Started Setup**: Tweaked the initial setup flow to reference AI/ML API as an alternative OpenAI-compatible proxy.

All existing content and formatting have been preserved; this PR simply appends AI/ML API integration points where relevant.
