### PR TITLE
allow setting the directory for the embedded postgres db with PGSERVER_DATA_DIR

### DIFF
--- a/src/khoj/app/settings.py
+++ b/src/khoj/app/settings.py
@@ -139,10 +139,10 @@ if USE_EMBEDDED_DB:
         import pgserver
 
         # Set up data directory
-        PGSERVER_DATA_DIR = os.path.join(BASE_DIR, "pgserver_data")
+        PGSERVER_DATA_DIR = os.getenv("PGSERVER_DATA_DIR") or os.path.join(BASE_DIR, "pgserver_data")
         os.makedirs(PGSERVER_DATA_DIR, exist_ok=True)
 
-        logger.debug(f"Initializing embedded Postgres DB with data directory: {PGSERVER_DATA_DIR}")
+        logger.info(f"Initializing embedded Postgres DB with data directory: {PGSERVER_DATA_DIR}")
 
         # Start server
         PGSERVER_INSTANCE = pgserver.get_server(PGSERVER_DATA_DIR)


### PR DESCRIPTION
I was playing around with this, and ended up blowing away some data by destroying my `.venv`. 

It seems to me that it would be useful to be able to be explicit about where the embedded database should live - as well as where it _does_ live (via the info log), when not specifying.