### PR TITLE
docs: fix grammatical erros in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@
 [Khoj](https://khoj.dev) is a personal AI app to extend your capabilities. It smoothly scales up from an on-device personal AI to a cloud-scale enterprise AI.
 
 - Chat with any local or online LLM (e.g llama3, qwen, gemma, mistral, gpt, claude, gemini, deepseek).
-- Get answers from the internet and your docs (including image, pdf, markdown, org-mode, word, notion files).
-- Access it from your Browser, Obsidian, Emacs, Desktop, Phone or Whatsapp.
+- Get answers from the internet and your docs (including image, PDF, markdown, org-mode, Word, and Notion files).
+- Access it from your Browser, Obsidian, Emacs, Desktop, Phone or WhatsApp.
 - Create agents with custom knowledge, persona, chat model and tools to take on any role.
 - Automate away repetitive research. Get personal newsletters and smart notifications delivered to your inbox.
 - Find relevant docs quickly and easily using our advanced semantic search.
-- Generate images, talk out loud, play your messages.
+- Generate images, talk out loud, and play your messages.
 - Khoj is open-source, self-hostable. Always.
 - Run it privately on [your computer](https://docs.khoj.dev/get-started/setup) or try it on our [cloud app](https://app.khoj.dev).
 


### PR DESCRIPTION
Fixed punctuation errors in the README.md document to improve clarity and readability. Minor grammar and formatting adjustments were made for consistency across the documentation.

