### PR TITLE
Add 'obsidian' EntrySource to distinguish plugin-imported content

### DIFF
--- a/src/khoj/database/models/__init__.py
+++ b/src/khoj/database/models/__init__.py
@@ -781,6 +781,7 @@ class Entry(DbBaseModel):
         COMPUTER = "computer"
         NOTION = "notion"
         GITHUB = "github"
+        OBSIDIAN = "obsidian"
 
     user = models.ForeignKey(KhojUser, on_delete=models.CASCADE, default=None, null=True, blank=True)
     agent = models.ForeignKey(Agent, on_delete=models.CASCADE, default=None, null=True, blank=True)

--- a/src/khoj/processor/content/docx/docx_to_entries.py
+++ b/src/khoj/processor/content/docx/docx_to_entries.py
@@ -18,7 +18,9 @@ class DocxToEntries(TextToEntries):
         super().__init__()
 
     # Define Functions
-    def process(self, files: dict[str, str], user: KhojUser, regenerate: bool = False) -> Tuple[int, int]:
+    def process(
+        self, files: dict[str, str], user: KhojUser, regenerate: bool = False, file_source: str = None
+    ) -> Tuple[int, int]:
         # Extract required fields from config
         deletion_file_names = set([file for file in files if files[file] == b""])
         files_to_process = set(files) - deletion_file_names
@@ -38,7 +40,7 @@ class DocxToEntries(TextToEntries):
                 user,
                 current_entries,
                 DbEntry.EntryType.DOCX,
-                DbEntry.EntrySource.COMPUTER,
+                file_source or DbEntry.EntrySource.COMPUTER,
                 "compiled",
                 logger,
                 deletion_file_names,

--- a/src/khoj/processor/content/images/image_to_entries.py
+++ b/src/khoj/processor/content/images/image_to_entries.py
@@ -17,7 +17,9 @@ class ImageToEntries(TextToEntries):
         super().__init__()
 
     # Define Functions
-    def process(self, files: dict[str, str], user: KhojUser, regenerate: bool = False) -> Tuple[int, int]:
+    def process(
+        self, files: dict[str, str], user: KhojUser, regenerate: bool = False, file_source: str = None
+    ) -> Tuple[int, int]:
         # Extract required fields from config
         deletion_file_names = set([file for file in files if files[file] == b""])
         files_to_process = set(files) - deletion_file_names
@@ -37,7 +39,7 @@ class ImageToEntries(TextToEntries):
                 user,
                 current_entries,
                 DbEntry.EntryType.IMAGE,
-                DbEntry.EntrySource.COMPUTER,
+                file_source or DbEntry.EntrySource.COMPUTER,
                 "compiled",
                 logger,
                 deletion_file_names,

--- a/src/khoj/processor/content/markdown/markdown_to_entries.py
+++ b/src/khoj/processor/content/markdown/markdown_to_entries.py
@@ -18,7 +18,9 @@ class MarkdownToEntries(TextToEntries):
         super().__init__()
 
     # Define Functions
-    def process(self, files: dict[str, str], user: KhojUser, regenerate: bool = False) -> Tuple[int, int]:
+    def process(
+        self, files: dict[str, str], user: KhojUser, regenerate: bool = False, file_source: str = None
+    ) -> Tuple[int, int]:
         # Extract required fields from config
         deletion_file_names = set([file for file in files if files[file] == ""])
         files_to_process = set(files) - deletion_file_names
@@ -39,7 +41,7 @@ class MarkdownToEntries(TextToEntries):
                 user,
                 current_entries,
                 DbEntry.EntryType.MARKDOWN,
-                DbEntry.EntrySource.COMPUTER,
+                file_source or DbEntry.EntrySource.COMPUTER,
                 "compiled",
                 logger,
                 deletion_file_names,

--- a/src/khoj/processor/content/org_mode/org_to_entries.py
+++ b/src/khoj/processor/content/org_mode/org_to_entries.py
@@ -19,7 +19,9 @@ class OrgToEntries(TextToEntries):
         super().__init__()
 
     # Define Functions
-    def process(self, files: dict[str, str], user: KhojUser, regenerate: bool = False) -> Tuple[int, int]:
+    def process(
+        self, files: dict[str, str], user: KhojUser, regenerate: bool = False, file_source: str = None
+    ) -> Tuple[int, int]:
         deletion_file_names = set([file for file in files if files[file] == ""])
         files_to_process = set(files) - deletion_file_names
         files = {file: files[file] for file in files_to_process}
@@ -38,7 +40,7 @@ class OrgToEntries(TextToEntries):
                 user,
                 current_entries,
                 DbEntry.EntryType.ORG,
-                DbEntry.EntrySource.COMPUTER,
+                file_source or DbEntry.EntrySource.COMPUTER,
                 "compiled",
                 logger,
                 deletion_file_names,

--- a/src/khoj/processor/content/pdf/pdf_to_entries.py
+++ b/src/khoj/processor/content/pdf/pdf_to_entries.py
@@ -21,7 +21,9 @@ class PdfToEntries(TextToEntries):
         super().__init__()
 
     # Define Functions
-    def process(self, files: dict[str, str], user: KhojUser, regenerate: bool = False) -> Tuple[int, int]:
+    def process(
+        self, files: dict[str, str], user: KhojUser, regenerate: bool = False, file_source: str = None
+    ) -> Tuple[int, int]:
         # Extract required fields from config
         deletion_file_names = set([file for file in files if files[file] == b""])
         files_to_process = set(files) - deletion_file_names
@@ -41,7 +43,7 @@ class PdfToEntries(TextToEntries):
                 user,
                 current_entries,
                 DbEntry.EntryType.PDF,
-                DbEntry.EntrySource.COMPUTER,
+                file_source or DbEntry.EntrySource.COMPUTER,
                 "compiled",
                 logger,
                 deletion_file_names,

--- a/src/khoj/processor/content/plaintext/plaintext_to_entries.py
+++ b/src/khoj/processor/content/plaintext/plaintext_to_entries.py
@@ -19,7 +19,9 @@ class PlaintextToEntries(TextToEntries):
         super().__init__()
 
     # Define Functions
-    def process(self, files: dict[str, str], user: KhojUser, regenerate: bool = False) -> Tuple[int, int]:
+    def process(
+        self, files: dict[str, str], user: KhojUser, regenerate: bool = False, file_source: str = None
+    ) -> Tuple[int, int]:
         deletion_file_names = set([file for file in files if files[file] == ""])
         files_to_process = set(files) - deletion_file_names
         files = {file: files[file] for file in files_to_process}
@@ -38,7 +40,7 @@ class PlaintextToEntries(TextToEntries):
                 user,
                 current_entries,
                 DbEntry.EntryType.PLAINTEXT,
-                DbEntry.EntrySource.COMPUTER,
+                file_source or DbEntry.EntrySource.COMPUTER,
                 key="compiled",
                 logger=logger,
                 deletion_filenames=deletion_file_names,

--- a/src/khoj/processor/content/text_to_entries.py
+++ b/src/khoj/processor/content/text_to_entries.py
@@ -30,7 +30,9 @@ class TextToEntries(ABC):
         self.date_filter = DateFilter()
 
     @abstractmethod
-    def process(self, files: dict[str, str], user: KhojUser, regenerate: bool = False) -> Tuple[int, int]: ...
+    def process(
+        self, files: dict[str, str], user: KhojUser, regenerate: bool = False, file_source: str = None
+    ) -> Tuple[int, int]: ...
 
     @staticmethod
     def hash_func(key: str) -> Callable:

--- a/src/khoj/routers/api_content.py
+++ b/src/khoj/routers/api_content.py
@@ -581,6 +581,11 @@ async def indexer(
             docx=index_files["docx"],
         )
 
+        # Determine file_source based on client type
+        file_source = DbEntry.EntrySource.COMPUTER
+        if client and client.lower() == "obsidian":
+            file_source = DbEntry.EntrySource.OBSIDIAN
+
         loop = asyncio.get_event_loop()
         success = await loop.run_in_executor(
             None,
@@ -589,6 +594,7 @@ async def indexer(
             indexer_input.model_dump(),
             regenerate,
             t,
+            file_source,
         )
         if not success:
             raise RuntimeError(f"Failed to {method} {t} data sent by {client} client into content index")

--- a/src/khoj/routers/helpers.py
+++ b/src/khoj/routers/helpers.py
@@ -3003,6 +3003,7 @@ def configure_content(
     files: Optional[dict[str, dict[str, str]]],
     regenerate: bool = False,
     t: Optional[state.SearchType] = state.SearchType.All,
+    file_source: Optional[str] = None,
 ) -> bool:
     success = True
     if t is None:
@@ -3036,6 +3037,7 @@ def configure_content(
                 files.get("org"),
                 regenerate=regenerate,
                 user=user,
+                file_source=file_source,
             )
     except Exception as e:
         logger.error(f"🚨 Failed to setup org: {e}", exc_info=True)
@@ -3053,6 +3055,7 @@ def configure_content(
                 files.get("markdown"),
                 regenerate=regenerate,
                 user=user,
+                file_source=file_source,
             )
 
     except Exception as e:
@@ -3071,6 +3074,7 @@ def configure_content(
                 files.get("pdf"),
                 regenerate=regenerate,
                 user=user,
+                file_source=file_source,
             )
 
     except Exception as e:
@@ -3089,6 +3093,7 @@ def configure_content(
                 files.get("plaintext"),
                 regenerate=regenerate,
                 user=user,
+                file_source=file_source,
             )
 
     except Exception as e:
@@ -3149,6 +3154,7 @@ def configure_content(
                 files.get("image"),
                 regenerate=regenerate,
                 user=user,
+                file_source=file_source,
             )
     except Exception as e:
         logger.error(f"🚨 Failed to setup images: {e}", exc_info=True)
@@ -3161,6 +3167,7 @@ def configure_content(
                 files.get("docx"),
                 regenerate=regenerate,
                 user=user,
+                file_source=file_source,
             )
     except Exception as e:
         logger.error(f"🚨 Failed to setup docx: {e}", exc_info=True)

--- a/src/khoj/search_type/text_search.py
+++ b/src/khoj/search_type/text_search.py
@@ -212,14 +212,15 @@ def setup(
     regenerate: bool,
     user: KhojUser,
     config=None,
+    file_source: str = None,
 ) -> Tuple[int, int]:
     if config:
         num_new_embeddings, num_deleted_embeddings = text_to_entries(config).process(
-            files=files, user=user, regenerate=regenerate
+            files=files, user=user, regenerate=regenerate, file_source=file_source
         )
     else:
         num_new_embeddings, num_deleted_embeddings = text_to_entries().process(
-            files=files, user=user, regenerate=regenerate
+            files=files, user=user, regenerate=regenerate, file_source=file_source
         )
 
     if files:


### PR DESCRIPTION
## Summary
- Add `OBSIDIAN` value to `EntrySource` enum for content imported via Obsidian plugin
- Pass `file_source` parameter through the indexing pipeline:
  - `indexer` -> `configure_content` -> `text_search.setup` -> content processors
- Detect Obsidian client in the indexer API and set appropriate `file_source`
- Update all content processors to accept and propagate `file_source` parameter

## Motivation
This enables users to specifically target Obsidian-imported content for operations like deletion, filtering, or querying without affecting content from other sources (desktop client, manual ingestion, etc.).

## Test plan
- [x] Ruff lint passes
- [x] Ruff format passes
- [ ] CI tests pass

Fixes #1239