### PR TITLE
Remove redundant SDK version check in LauncherActivity of Android app

### DIFF
--- a/src/interface/android/app/src/main/java/dev/khoj/app/LauncherActivity.java
+++ b/src/interface/android/app/src/main/java/dev/khoj/app/LauncherActivity.java
@@ -17,7 +17,6 @@ package dev.khoj.app;
 
 import android.content.pm.ActivityInfo;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 
 
@@ -35,11 +34,7 @@ public class LauncherActivity
         // Oreo and below. We only set the orientation on Oreo and above. This only affects the
         // splash screen and Chrome will still respect the orientation.
         // See https://github.com/GoogleChromeLabs/bubblewrap/issues/496 for details.
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
-        } else {
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
-        }
+        setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
     }
 
     @Override


### PR DESCRIPTION
Remove redundant SDK version check in LauncherActivity since both branches set the same orientation value. This simplifies the code without changing behavior