### PR TITLE
Allow disabling auto-scroll on new token in web chat

### DIFF
--- a/src/interface/web/app/common/utils.ts
+++ b/src/interface/web/app/common/utils.ts
@@ -19,6 +19,8 @@ const locationFetcher = () =>
 export const toTitleCase = (str: string) =>
     str.replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase());
 
+export const AUTO_SCROLL_ON_STREAM_SETTING_KEY = "chat_auto_scroll_on_stream";
+
 export function welcomeConsole() {
     console.log(
         `%c %s`,

--- a/src/interface/web/app/components/chatHistory/chatHistory.tsx
+++ b/src/interface/web/app/components/chatHistory/chatHistory.tsx
@@ -22,7 +22,10 @@ import AgentProfileCard from "../profileCard/profileCard";
 import { getIconFromIconName } from "@/app/common/iconUtils";
 import { AgentData } from "@/app/components/agentCard/agentCard";
 import React from "react";
-import { useIsMobileWidth } from "@/app/common/utils";
+import {
+    AUTO_SCROLL_ON_STREAM_SETTING_KEY,
+    useIsMobileWidth,
+} from "@/app/common/utils";
 import { Button } from "@/components/ui/button";
 import { KhojLogo } from "../logo/khojLogo";
 
@@ -279,10 +282,26 @@ export default function ChatHistory(props: ChatHistoryProps) {
     >(null);
     const [fetchingData, setFetchingData] = useState(false);
     const [isNearBottom, setIsNearBottom] = useState(true);
+    const [autoScrollOnStream, setAutoScrollOnStream] = useState(true);
+    const hasActiveStreamingMessage =
+        props.incomingMessages?.some((message) => !message.completed) ?? false;
     const isMobileWidth = useIsMobileWidth();
     const scrollAreaSelector = "[data-radix-scroll-area-viewport]";
     const fetchMessageCount = 10;
     const hasStartingMessage = localStorage.getItem("message");
+
+    useEffect(() => {
+        const storedPreference = localStorage.getItem(AUTO_SCROLL_ON_STREAM_SETTING_KEY);
+        setAutoScrollOnStream(storedPreference !== "false");
+
+        const onStorageUpdate = (event: StorageEvent) => {
+            if (event.key !== AUTO_SCROLL_ON_STREAM_SETTING_KEY) return;
+            setAutoScrollOnStream(event.newValue !== "false");
+        };
+
+        window.addEventListener("storage", onStorageUpdate);
+        return () => window.removeEventListener("storage", onStorageUpdate);
+    }, []);
 
     useEffect(() => {
         const scrollAreaEl = scrollAreaRef.current?.querySelector<HTMLElement>(scrollAreaSelector);
@@ -303,10 +322,15 @@ export default function ChatHistory(props: ChatHistoryProps) {
 
     // Auto scroll while incoming message is streamed
     useEffect(() => {
-        if (props.incomingMessages && props.incomingMessages.length > 0 && isNearBottom) {
+        if (
+            autoScrollOnStream &&
+            props.incomingMessages &&
+            props.incomingMessages.length > 0 &&
+            isNearBottom
+        ) {
             scrollToBottom(true);
         }
-    }, [props.incomingMessages, isNearBottom]);
+    }, [autoScrollOnStream, props.incomingMessages, isNearBottom]);
 
     // ResizeObserver to handle content height changes (e.g., images loading)
     useEffect(() => {
@@ -314,7 +338,7 @@ export default function ChatHistory(props: ChatHistoryProps) {
         const scrollViewport =
             scrollAreaRef.current?.querySelector<HTMLElement>(scrollAreaSelector);
 
-        if (!contentWrapper || !scrollViewport) return;
+        if (!contentWrapper || !scrollViewport || !autoScrollOnStream) return;
 
         const observer = new ResizeObserver(() => {
             // Check current scroll position to decide if auto-scroll is warranted
@@ -340,7 +364,7 @@ export default function ChatHistory(props: ChatHistoryProps) {
 
         observer.observe(contentWrapper);
         return () => observer.disconnect();
-    }, [props.incomingMessages, incompleteIncomingMessageIndex, scrollAreaRef]); // Dependencies
+    }, [autoScrollOnStream, props.incomingMessages, incompleteIncomingMessageIndex, scrollAreaRef]); // Dependencies
 
     // Scroll to most recent user message after the first page of chat messages is loaded.
     useEffect(() => {
@@ -486,6 +510,16 @@ export default function ChatHistory(props: ChatHistoryProps) {
                     5)
         ) {
             setIsNearBottom(true);
+        }
+    };
+
+    const handleToggleAutoScrollOnStream = () => {
+        const nextValue = !autoScrollOnStream;
+        setAutoScrollOnStream(nextValue);
+        localStorage.setItem(AUTO_SCROLL_ON_STREAM_SETTING_KEY, String(nextValue));
+
+        if (nextValue) {
+            scrollToBottom(true);
         }
     };
 
@@ -737,17 +771,34 @@ export default function ChatHistory(props: ChatHistoryProps) {
                     )}
                 </div>
                 <div className={`${props.customClassName} fixed bottom-[20%] z-10`}>
-                    {!isNearBottom && (
-                        <button
-                            title="Scroll to bottom"
-                            className="absolute bottom-0 right-0 bg-white dark:bg-[hsl(var(--background))] text-neutral-500 dark:text-white p-2 rounded-full shadow-xl"
-                            onClick={() => {
-                                scrollToBottom();
-                            }}
-                        >
-                            <ArrowDown size={24} />
-                        </button>
-                    )}
+                    <div className="absolute bottom-0 right-0 flex flex-col gap-2 items-end">
+                        {hasActiveStreamingMessage && (
+                            <button
+                                title={
+                                    autoScrollOnStream
+                                        ? "Pause auto-scroll"
+                                        : "Resume auto-scroll"
+                                }
+                                className="bg-white dark:bg-[hsl(var(--background))] text-neutral-700 dark:text-white px-3 py-2 rounded-full shadow-xl text-xs"
+                                onClick={handleToggleAutoScrollOnStream}
+                            >
+                                {autoScrollOnStream
+                                    ? "Pause auto-scroll"
+                                    : "Resume auto-scroll"}
+                            </button>
+                        )}
+                        {!isNearBottom && (
+                            <button
+                                title="Scroll to bottom"
+                                className="bg-white dark:bg-[hsl(var(--background))] text-neutral-500 dark:text-white p-2 rounded-full shadow-xl"
+                                onClick={() => {
+                                    scrollToBottom();
+                                }}
+                            >
+                                <ArrowDown size={24} />
+                            </button>
+                        )}
+                    </div>
                 </div>
             </div>
         </ScrollArea>

--- a/src/interface/web/app/settings/page.tsx
+++ b/src/interface/web/app/settings/page.tsx
@@ -7,7 +7,11 @@ import { Suspense, useEffect, useState } from "react";
 import { useToast } from "@/components/ui/use-toast";
 
 import { useUserConfig, ModelOptions, UserConfig, SubscriptionStates, isUserSubscribed } from "../common/auth";
-import { toTitleCase, useIsMobileWidth } from "../common/utils";
+import {
+    AUTO_SCROLL_ON_STREAM_SETTING_KEY,
+    toTitleCase,
+    useIsMobileWidth,
+} from "../common/utils";
 
 import { isValidPhoneNumber } from "libphonenumber-js";
 
@@ -338,6 +342,7 @@ export default function SettingsView() {
     const [memories, setMemories] = useState<UserMemorySchema[]>([]);
     const [enableMemory, setEnableMemory] = useState<boolean>(true);
     const [serverMemoryMode, setServerMemoryMode] = useState<string>("enabled_default_on");
+    const [autoScrollOnStream, setAutoScrollOnStream] = useState<boolean>(true);
     const [isExporting, setIsExporting] = useState(false);
     const [exportProgress, setExportProgress] = useState(0);
     const [exportedConversations, setExportedConversations] = useState(0);
@@ -365,6 +370,11 @@ export default function SettingsView() {
         setEnableMemory(initialUserConfig?.enable_memory ?? true);
         setServerMemoryMode(initialUserConfig?.server_memory_mode ?? "enabled_default_on");
     }, [initialUserConfig]);
+
+    useEffect(() => {
+        const storedPreference = localStorage.getItem(AUTO_SCROLL_ON_STREAM_SETTING_KEY);
+        setAutoScrollOnStream(storedPreference !== "false");
+    }, []);
 
     const sendOTP = async () => {
         try {
@@ -717,6 +727,11 @@ export default function SettingsView() {
                 variant: "destructive"
             });
         }
+    };
+
+    const handleToggleAutoScrollOnStream = (enabled: boolean) => {
+        setAutoScrollOnStream(enabled);
+        localStorage.setItem(AUTO_SCROLL_ON_STREAM_SETTING_KEY, String(enabled));
     };
 
 
@@ -1284,6 +1299,34 @@ export default function SettingsView() {
                                                             : "Export Chats"}
                                                     </Button>
                                                 </CardFooter>
+                                            </Card>
+                                            <Card className={cardClassName}>
+                                                <CardHeader className="text-xl flex flex-row">
+                                                    <ChatCircleText className="h-7 w-7 mr-2" />
+                                                    Chat Experience
+                                                </CardHeader>
+                                                <CardContent className="overflow-hidden">
+                                                    <p className="pb-4 text-gray-400">
+                                                        Keep this enabled to follow new tokens as they
+                                                        stream. Disable it to keep your position when
+                                                        reading earlier messages.
+                                                    </p>
+                                                    <div className="flex items-center justify-between">
+                                                        <label
+                                                            htmlFor="auto-scroll-on-stream"
+                                                            className="text-sm font-medium leading-none"
+                                                        >
+                                                            Auto-scroll while responses stream
+                                                        </label>
+                                                        <Switch
+                                                            id="auto-scroll-on-stream"
+                                                            checked={autoScrollOnStream}
+                                                            onCheckedChange={
+                                                                handleToggleAutoScrollOnStream
+                                                            }
+                                                        />
+                                                    </div>
+                                                </CardContent>
                                             </Card>
                                             <Card className={cardClassName}>
                                                 <CardHeader className="text-xl flex flex-row">


### PR DESCRIPTION
Related to https://github.com/khoj-ai/khoj/issues/1252

Description:
- This PR adds user control over streaming auto-scroll in the web chat interface.
- Added a new **Chat Experience** setting: **Auto-scroll while responses stream**.
- Persisted preference via [localStorage] using `chat_auto_scroll_on_stream`.
- Updated chat scrolling behavior to only follow new tokens when the setting is enabled.
- Added an in-chat **Pause/Resume auto-scroll** quick control near the down-arrow button.
- The quick control is intentionally shown only during active streaming to reduce idle UI clutter.