### PR TITLE
Fix context references dropped due to wrong isinstance check

### DIFF
--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -747,7 +747,6 @@ def generate_chatml_messages_with_context(
                 {
                     f"# URI: {item.uri or item.file}\n## {item.compiled}\n"
                     for item in chat.context or []
-                    if isinstance(item, dict)
                 }
             )
             message_context += [{"type": "text", "text": f"{prompts.notes_conversation.format(references=references)}"}]


### PR DESCRIPTION
## Summary

In `generate_chatml_messages_with_context()`, document references from prior conversation turns are never included in the prompt because of an incorrect `isinstance(item, dict)` type check.

## Bug

`chat.context` is `List[Context]` where `Context` is a Pydantic `BaseModel`. After `ChatMessageModel.model_validate()` in the `Conversation.messages` property, context items are `Context` objects, not raw dicts. The `isinstance(item, dict)` guard therefore filters out *all* items, producing an empty `references` string every time.

```python
references = "\n\n".join(
    {
        f"# URI: {item.uri or item.file}\n## {item.compiled}\n"
        for item in chat.context or []
        if isinstance(item, dict)   # <-- always False for Context objects
    }
)
```

## Fix

Remove the `isinstance(item, dict)` guard. The list is already typed as `List[Context]` and validated by Pydantic, so the type check is unnecessary and harmful.

## Impact

Without this fix, the LLM does not see document references from earlier turns in multi-turn conversations, which can degrade response quality when prior context is relevant.