### PR TITLE
Fix operator precedence in research iteration counter

### DIFF
--- a/src/khoj/routers/research.py
+++ b/src/khoj/routers/research.py
@@ -503,7 +503,7 @@ async def research(
 
     # Incorporate previous partial research into current research chat history
     research_conversation_history = [chat for chat in deepcopy(conversation_history) if chat.message]
-    if current_iteration := len(previous_iterations) > 0:
+    if (current_iteration := len(previous_iterations)) > 0:
         logger.info(f"Continuing research with the previous {len(previous_iterations)} iteration results.")
         previous_iterations_history = construct_iteration_history(previous_iterations)
         research_conversation_history += previous_iterations_history


### PR DESCRIPTION
## Summary

Fix a Python operator precedence bug in the `research()` function that causes `current_iteration` to be set to a boolean instead of the actual count of previous iterations.

## Bug

```python
if current_iteration := len(previous_iterations) > 0:
```

Python evaluates this as:
```python
if current_iteration := (len(previous_iterations) > 0):  # assigns True or False
```

So `current_iteration` becomes `True` (1) or `False` (0) regardless of how many previous iterations exist.

## Fix

```python
if (current_iteration := len(previous_iterations)) > 0:
```

With parentheses, `current_iteration` is correctly set to the count (e.g. 4), and then compared to 0.

## Impact

When resuming research with previous iterations, the loop counter was effectively reset to 1 instead of the true count. This allowed the research loop to run significantly more iterations than `MAX_ITERATIONS` intended, wasting compute and API calls.