### PR TITLE
fix: ChatModel.__str__ returns None when friendly_name is null

### DIFF
--- a/src/khoj/database/models/__init__.py
+++ b/src/khoj/database/models/__init__.py
@@ -236,7 +236,7 @@ class ChatModel(DbBaseModel):
     strengths = models.TextField(default=None, null=True, blank=True)
 
     def __str__(self):
-        return self.friendly_name
+        return self.friendly_name or self.name
 
 
 class VoiceModelOption(DbBaseModel):


### PR DESCRIPTION
## Problem
When `ChatModel.friendly_name` is `None`, the `__str__` method returns `None`, causing:
```
TypeError: __str__ returned non-string (type NoneType)
```

Related issue: #1251

## Solution
Fall back to `name` field when `friendly_name` is `None`.

## Changes
- Modified `ChatModel.__str__` to return `self.friendly_name or self.name`

## Testing
```python
# Before fix
class ChatModel:
    friendly_name = None
    name = 'test-model'
    def __str__(self):
        return self.friendly_name  # Returns None -> TypeError

# After fix  
    def __str__(self):
        return self.friendly_name or self.name  # Returns 'test-model'
```