### PR TITLE
fix: ChatModel.__str__ returning None causing Server Error

### DIFF
--- a/src/khoj/database/models/__init__.py
+++ b/src/khoj/database/models/__init__.py
@@ -236,7 +236,7 @@ class ChatModel(DbBaseModel):
     strengths = models.TextField(default=None, null=True, blank=True)
 
     def __str__(self):
-        return self.friendly_name
+        return self.friendly_name or self.name or f"ChatModel({self.id})"
 
 
 class VoiceModelOption(DbBaseModel):


### PR DESCRIPTION
## Bug Fix

Fixes #1251

### Problem
When adding a new ChatModel in Django admin, if `friendly_name` is None, the `__str__` method returns None instead of a string. This causes:

```
TypeError: __str__ returned non-string (type NoneType)
```

### Solution
Fallback chain: `friendly_name` → `name` → `f"ChatModel({self.id})"`

### Testing
- Create ChatModel without friendly_name → no error
- Edit existing ChatModel → works correctly

### Code Change
```python
# Before
def __str__(self):
    return self.friendly_name

# After  
def __str__(self):
    return self.friendly_name or self.name or f"ChatModel({self.id})"
```