### PR TITLE
Close leaked file handle in orgnode parser

### DIFF
--- a/src/khoj/processor/content/org_mode/orgnode.py
+++ b/src/khoj/processor/content/org_mode/orgnode.py
@@ -54,8 +54,8 @@ def normalize_filename(filename):
 
 
 def makelist_with_filepath(filename):
-    f = open(filename, "r")
-    return makelist(f, filename)
+    with open(filename, "r") as f:
+        return makelist(f, filename)
 
 
 def makelist(file, filename, start_line: int = 1, ancestry_lines: int = 0) -> List["Orgnode"]:


### PR DESCRIPTION
## Summary

`src/khoj/processor/content/org_mode/orgnode.py:57` opens a file with `open(filename, "r")` but never closes it. The file handle leaks for the lifetime of the returned `Orgnode` list.

## Fix

Replaced bare `open()` with a `with` statement to ensure the file is closed after `makelist()` finishes reading.

```python
# Before
def makelist_with_filepath(filename):
    f = open(filename, "r")
    return makelist(f, filename)

# After
def makelist_with_filepath(filename):
    with open(filename, "r") as f:
        return makelist(f, filename)
```

This is safe because `makelist()` fully consumes the file during the call (building the Orgnode list from file contents), so the file handle is no longer needed after it returns.