### PR TITLE
feat: show autocomplete suggestions for file query filters in web chat

### DIFF
--- a/src/interface/web/app/components/chatInputArea/FileFilterAutocomplete.tsx
+++ b/src/interface/web/app/components/chatInputArea/FileFilterAutocomplete.tsx
@@ -1,0 +1,302 @@
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { CircleNotch } from "@phosphor-icons/react";
+
+import { getIconFromFilename } from "@/app/common/iconUtils";
+
+const MAX_VISIBLE_SUGGESTIONS = 8;
+
+interface FileListItem {
+    file_name: string;
+}
+
+interface FileListResponse {
+    files: FileListItem[];
+    num_pages: number;
+}
+
+interface FileFilterAutocompleteProps {
+    query: string;
+    onSelect: (file: string) => void;
+    onClose: () => void;
+    isVisible: boolean;
+}
+
+type FileFilterAutocompleteKeyboardEvent = Pick<
+    React.KeyboardEvent<HTMLTextAreaElement>,
+    "altKey" | "ctrlKey" | "key" | "metaKey" | "preventDefault" | "shiftKey"
+>;
+
+export interface FileFilterAutocompleteHandle {
+    handleKeyDown: (event: FileFilterAutocompleteKeyboardEvent) => boolean;
+}
+
+let cachedFilePaths: string[] | null = null;
+let pendingFilePathsRequest: Promise<string[]> | null = null;
+
+async function fetchAllFiles() {
+    if (cachedFilePaths) {
+        return cachedFilePaths;
+    }
+
+    if (pendingFilePathsRequest) {
+        return pendingFilePathsRequest;
+    }
+
+    pendingFilePathsRequest = (async () => {
+        const collectedFiles: string[] = [];
+        let currentPage = 0;
+        let totalPages = 1;
+
+        while (currentPage < totalPages) {
+            const response = await fetch(`/api/content/files?page=${currentPage}`);
+
+            if (!response.ok) {
+                throw new Error(`Failed to fetch files: ${response.status}`);
+            }
+
+            const data = (await response.json()) as FileListResponse;
+            collectedFiles.push(...data.files.map((file) => file.file_name));
+            totalPages = Math.max(data.num_pages || 0, currentPage + 1);
+            currentPage += 1;
+        }
+
+        cachedFilePaths = Array.from(new Set(collectedFiles)).sort((firstFile, secondFile) =>
+            firstFile.localeCompare(secondFile),
+        );
+
+        return cachedFilePaths;
+    })();
+
+    try {
+        return await pendingFilePathsRequest;
+    } finally {
+        pendingFilePathsRequest = null;
+    }
+}
+
+function getMatchingFiles(allFiles: string[], query: string) {
+    const normalizedQuery = query.trim().toLowerCase();
+    const matchingFiles = normalizedQuery
+        ? allFiles.filter((file) => file.toLowerCase().includes(normalizedQuery))
+        : allFiles;
+
+    return matchingFiles.slice(0, MAX_VISIBLE_SUGGESTIONS);
+}
+
+function getDisplayFileName(filePath: string) {
+    const pathParts = filePath.split(/[\\/]/);
+    return pathParts[pathParts.length - 1] || filePath;
+}
+
+const FileFilterAutocomplete = forwardRef<
+    FileFilterAutocompleteHandle,
+    FileFilterAutocompleteProps
+>((props, ref) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [files, setFiles] = useState<string[]>(cachedFilePaths ?? []);
+    const [loading, setLoading] = useState(cachedFilePaths === null);
+    const [error, setError] = useState<string | null>(null);
+    const [activeIndex, setActiveIndex] = useState(0);
+
+    const matchingFiles = getMatchingFiles(files, props.query);
+
+    useEffect(() => {
+        if (!props.isVisible) {
+            return;
+        }
+
+        let isCancelled = false;
+
+        if (cachedFilePaths) {
+            setFiles(cachedFilePaths);
+            setLoading(false);
+            setError(null);
+            return;
+        }
+
+        setLoading(true);
+        setError(null);
+
+        fetchAllFiles()
+            .then((loadedFiles) => {
+                if (isCancelled) {
+                    return;
+                }
+
+                setFiles(loadedFiles);
+            })
+            .catch((error) => {
+                if (isCancelled) {
+                    return;
+                }
+
+                console.error("Error loading synced files:", error);
+                setError("Failed to load synced files.");
+            })
+            .finally(() => {
+                if (isCancelled) {
+                    return;
+                }
+
+                setLoading(false);
+            });
+
+        return () => {
+            isCancelled = true;
+        };
+    }, [props.isVisible]);
+
+    useEffect(() => {
+        if (props.isVisible) {
+            setActiveIndex(0);
+        }
+    }, [files.length, props.isVisible, props.query]);
+
+    useEffect(() => {
+        if (!props.isVisible) {
+            return;
+        }
+
+        function handlePointerDown(event: MouseEvent | TouchEvent) {
+            if (containerRef.current?.contains(event.target as Node)) {
+                return;
+            }
+
+            props.onClose();
+        }
+
+        document.addEventListener("mousedown", handlePointerDown);
+        document.addEventListener("touchstart", handlePointerDown);
+
+        return () => {
+            document.removeEventListener("mousedown", handlePointerDown);
+            document.removeEventListener("touchstart", handlePointerDown);
+        };
+    }, [props.isVisible, props.onClose]);
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            handleKeyDown(event) {
+                if (!props.isVisible || event.altKey || event.ctrlKey || event.metaKey) {
+                    return false;
+                }
+
+                if (event.key === "Escape") {
+                    event.preventDefault();
+                    props.onClose();
+                    return true;
+                }
+
+                if (loading || error || matchingFiles.length === 0) {
+                    return false;
+                }
+
+                if (event.key === "ArrowDown") {
+                    event.preventDefault();
+                    setActiveIndex((previousIndex) => (previousIndex + 1) % matchingFiles.length);
+                    return true;
+                }
+
+                if (event.key === "ArrowUp") {
+                    event.preventDefault();
+                    setActiveIndex(
+                        (previousIndex) =>
+                            (previousIndex - 1 + matchingFiles.length) % matchingFiles.length,
+                    );
+                    return true;
+                }
+
+                if (event.key === "Enter" && !event.shiftKey) {
+                    event.preventDefault();
+
+                    const selectedFile = matchingFiles[activeIndex] || matchingFiles[0];
+                    if (!selectedFile) {
+                        return false;
+                    }
+
+                    props.onSelect(selectedFile);
+                    return true;
+                }
+
+                return false;
+            },
+        }),
+        [
+            activeIndex,
+            error,
+            loading,
+            matchingFiles,
+            props.isVisible,
+            props.onClose,
+            props.onSelect,
+        ],
+    );
+
+    if (!props.isVisible) {
+        return null;
+    }
+
+    return (
+        <div
+            ref={containerRef}
+            className="absolute left-0 right-0 top-full z-50 mt-2 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
+        >
+            <div className="border-b px-3 py-2 text-xs font-medium text-muted-foreground">
+                Synced files
+            </div>
+            {loading ? (
+                <div className="flex items-center gap-2 px-3 py-4 text-sm text-muted-foreground">
+                    <CircleNotch className="h-4 w-4 animate-spin" />
+                    Loading synced files...
+                </div>
+            ) : error ? (
+                <div className="px-3 py-4 text-sm text-destructive">{error}</div>
+            ) : matchingFiles.length === 0 ? (
+                <div className="px-3 py-4 text-sm text-muted-foreground">
+                    {props.query ? `No files match "${props.query}".` : "No synced files found."}
+                </div>
+            ) : (
+                <div className="max-h-72 overflow-y-auto py-1">
+                    {matchingFiles.map((file, index) => {
+                        const displayName = getDisplayFileName(file);
+                        const isActive = index === activeIndex;
+
+                        return (
+                            <button
+                                key={file}
+                                type="button"
+                                aria-selected={isActive}
+                                className={`flex w-full items-start gap-3 px-3 py-2 text-left transition-colors ${
+                                    isActive
+                                        ? "bg-accent text-accent-foreground"
+                                        : "hover:bg-accent/60"
+                                }`}
+                                onMouseEnter={() => setActiveIndex(index)}
+                                onClick={() => props.onSelect(file)}
+                            >
+                                <span className="mt-0.5 shrink-0">
+                                    {getIconFromFilename(file, "h-4 w-4 text-muted-foreground")}
+                                </span>
+                                <span className="min-w-0">
+                                    <span className="block truncate text-sm font-medium">
+                                        {displayName}
+                                    </span>
+                                    {displayName !== file && (
+                                        <span className="block truncate text-xs text-muted-foreground">
+                                            {file}
+                                        </span>
+                                    )}
+                                </span>
+                            </button>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+});
+
+FileFilterAutocomplete.displayName = "FileFilterAutocomplete";
+
+export default FileFilterAutocomplete;

--- a/src/interface/web/app/components/chatInputArea/chatInputArea.tsx
+++ b/src/interface/web/app/components/chatInputArea/chatInputArea.tsx
@@ -53,6 +53,7 @@ import {
     DialogTrigger,
 } from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import FileFilterAutocomplete, { FileFilterAutocompleteHandle } from "./FileFilterAutocomplete";
 
 export interface ChatOptions {
     [key: string]: string;
@@ -69,6 +70,25 @@ export enum ChatInputFocus {
     MESSAGE = "message",
     FILE = "file",
     RESEARCH = "research",
+}
+
+interface ActiveFileFilter {
+    query: string;
+    tokenStart: number;
+}
+
+function getActiveFileFilter(inputText: string): ActiveFileFilter | null {
+    const fileFilterMatch = inputText.match(/(^|\s)file:([^"\s]*)$/i);
+
+    if (!fileFilterMatch) {
+        return null;
+    }
+
+    const tokenStart = inputText.length - fileFilterMatch[0].length + fileFilterMatch[1].length;
+    return {
+        query: fileFilterMatch[2] || "",
+        tokenStart,
+    };
 }
 
 interface ChatInputProps {
@@ -91,6 +111,7 @@ export const ChatInputArea = forwardRef<HTMLTextAreaElement, ChatInputProps>((pr
     const [message, setMessage] = useState("");
     const fileInputRef = useRef<HTMLInputElement>(null);
     const fileInputButtonRef = useRef<HTMLButtonElement>(null);
+    const fileAutocompleteRef = useRef<FileFilterAutocompleteHandle>(null);
     const researchModeRef = useRef<HTMLButtonElement>(null);
 
     const [warning, setWarning] = useState<string | null>(null);
@@ -113,11 +134,19 @@ export const ChatInputArea = forwardRef<HTMLTextAreaElement, ChatInputProps>((pr
     const [isDragAndDropping, setIsDragAndDropping] = useState(false);
 
     const [showCommandList, setShowCommandList] = useState(false);
+    const [showFileAutocomplete, setShowFileAutocomplete] = useState(false);
     const [useResearchMode, setUseResearchMode] = useState<boolean>(
         props.isResearchModeEnabled || false,
     );
 
     const chatInputRef = ref as React.MutableRefObject<HTMLTextAreaElement>;
+    const activeFileFilter = getActiveFileFilter(message);
+
+    function setMessageValue(nextMessage: string) {
+        setMessage(nextMessage);
+        setShowFileAutocomplete(Boolean(getActiveFileFilter(nextMessage)));
+    }
+
     useEffect(() => {
         if (!uploading) {
             setProgressValue(0);
@@ -137,7 +166,7 @@ export const ChatInputArea = forwardRef<HTMLTextAreaElement, ChatInputProps>((pr
 
     useEffect(() => {
         if (props.prefillMessage === undefined) return;
-        setMessage(props.prefillMessage);
+        setMessageValue(props.prefillMessage);
         chatInputRef?.current?.focus();
     }, [props.prefillMessage]);
 
@@ -192,7 +221,7 @@ export const ChatInputArea = forwardRef<HTMLTextAreaElement, ChatInputProps>((pr
         // If currently processing, handle interrupt first
         if (props.sendDisabled) {
             props.setTriggeredAbort(true, message.trim());
-            setMessage(""); // Clear the input
+            setMessageValue(""); // Clear the input
             return; // Don't continue with regular message sending
         }
 
@@ -215,11 +244,30 @@ export const ChatInputArea = forwardRef<HTMLTextAreaElement, ChatInputProps>((pr
         props.sendMessage(messageToSend);
         setAttachedFiles(null);
         setConvertedAttachedFiles([]);
-        setMessage("");
+        setMessageValue("");
     }
 
     function handleSlashCommandClick(command: string) {
-        setMessage(`/${command} `);
+        setMessageValue(`/${command} `);
+    }
+
+    function handleFileFilterSelection(filePath: string) {
+        const currentFileFilter = getActiveFileFilter(message);
+        if (!currentFileFilter) {
+            return;
+        }
+
+        const nextMessage = `${message.slice(0, currentFileFilter.tokenStart)}file:"${filePath}"`;
+        setMessageValue(nextMessage);
+
+        requestAnimationFrame(() => {
+            if (!chatInputRef?.current) {
+                return;
+            }
+
+            chatInputRef.current.focus();
+            chatInputRef.current.setSelectionRange(nextMessage.length, nextMessage.length);
+        });
     }
 
     function handleFileButtonClick() {
@@ -355,7 +403,7 @@ export const ChatInputArea = forwardRef<HTMLTextAreaElement, ChatInputProps>((pr
                     }
 
                     const transcription = await response.json();
-                    setMessage(transcription.text.trim());
+                    setMessageValue(transcription.text.trim());
                 } catch (error) {
                     console.error("Error sending audio to server:", error);
                 }
@@ -383,7 +431,7 @@ export const ChatInputArea = forwardRef<HTMLTextAreaElement, ChatInputProps>((pr
                     const transcription = await response.json();
                     mediaRecorder.stream.getTracks().forEach((track) => track.stop());
                     setMediaRecorder(null);
-                    setMessage(transcription.text.trim());
+                    setMessageValue(transcription.text.trim());
                 } catch (error) {
                     console.error("Error sending audio to server:", error);
                 }
@@ -689,6 +737,10 @@ export const ChatInputArea = forwardRef<HTMLTextAreaElement, ChatInputProps>((pr
                             autoFocus={true}
                             value={message}
                             onKeyDown={(e) => {
+                                if (fileAutocompleteRef.current?.handleKeyDown(e)) {
+                                    return;
+                                }
+
                                 if (
                                     e.key === "Enter" &&
                                     !e.shiftKey &&
@@ -702,9 +754,18 @@ export const ChatInputArea = forwardRef<HTMLTextAreaElement, ChatInputProps>((pr
                                     onSendMessage();
                                 }
                             }}
-                            onChange={(e) => setMessage(e.target.value)}
+                            onChange={(e) => setMessageValue(e.target.value)}
                             disabled={recording}
                         />
+                        {props.isLoggedIn && activeFileFilter && (
+                            <FileFilterAutocomplete
+                                ref={fileAutocompleteRef}
+                                query={activeFileFilter.query}
+                                onSelect={handleFileFilterSelection}
+                                onClose={() => setShowFileAutocomplete(false)}
+                                isVisible={showFileAutocomplete}
+                            />
+                        )}
                     </div>
                     <div className="flex items-end pb-2">
                         {recording ? (
@@ -749,7 +810,7 @@ export const ChatInputArea = forwardRef<HTMLTextAreaElement, ChatInputProps>((pr
                                                 className={`${!message || recording || "hidden"} ${props.agentColor ? convertToBGClass(props.agentColor) : "bg-orange-300 hover:bg-orange-500"} rounded-full p-1 m-2 h-auto text-3xl transition transform md:hover:-translate-y-1`}
                                                 disabled={props.sendDisabled || !props.isLoggedIn}
                                                 onClick={() => {
-                                                    setMessage("Listening...");
+                                                    setMessageValue("Listening...");
                                                     setRecording(!recording);
                                                 }}
                                             >


### PR DESCRIPTION
## Summary

Fixes #1182

Adds file filter autocomplete to the Khoj web chat input. When a user types \ile:\ in the chat box, a dropdown appears showing their synced files. The list filters as they type, and clicking a suggestion completes the filter in the input.

## How it works

1. User types \ile:\ in chat input
2. Fetches synced files from \/api/content/files\
3. Shows filtered dropdown below the input
4. User selects a file → input updated with full path
5. Press Escape or click outside to dismiss

## Changes
- Added \FileFilterAutocomplete.tsx\ component
- Updated chat input to detect \ile:\ trigger and show autocomplete

## Testing
- Type \ile:\ in the chat input box
- Verify dropdown appears with synced files
- Type partial filename — verify list filters
- Click a suggestion — verify input is updated
- Press Escape — verify dropdown closes
- Keyboard navigation works (↑↓ arrows + Enter)

Related: The Obsidian plugin has this feature (PR #1128).
This brings the same UX to the web app.

cc @debanjum