### PR TITLE
feat: add Tavily as configurable web search provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ dependencies = [
     "e2b-code-interpreter ~= 1.0.0",
     "mcp >= 1.23.0",
     "pyasn1>=0.6.3",
+    "tavily-python >= 0.5.0",
 ]
 dynamic = ["version"]
 

--- a/src/khoj/processor/tools/online_search.py
+++ b/src/khoj/processor/tools/online_search.py
@@ -46,6 +46,8 @@ FIRECRAWL_API_KEY = os.getenv("FIRECRAWL_API_KEY")
 SEARXNG_URL = os.getenv("KHOJ_SEARXNG_URL")
 # Exa API credentials
 EXA_API_KEY = os.getenv("EXA_API_KEY")
+# Tavily API credentials
+TAVILY_API_KEY = os.getenv("TAVILY_API_KEY")
 
 # Whether to automatically read web pages from search results
 AUTO_READ_WEBPAGE = is_env_var_true("KHOJ_AUTO_READ_WEBPAGE")
@@ -114,6 +116,9 @@ async def search_online(
     if SEARXNG_URL:
         search_engine = "Searxng"
         search_engines.append((search_engine, search_with_searxng))
+    if TAVILY_API_KEY:
+        search_engine = "Tavily"
+        search_engines.append((search_engine, search_with_tavily))
 
     if send_status_func:
         subqueries_str = "\n- " + "\n- ".join(subqueries)
@@ -406,6 +411,50 @@ async def search_with_google(query: str, location: LocationData) -> Tuple[str, D
                 extracted_search_result["knowledgeGraph"] = knowledge_graph
 
             return query, extracted_search_result
+
+
+async def search_with_tavily(query: str, location: LocationData) -> Tuple[str, Dict[str, List[Dict]]]:
+    """
+    Search using Tavily API.
+
+    Args:
+        query: The search query string
+        location: Location data for geolocation-based search
+
+    Returns:
+        Tuple containing the original query and a dictionary of search results
+    """
+    from tavily import AsyncTavilyClient
+
+    try:
+        client = AsyncTavilyClient(api_key=TAVILY_API_KEY)
+        response = await client.search(
+            query=query,
+            max_results=10,
+            search_depth="basic",
+            topic="general",
+        )
+
+        results = response.get("results", [])
+        if is_none_or_empty(results):
+            return query, {}
+
+        organic_results = []
+        for item in results:
+            organic_results.append(
+                {
+                    "title": item.get("title", ""),
+                    "link": item.get("url", ""),
+                    "snippet": item.get("content", ""),
+                    "content": item.get("raw_content", None),
+                }
+            )
+
+        return query, {"organic": organic_results}
+
+    except Exception as e:
+        logger.error(f"Error searching with Tavily: {str(e)}")
+        return query, {}
 
 
 async def search_with_serper(query: str, location: LocationData) -> Tuple[str, Dict[str, List[Dict]]]:


### PR DESCRIPTION
## Summary
- Added Tavily as a new web search engine option in the online search module
- Tavily is used when `TAVILY_API_KEY` environment variable is set
- Existing search providers (Serper, Exa, Firecrawl, Google, SearXNG) are unchanged
- Tavily participates in the existing fallback chain automatically

## Files changed
- `src/khoj/processor/tools/online_search.py` — Added `TAVILY_API_KEY` env var, `search_with_tavily()` async function using tavily-python SDK, and registered Tavily in the search engine dispatcher
- `pyproject.toml` — Added `tavily-python >= 0.5.0` to project dependencies

## Dependency changes
- Added `tavily-python >= 0.5.0` to pyproject.toml

## Environment variable changes
- Added `TAVILY_API_KEY` — set this to enable Tavily as a search provider

## Notes for reviewers
- The `search_with_tavily()` function normalizes results to the same `{organic: [{title, link, snippet, content}]}` format used by all other providers
- Uses `AsyncTavilyClient` for async compatibility with the existing `asyncio.gather` pattern
- The import is done inside the function to avoid import errors when tavily-python is not installed or TAVILY_API_KEY is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily web search integration is well-implemented and additive. It correctly uses `AsyncTavilyClient`, maps result fields to the expected `{"organic": [...]}` format, registers in the dispatcher only when the API key is present, and adds the dependency to pyproject.toml. No regressions to existing providers. Three minor issues noted but none are blocking.
