### PR TITLE
feat: add Tavily Extract as pluggable web scraper option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ dependencies = [
     "e2b-code-interpreter ~= 1.0.0",
     "mcp >= 1.23.0",
     "pyasn1>=0.6.3",
+    "tavily-python >= 0.5.0",
 ]
 dynamic = ["version"]
 

--- a/src/khoj/database/adapters/__init__.py
+++ b/src/khoj/database/adapters/__init__.py
@@ -1525,6 +1525,16 @@ class ConversationAdapters:
                         api_url=api_url,
                     )
                 )
+            if os.getenv("TAVILY_API_KEY"):
+                api_url = os.getenv("TAVILY_API_URL", "https://api.tavily.com")
+                enabled_scrapers.append(
+                    WebScraper(
+                        type=WebScraper.WebScraperType.TAVILY,
+                        name=WebScraper.WebScraperType.TAVILY.capitalize(),
+                        api_key=os.getenv("TAVILY_API_KEY"),
+                        api_url=api_url,
+                    )
+                )
             # Only enable the direct web page scraper by default in self-hosted single user setups.
             # Useful for reading webpages on your intranet.
             if state.anonymous_mode or in_debug_mode():

--- a/src/khoj/database/migrations/0100_alter_webscraper_type.py
+++ b/src/khoj/database/migrations/0100_alter_webscraper_type.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("database", "0099_usermemory"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="webscraper",
+            name="type",
+            field=models.CharField(
+                choices=[
+                    ("Firecrawl", "Firecrawl"),
+                    ("Olostep", "Olostep"),
+                    ("Exa", "Exa"),
+                    ("Tavily", "Tavily"),
+                    ("Direct", "Direct"),
+                ],
+                default="Direct",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/src/khoj/database/models/__init__.py
+++ b/src/khoj/database/models/__init__.py
@@ -394,6 +394,7 @@ class WebScraper(DbBaseModel):
         FIRECRAWL = "Firecrawl"
         OLOSTEP = "Olostep"
         EXA = "Exa"
+        TAVILY = "Tavily"
         DIRECT = "Direct"
 
     name = models.CharField(
@@ -438,6 +439,8 @@ class WebScraper(DbBaseModel):
                 self.api_url = os.getenv("OLOSTEP_API_URL", "https://agent.olostep.com/olostep-p2p-incomingAPI")
             elif self.type == self.WebScraperType.EXA:
                 self.api_url = os.getenv("EXA_API_URL", "https://api.exa.ai")
+            elif self.type == self.WebScraperType.TAVILY:
+                self.api_url = os.getenv("TAVILY_API_URL", "https://api.tavily.com")
         if self.api_key is None:
             if self.type == self.WebScraperType.FIRECRAWL:
                 self.api_key = os.getenv("FIRECRAWL_API_KEY")
@@ -451,6 +454,10 @@ class WebScraper(DbBaseModel):
                 self.api_key = os.getenv("EXA_API_KEY")
                 if self.api_key is None:
                     error["api_key"] = "Set API key to use Exa. Get API key from https://exa.ai/."
+            elif self.type == self.WebScraperType.TAVILY:
+                self.api_key = os.getenv("TAVILY_API_KEY")
+                if self.api_key is None:
+                    error["api_key"] = "Set API key to use Tavily. Get API key from https://app.tavily.com/."
         if error:
             raise ValidationError(error)
 

--- a/src/khoj/processor/tools/online_search.py
+++ b/src/khoj/processor/tools/online_search.py
@@ -512,6 +512,8 @@ async def scrape_webpage(url, scraper_type=None, api_key=None, api_url=None) -> 
         return await read_webpage_with_olostep(url, api_key, api_url)
     elif scraper_type == WebScraper.WebScraperType.EXA:
         return await read_webpage_with_exa(url, api_key, api_url)
+    elif scraper_type == WebScraper.WebScraperType.TAVILY:
+        return await read_webpage_with_tavily(url, api_key, api_url)
     else:
         return await read_webpage_at_url(url)
 
@@ -646,6 +648,26 @@ async def read_webpage_with_firecrawl(web_url: str, api_key: str, api_url: str) 
             response.raise_for_status()
             response_json = await response.json()
             return response_json["data"]["markdown"]
+
+
+async def read_webpage_with_tavily(web_url: str, api_key: str, api_url: str) -> str:
+    """Extract content from a web page using Tavily Extract API."""
+    tavily_extract_url = f"{api_url}/extract"
+    headers = {"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"}
+    payload = {
+        "urls": [web_url],
+    }
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            tavily_extract_url, json=payload, headers=headers, timeout=WEBPAGE_REQUEST_TIMEOUT
+        ) as response:
+            response.raise_for_status()
+            response_json = await response.json()
+            results = response_json.get("results", [])
+            if results:
+                return results[0].get("raw_content") or results[0].get("text", "")
+            return ""
 
 
 def deduplicate_organic_results(online_results: dict) -> dict:


### PR DESCRIPTION
## Summary
- Added `TAVILY` to `WebScraper.WebScraperType` enum in the database model
- Implemented `read_webpage_with_tavily()` using the Tavily Extract API (`/extract` endpoint) to extract content from URLs, returning raw markdown content
- Added routing branch in `scrape_webpage()` for the new TAVILY scraper type
- Added env-var fallback in `aget_enabled_webscrapers()` adapter so Tavily is auto-discovered when `TAVILY_API_KEY` is set
- Added `TAVILY_API_KEY` and `TAVILY_API_URL` env var resolution in the model's `clean()` method (consistent with existing Exa/Firecrawl/Olostep handling)
- Created Django migration `0100_alter_webscraper_type` for the updated choices field
- Added `tavily-python >= 0.5.0` to `pyproject.toml` dependencies

## Files changed
- `src/khoj/database/models/__init__.py` — Added TAVILY enum value and env var resolution
- `src/khoj/processor/tools/online_search.py` — Added `read_webpage_with_tavily()` and scraper routing
- `src/khoj/database/adapters/__init__.py` — Added TAVILY env-var fallback in adapter
- `src/khoj/database/migrations/0100_alter_webscraper_type.py` — New migration for updated choices
- `pyproject.toml` — Added `tavily-python` dependency

## Environment variable changes
- `TAVILY_API_KEY` — Required to use Tavily web scraper (shared with tavily-web-search unit)
- `TAVILY_API_URL` — Optional, defaults to `https://api.tavily.com`

## Dependency changes
- Added `tavily-python >= 0.5.0` to pyproject.toml

## Notes for reviewers
- The `scrape_webpage_with_fallback()` function requires no changes as it already iterates over all configured WebScraper DB records by priority
- The Tavily Extract API is called via raw HTTP (aiohttp) consistent with the existing scraper implementations, rather than using the tavily-python SDK directly — the SDK dependency is added for potential use by the tavily-web-search unit
- This is an additive change; existing scraper providers are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily web scraper migration is correct and complete. It adds TAVILY to the WebScraperType enum, implements read_webpage_with_tavily() using the Tavily Extract API via raw aiohttp (consistent with how other scrapers are implemented), routes correctly in scrape_webpage(), adds the env-var fallback in aget_enabled_webscrapers(), creates the Django migration, and adds the pyproject.toml dependency. All changes are scoped appropriately and no regressions are introduced. Two minor issues noted below but neither blocks approval.
