### PR TITLE
feat: add Xquik as X/Twitter search engine for online research

### DIFF
--- a/src/khoj/processor/tools/online_search.py
+++ b/src/khoj/processor/tools/online_search.py
@@ -46,6 +46,8 @@ FIRECRAWL_API_KEY = os.getenv("FIRECRAWL_API_KEY")
 SEARXNG_URL = os.getenv("KHOJ_SEARXNG_URL")
 # Exa API credentials
 EXA_API_KEY = os.getenv("EXA_API_KEY")
+# Xquik API credentials (X/Twitter search)
+XQUIK_API_KEY = os.getenv("XQUIK_API_KEY")
 
 # Whether to automatically read web pages from search results
 AUTO_READ_WEBPAGE = is_env_var_true("KHOJ_AUTO_READ_WEBPAGE")
@@ -114,6 +116,9 @@ async def search_online(
     if SEARXNG_URL:
         search_engine = "Searxng"
         search_engines.append((search_engine, search_with_searxng))
+    if XQUIK_API_KEY:
+        search_engine = "Xquik"
+        search_engines.append((search_engine, search_with_xquik))
 
     if send_status_func:
         subqueries_str = "\n- " + "\n- ".join(subqueries)
@@ -355,6 +360,70 @@ async def search_with_searxng(query: str, location: LocationData) -> Tuple[str, 
 
         except Exception as e:
             logger.error(f"Error searching with SearXNG: {str(e)}")
+            return query, {}
+
+
+async def search_with_xquik(query: str, location: LocationData) -> Tuple[str, Dict[str, List[Dict]]]:
+    """
+    Search X/Twitter using Xquik API.
+    Returns real-time social media perspectives, expert opinions, and community sentiment.
+
+    Args:
+        query: The search query string
+        location: Location data (unused — X/Twitter search is global)
+
+    Returns:
+        Tuple containing the original query and a dictionary of search results
+    """
+    xquik_api_url = "https://xquik.com/api/v1/x/tweets/search"
+    headers = {"X-API-Key": XQUIK_API_KEY, "Accept": "application/json"}
+    params = {"q": query, "limit": "10", "queryType": "Top"}
+
+    async with aiohttp.ClientSession() as session:
+        try:
+            async with session.get(
+                xquik_api_url, headers=headers, params=params, timeout=WEBPAGE_REQUEST_TIMEOUT
+            ) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    logger.error(f"Xquik search failed: {error_text[:200]}")
+                    return query, {}
+
+                response_json = await response.json()
+                tweets = response_json.get("tweets", [])
+
+                if is_none_or_empty(tweets):
+                    return query, {}
+
+                organic_results = []
+                for tweet in tweets:
+                    author = tweet.get("author", {})
+                    username = author.get("username", "unknown")
+                    text = tweet.get("text", "")
+                    tweet_id = tweet.get("id", "")
+
+                    likes = tweet.get("likeCount", 0)
+                    retweets = tweet.get("retweetCount", 0)
+                    views = tweet.get("viewCount", 0)
+
+                    engagement = f"{likes} likes, {retweets} RTs"
+                    if views:
+                        engagement += f", {views} views"
+
+                    organic_results.append(
+                        {
+                            "title": f"@{username}: {text[:120]}",
+                            "link": f"https://x.com/{username}/status/{tweet_id}",
+                            "snippet": text,
+                            "content": f"Tweet by @{username}:\n\n{text}\n\nEngagement: {engagement}\n\n"
+                            f"Source: X/Twitter (social media post, represents real-time opinion)",
+                        }
+                    )
+
+                return query, {"organic": organic_results}
+
+        except Exception as e:
+            logger.error(f"Error searching with Xquik: {str(e)}")
             return query, {}
 
 


### PR DESCRIPTION
## Summary

Adds **Xquik** as a sixth search engine for Khoj's online research, alongside Serper, Exa, Firecrawl, Google, and SearXNG. Set `XQUIK_API_KEY` to activate. Returns results in the same `{organic: [...]}` format - zero changes needed elsewhere.

This adds a **social media dimension** to research. Currently all five search engines return web pages (articles, docs, blogs). Xquik searches **X/Twitter** - real-time perspectives, expert opinions, community sentiment, and breaking news that hasn't been written about yet.

## Why this is useful

Research questions like *"What do developers think about X?"* or *"What's the reaction to Y?"* currently only return web articles. With Xquik, Khoj can now surface the actual discussion happening on X/Twitter - primary sources, not just secondary reporting.

Each result includes:
- Full tweet text as `content` (available for extraction/summarization)
- Engagement metrics (likes, RTs, views) for signal quality
- A note marking it as social media (so the LLM treats it as opinion, not authoritative fact)

## Configuration

```bash
# Add to your .env
XQUIK_API_KEY=xk_your_key_here
```

Get a key at [xquik.com](https://xquik.com). $0.00015 per tweet read.

Xquik is registered as a **fallback** search engine (appended after existing engines). If Serper/Exa/etc. return results first, Xquik won't be called. To use Xquik as the primary engine, set only `XQUIK_API_KEY` without other search engine keys.

## Changes

**1 file changed** - `src/khoj/processor/tools/online_search.py`:

1. Added `XQUIK_API_KEY = os.getenv("XQUIK_API_KEY")` constant (line 50)
2. Added `search_with_xquik` to the `search_engines` list when env var is set (line 119)
3. Added `search_with_xquik()` async function following the exact same pattern as `search_with_exa`, `search_with_firecrawl`, etc.

## Pattern compliance

The function follows the exact interface of every other search engine in the file:

```python
async def search_with_xquik(
    query: str, location: LocationData
) -> Tuple[str, Dict[str, List[Dict]]]:
    # Returns: (query, {"organic": [{"title", "link", "snippet", "content"}]})
```

- Same signature as `search_with_exa`, `search_with_serper`, etc.
- Same return format: `(query, {"organic": [...]})`
- Same error handling: logs error, returns `(query, {})`
- Uses `aiohttp.ClientSession` like all other engines
- Uses `WEBPAGE_REQUEST_TIMEOUT` constant
- No new dependencies

## Test plan

- [x] `python -m py_compile src/khoj/processor/tools/online_search.py` - syntax valid
- [x] Function signature matches all other search engines
- [x] Return format matches expected `{"organic": [...]}` structure
- [x] Without `XQUIK_API_KEY` - behavior 100% unchanged (not added to engine list)
- [x] API errors caught and logged, returns empty dict (never breaks the research loop)

Built with [Claude Code](https://claude.ai/code)
