### PR TITLE
Add data/ to .dockerignore to prevent bloat

Applied via garcia ladle from recipe: dockerignore-data

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ scripts/
 src/interface/
 src/telemetry/
 !src/interface/web
+data/


### PR DESCRIPTION
## fix(docker): add data/ to .dockerignore to prevent bloat

**Source:** garcia recipe `dockerignore-data`

### Changes

- `.dockerignore` — adds `data/` to the ignore list

### Why this matters

The `data/` directory can grow large with user-generated content (indexes, caches, embeddings).
Including it in the Docker build context adds unnecessary bloat to every build and slows down
both CI and local development.

### Verification

- [x] Patch applies cleanly against `master`
- [x] No breaking changes (just adds an ignore rule)
- [x] Docker builds still work correctly without the data/ directory

### Branch

```
git checkout pr/dockerignore-data
```

---

*Generated by garcia 🍦*