### PR TITLE
fix(api): reduce max_completion_tokens for Groq to 8192

### DIFF
--- a/src/khoj/processor/conversation/openai/utils.py
+++ b/src/khoj/processor/conversation/openai/utils.py
@@ -58,6 +58,8 @@ openai_async_clients: Dict[str, openai.AsyncOpenAI] = {}
 # Default completion tokens
 # Reduce premature termination, especially when streaming structured responses
 MAX_COMPLETION_TOKENS = 16000
+# Groq API has a lower max_completion_tokens limit
+MAX_COMPLETION_TOKENS_GROQ = 8192
 
 
 def _extract_text_for_instructions(content: Union[str, List, Dict, None]) -> str:
@@ -115,7 +117,9 @@ def completion_with_backoff(
 
     model_kwargs["temperature"] = temperature
     model_kwargs["top_p"] = model_kwargs.get("top_p", 0.95)
-    model_kwargs["max_completion_tokens"] = model_kwargs.get("max_completion_tokens", MAX_COMPLETION_TOKENS)
+    # Set max_completion_tokens with Groq-specific limit
+    default_max_tokens = MAX_COMPLETION_TOKENS_GROQ if is_groq_api(api_base_url) else MAX_COMPLETION_TOKENS
+    model_kwargs["max_completion_tokens"] = model_kwargs.get("max_completion_tokens", default_max_tokens)
 
     formatted_messages = format_message_for_api(messages, model_name, api_base_url)
 
@@ -308,7 +312,9 @@ async def chat_completion_with_backoff(
         model_kwargs.pop("stream_options", None)
 
     model_kwargs["top_p"] = model_kwargs.get("top_p", 0.95)
-    model_kwargs["max_completion_tokens"] = model_kwargs.get("max_completion_tokens", MAX_COMPLETION_TOKENS)
+    # Set max_completion_tokens with Groq-specific limit
+    default_max_tokens = MAX_COMPLETION_TOKENS_GROQ if is_groq_api(api_base_url) else MAX_COMPLETION_TOKENS
+    model_kwargs["max_completion_tokens"] = model_kwargs.get("max_completion_tokens", default_max_tokens)
 
     formatted_messages = format_message_for_api(messages, model_name, api_base_url)
 


### PR DESCRIPTION
## Problem

Groq API has a maximum of 8192 tokens for `max_completion_tokens`, but the code was hardcoded to 16000, causing API errors.

Fixes #1236

## Solution

- Added `MAX_COMPLETION_TOKENS_GROQ` constant (8192)
- Uses Groq-specific limit when `api_base_url` is `api.groq.com`
- Applied to both sync (`completion_with_backoff`) and async (`chat_completion_with_backoff`) functions

## Testing

- Python syntax check passed
- The fix is minimal and follows existing code patterns (similar to how `fields_to_exclude` is handled for Groq in `clean_response_schema`)