### PR TITLE
Make chat export robust and fix export truncation

### DIFF
--- a/src/interface/web/app/settings/page.tsx
+++ b/src/interface/web/app/settings/page.tsx
@@ -572,7 +572,7 @@ export default function SettingsView() {
 
             // Fetch all conversations in batches of 10
             for (let page = 0; page * 10 < total; page++) {
-                const response = await fetch(`/api/chat/export?page=${page}`);
+                const response = await fetch(`/api/chat/export?offset=${page * 10}&limit=10`);
                 const data = await response.json();
                 conversations.push(...data);
 

--- a/src/interface/web/app/settings/page.tsx
+++ b/src/interface/web/app/settings/page.tsx
@@ -95,6 +95,10 @@ import { Progress } from "@/components/ui/progress";
 import JSZip from "jszip";
 import { saveAs } from "file-saver";
 
+// Number of conversations to fetch per request when exporting chats.
+// Keep in sync with the max limit accepted by the /api/chat/export endpoint.
+const EXPORT_BATCH_SIZE = 10;
+
 interface DropdownComponentProps {
     items: ModelOptions[];
     selected: number;
@@ -562,6 +566,7 @@ export default function SettingsView() {
 
             // Get total conversation count
             const statsResponse = await fetch("/api/chat/stats");
+            if (!statsResponse.ok) throw new Error("Failed to fetch conversation count");
             const stats = await statsResponse.json();
             const total = stats.num_conversations;
             setTotalConversations(total);
@@ -570,14 +575,26 @@ export default function SettingsView() {
             const zip = new JSZip();
             const conversations = [];
 
-            // Fetch all conversations in batches of 10
-            for (let page = 0; page * 10 < total; page++) {
-                const response = await fetch(`/api/chat/export?offset=${page * 10}&limit=10`);
+            // Fetch all conversations in batches, stopping on a page shorter than the batch size.
+            // A short page means the server ran out of rows, so it marks the end of the export
+            // more reliably than the total count, which goes stale if conversations are added
+            // while the export runs. The max offset keeps the loop bounded even if the server
+            // were to keep returning full pages, with slack for conversations added mid-export.
+            const maxOffset = total + 2 * EXPORT_BATCH_SIZE;
+            for (let offset = 0; offset <= maxOffset; offset += EXPORT_BATCH_SIZE) {
+                const response = await fetch(
+                    `/api/chat/export?offset=${offset}&limit=${EXPORT_BATCH_SIZE}`,
+                );
+                if (!response.ok) throw new Error("Failed to fetch conversations to export");
                 const data = await response.json();
                 conversations.push(...data);
 
-                setExportedConversations((page + 1) * 10);
-                setExportProgress((((page + 1) * 10) / total) * 100);
+                setExportedConversations(conversations.length);
+                setExportProgress(
+                    total > 0 ? Math.min((conversations.length / total) * 100, 100) : 100,
+                );
+
+                if (data.length < EXPORT_BATCH_SIZE) break;
             }
 
             // Add conversations to zip

--- a/src/khoj/database/adapters/__init__.py
+++ b/src/khoj/database/adapters/__init__.py
@@ -1026,8 +1026,12 @@ class ConversationAdapters:
 
     @staticmethod
     @require_valid_user
-    def get_all_conversations_for_export(user: KhojUser, page: Optional[int] = 0):
-        all_conversations = Conversation.objects.filter(user=user).prefetch_related("agent")[page : page + 10]
+    def get_all_conversations_for_export(user: KhojUser, offset: int = 0, limit: int = 10):
+        all_conversations = (
+            Conversation.objects.filter(user=user)
+            .prefetch_related("agent")
+            .order_by("-updated_at")[offset : offset + limit]
+        )
         histories = []
         for conversation in all_conversations:
             history = {

--- a/src/khoj/database/adapters/__init__.py
+++ b/src/khoj/database/adapters/__init__.py
@@ -1027,10 +1027,12 @@ class ConversationAdapters:
     @staticmethod
     @require_valid_user
     def get_all_conversations_for_export(user: KhojUser, offset: int = 0, limit: int = 10):
+        # Order by immutable fields to keep pagination stable across the multi-request export.
+        # Sorting by updated_at would reshuffle rows mid-export whenever a conversation is written to.
         all_conversations = (
             Conversation.objects.filter(user=user)
             .prefetch_related("agent")
-            .order_by("-updated_at")[offset : offset + limit]
+            .order_by("-created_at", "id")[offset : offset + limit]
         )
         histories = []
         for conversation in all_conversations:

--- a/src/khoj/routers/api_chat.py
+++ b/src/khoj/routers/api_chat.py
@@ -116,8 +116,10 @@ def chat_stats(request: Request, common: CommonQueryParams) -> Response:
 
 @api_chat.get("/export", response_class=Response)
 @requires(["authenticated"])
-def export_conversation(request: Request, common: CommonQueryParams, page: Optional[int] = 1) -> Response:
-    all_conversations = ConversationAdapters.get_all_conversations_for_export(request.user.object, page=page)
+def export_conversation(request: Request, common: CommonQueryParams, offset: int = 0, limit: int = 10) -> Response:
+    all_conversations = ConversationAdapters.get_all_conversations_for_export(
+        request.user.object, offset=offset, limit=limit
+    )
     return Response(content=json.dumps(all_conversations), media_type="application/json", status_code=200)
 
 

--- a/src/khoj/routers/api_chat.py
+++ b/src/khoj/routers/api_chat.py
@@ -14,6 +14,7 @@ from fastapi import (
     APIRouter,
     Depends,
     HTTPException,
+    Query,
     Request,
     WebSocket,
     WebSocketDisconnect,
@@ -116,7 +117,12 @@ def chat_stats(request: Request, common: CommonQueryParams) -> Response:
 
 @api_chat.get("/export", response_class=Response)
 @requires(["authenticated"])
-def export_conversation(request: Request, common: CommonQueryParams, offset: int = 0, limit: int = 10) -> Response:
+def export_conversation(
+    request: Request,
+    common: CommonQueryParams,
+    offset: int = Query(0, ge=0),
+    limit: int = Query(10, ge=1, le=100),
+) -> Response:
     all_conversations = ConversationAdapters.get_all_conversations_for_export(
         request.user.object, offset=offset, limit=limit
     )

--- a/tests/test_conversation_export.py
+++ b/tests/test_conversation_export.py
@@ -1,0 +1,99 @@
+import json
+
+import pytest
+
+from khoj.database.adapters import ConversationAdapters
+from khoj.database.models import Conversation
+
+EXPORT_BATCH_SIZE = 10
+
+
+def export_all_conversations(user, limit=EXPORT_BATCH_SIZE):
+    """Walk the export adapter the way the web client's export loop does.
+
+    Pages until a page shorter than the requested limit comes back, bounded by a max
+    offset so a regression that keeps returning full pages fails instead of hanging.
+    """
+    exported = []
+    max_offset = Conversation.objects.filter(user=user).count() + 2 * limit
+    offset = 0
+    while offset <= max_offset:
+        page = ConversationAdapters.get_all_conversations_for_export(user, offset=offset, limit=limit)
+        exported.extend(page)
+        if len(page) < limit:
+            break
+        offset += limit
+    return exported
+
+
+# ----------------------------------------------------------------------------------------------------
+@pytest.mark.django_db(transaction=True)
+def test_export_conversations_across_pages(default_user):
+    # Arrange
+    for index in range(25):
+        Conversation.objects.create(user=default_user, title=f"conv-{index:02d}")
+
+    # Act
+    titles = [conversation["title"] for conversation in export_all_conversations(default_user)]
+
+    # Assert
+    assert len(titles) == 25, f"Expected 25 conversations, exported {len(titles)}"
+    assert len(set(titles)) == 25, "Export contains duplicate conversations"
+    assert set(titles) == {f"conv-{index:02d}" for index in range(25)}
+
+
+# ----------------------------------------------------------------------------------------------------
+@pytest.mark.django_db(transaction=True)
+def test_export_order_unaffected_by_conversation_update(default_user):
+    """Conversations written to mid-export must not shift rows across page boundaries."""
+    # Arrange
+    for index in range(25):
+        Conversation.objects.create(user=default_user, title=f"conv-{index:02d}")
+    before = [conversation["title"] for conversation in export_all_conversations(default_user)]
+
+    # Act: touch a conversation to bump its auto_now updated_at, as a concurrent write would
+    stale_conversation = Conversation.objects.filter(user=default_user, title="conv-00").first()
+    stale_conversation.save()
+    after = [conversation["title"] for conversation in export_all_conversations(default_user)]
+
+    # Assert
+    assert before == after, "Export order shifted after a conversation was updated"
+    assert len(set(after)) == 25, "Export contains duplicate conversations after an update"
+
+
+# ----------------------------------------------------------------------------------------------------
+@pytest.mark.django_db(transaction=True)
+def test_export_endpoint_paginates_with_offset_and_limit(client, default_user):
+    # Arrange
+    headers = {"Authorization": "Bearer kk-secret"}
+    for index in range(15):
+        Conversation.objects.create(user=default_user, title=f"conv-{index:02d}")
+
+    # Act
+    first = client.get("/api/chat/export?offset=0&limit=10", headers=headers)
+    second = client.get("/api/chat/export?offset=10&limit=10", headers=headers)
+
+    # Assert
+    assert first.status_code == 200 and second.status_code == 200
+    first_titles = [conversation["title"] for conversation in json.loads(first.content)]
+    second_titles = [conversation["title"] for conversation in json.loads(second.content)]
+    assert len(first_titles) == 10 and len(second_titles) == 5
+    assert not set(first_titles) & set(second_titles), "Export endpoint returned overlapping pages"
+
+
+# ----------------------------------------------------------------------------------------------------
+@pytest.mark.django_db(transaction=True)
+def test_export_endpoint_rejects_out_of_range_pagination(client):
+    # Arrange
+    headers = {"Authorization": "Bearer kk-secret"}
+
+    # Act, Assert: negative offsets and limits would raise on the queryset slice, huge limits
+    # would load every conversation into memory at once. Reject them at the API boundary.
+    for query in ["offset=-1", "limit=0", "limit=-5", "limit=101", "limit=1000000"]:
+        response = client.get(f"/api/chat/export?{query}", headers=headers)
+        assert response.status_code == 422, f"Expected 422 for {query}, got {response.status_code}"
+
+    # Act, Assert: the accepted bounds still work
+    for query in ["", "offset=0&limit=1", "offset=0&limit=100"]:
+        response = client.get(f"/api/chat/export?{query}", headers=headers)
+        assert response.status_code == 200, f"Expected 200 for {query}, got {response.status_code}"


### PR DESCRIPTION
## Description
This PR fixes the data truncation issue reported in #1299, where the "Export Chats" feature would download an incomplete `conversations.json` file, missing recent conversations and getting stuck in a loop of duplicate records.

### Root Cause
1. **Broken Slicing:** The database adapter `get_all_conversations_for_export` used the `page` argument directly in the Django queryset slice (`[page : page + 10]`). This meant `page=0` fetched `[0:10]`, `page=1` fetched `[1:11]`, causing massive overlaps and preventing it from ever reaching all records.
2. **Missing Order:** The queryset lacked an explicit `.order_by()`, which could lead to inconsistent pagination results across different databases.
3. **Frontend Mismatch:** The frontend was passing a sequential `page` index, while the backend expected an explicit offset value.

### Changes Made
- **Backend (`adapters/__init__.py`)**: Updated `get_all_conversations_for_export` to accept `offset` and `limit` instead of `page`. Added `.order_by("-updated_at")` to ensure a consistent, predictable order. Fixed the slice to `[offset : offset + limit]`.
- **Backend (`api_chat.py`)**: Updated the `/api/chat/export` route signature to accept `offset` and `limit` query parameters.
- **Frontend (`settings/page.tsx`)**: Updated the `exportChats` loop to explicitly pass `?offset=${page * 10}&limit=10` to the backend.

### How to Test
1. Create more than 10 test conversations in the Khoj app.
2. Navigate to Settings and click "Export Chats".
3. Check the downloaded `conversations.json` file to verify that the total count of unique conversations matches the database count exactly, with zero duplicates.

## Before:

<img width="734" height="517" alt="image" src="https://github.com/user-attachments/assets/56785d99-bfe1-411c-b2b9-e7d1f3b6aff9" />

## After:
<img width="749" height="533" alt="image" src="https://github.com/user-attachments/assets/a53a86b7-e8ec-448d-9e59-0b481e2869c1" />

Fixes #1299
