### PR TITLE
feat: add [ LiteLLM as AI gateway ]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,9 @@ prod = [
 local = [
     "pgserver == 0.1.4",
 ]
+litellm = [
+    "litellm >= 1.30.0",
+]
 dev = [
     "khoj[prod,local]",
     "pytest >= 7.1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ local = [
     "pgserver == 0.1.4",
 ]
 litellm = [
-    "litellm >= 1.30.0",
+    "litellm >= 1.60, < 1.85",
 ]
 dev = [
     "khoj[prod,local]",

--- a/src/khoj/database/adapters/__init__.py
+++ b/src/khoj/database/adapters/__init__.py
@@ -1738,6 +1738,7 @@ class ConversationAdapters:
                 ChatModel.ModelType.ANTHROPIC,
                 ChatModel.ModelType.OPENAI,
                 ChatModel.ModelType.GOOGLE,
+                ChatModel.ModelType.LITELLM,
             ]
         ) and chat_model.ai_model_api:
             return chat_model

--- a/src/khoj/database/migrations/0100_alter_chatmodel_model_type.py
+++ b/src/khoj/database/migrations/0100_alter_chatmodel_model_type.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("database", "0099_usermemory"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="chatmodel",
+            name="model_type",
+            field=models.CharField(
+                choices=[
+                    ("openai", "Openai"),
+                    ("anthropic", "Anthropic"),
+                    ("google", "Google"),
+                    ("litellm", "Litellm"),
+                ],
+                default="google",
+                max_length=200,
+            ),
+        ),
+    ]

--- a/src/khoj/database/models/__init__.py
+++ b/src/khoj/database/models/__init__.py
@@ -222,6 +222,7 @@ class ChatModel(DbBaseModel):
         OPENAI = "openai"
         ANTHROPIC = "anthropic"
         GOOGLE = "google"
+        LITELLM = "litellm"
 
     max_prompt_size = models.IntegerField(default=None, null=True, blank=True)
     subscribed_max_prompt_size = models.IntegerField(default=None, null=True, blank=True)

--- a/src/khoj/processor/conversation/litellm/litellm_chat.py
+++ b/src/khoj/processor/conversation/litellm/litellm_chat.py
@@ -61,6 +61,7 @@ async def converse_litellm(
     model: str = "gpt-4o-mini",
     api_key: Optional[str] = None,
     api_base_url: Optional[str] = None,
+    temperature: float = 0.6,
     deepthought: Optional[bool] = False,
     tracer: dict = {},
 ) -> AsyncGenerator[ResponseWithThought, None]:
@@ -70,7 +71,7 @@ async def converse_litellm(
     async for chunk in litellm_chat_completion_with_backoff(
         messages=messages,
         model_name=model,
-        temperature=0.6,
+        temperature=temperature,
         api_key=api_key,
         api_base_url=api_base_url,
         deepthought=deepthought,

--- a/src/khoj/processor/conversation/litellm/litellm_chat.py
+++ b/src/khoj/processor/conversation/litellm/litellm_chat.py
@@ -1,0 +1,79 @@
+import logging
+from typing import AsyncGenerator, List, Optional
+
+from langchain_core.messages.chat import ChatMessage
+
+from khoj.processor.conversation.litellm.utils import (
+    litellm_chat_completion_with_backoff,
+    litellm_completion_with_backoff,
+    to_litellm_tools,
+)
+from khoj.processor.conversation.utils import (
+    ResponseWithThought,
+    messages_to_print,
+)
+from khoj.utils.helpers import ToolDefinition
+
+logger = logging.getLogger(__name__)
+
+
+def litellm_send_message_to_model(
+    messages,
+    api_key,
+    model: str,
+    response_type="text",
+    response_schema=None,
+    tools: list[ToolDefinition] = None,
+    deepthought=False,
+    api_base_url: str | None = None,
+    tracer: dict = {},
+):
+    """Send message to model via LiteLLM AI Gateway."""
+    model_kwargs: dict = {}
+
+    if tools:
+        model_kwargs["tools"] = to_litellm_tools(tools)
+    elif response_schema:
+        schema_json = response_schema if isinstance(response_schema, dict) else response_schema.model_json_schema()
+        model_kwargs["response_format"] = {
+            "type": "json_schema",
+            "json_schema": {
+                "schema": schema_json,
+                "name": getattr(response_schema, "__name__", "response"),
+            },
+        }
+    elif response_type == "json_object":
+        model_kwargs["response_format"] = {"type": response_type}
+
+    return litellm_completion_with_backoff(
+        messages=messages,
+        model_name=model,
+        api_key=api_key,
+        api_base_url=api_base_url,
+        deepthought=deepthought,
+        model_kwargs=model_kwargs,
+        tracer=tracer,
+    )
+
+
+async def converse_litellm(
+    messages: List[ChatMessage],
+    model: str = "gpt-4o-mini",
+    api_key: Optional[str] = None,
+    api_base_url: Optional[str] = None,
+    deepthought: Optional[bool] = False,
+    tracer: dict = {},
+) -> AsyncGenerator[ResponseWithThought, None]:
+    """Converse with user using LiteLLM AI Gateway."""
+    logger.debug(f"Conversation Context for LiteLLM: {messages_to_print(messages)}")
+
+    async for chunk in litellm_chat_completion_with_backoff(
+        messages=messages,
+        model_name=model,
+        temperature=0.6,
+        api_key=api_key,
+        api_base_url=api_base_url,
+        deepthought=deepthought,
+        tracer=tracer,
+    ):
+        yield chunk

--- a/src/khoj/processor/conversation/litellm/utils.py
+++ b/src/khoj/processor/conversation/litellm/utils.py
@@ -1,0 +1,226 @@
+import json
+import logging
+from time import perf_counter
+from typing import AsyncGenerator, Dict, List, Optional
+
+from langchain_core.messages.chat import ChatMessage
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_random_exponential,
+)
+
+from khoj.processor.conversation.utils import (
+    ResponseWithThought,
+    ToolCall,
+    commit_conversation_trace,
+)
+from khoj.utils.helpers import (
+    ToolDefinition,
+    get_chat_usage_metrics,
+    is_none_or_empty,
+    is_promptrace_enabled,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_COMPLETION_TOKENS = 16000
+
+
+def format_messages_for_litellm(raw_messages: List[ChatMessage]) -> List[dict]:
+    """Format ChatMessage objects into the OpenAI-compatible dict format used by LiteLLM."""
+    formatted_messages = []
+    for message in raw_messages:
+        message_type = message.additional_kwargs.get("message_type")
+        if message_type == "tool_call" and isinstance(message.content, list):
+            content = []
+            for part in message.content:
+                if not isinstance(part, dict) or not part.get("id"):
+                    logger.warning(f"Dropping tool call without valid ID: {part}")
+                    continue
+                content.append(
+                    {
+                        "type": "function",
+                        "id": part.get("id"),
+                        "function": {
+                            "name": part.get("name"),
+                            "arguments": json.dumps(part.get("input", part.get("args", {}))),
+                        },
+                    }
+                )
+            if content:
+                formatted_messages.append({"role": "assistant", "content": None, "tool_calls": content})
+            continue
+        if message_type == "tool_result" and isinstance(message.content, list):
+            for part in message.content:
+                if not isinstance(part, dict):
+                    continue
+                tool_call_id = part.get("id") or part.get("tool_use_id")
+                if not tool_call_id:
+                    continue
+                formatted_messages.append(
+                    {"role": "tool", "tool_call_id": tool_call_id, "content": part.get("content") or "No output"}
+                )
+            continue
+
+        msg: dict = {"role": message.role, "content": message.content}
+        if message.role == "assistant" and not message.content:
+            continue
+        formatted_messages.append(msg)
+    return formatted_messages
+
+
+def to_litellm_tools(tools: List[ToolDefinition]) -> List[Dict] | None:
+    """Transform tool definitions to OpenAI-compatible format for LiteLLM."""
+    if not tools:
+        return None
+    litellm_tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.schema,
+            },
+        }
+        for tool in tools
+    ]
+    return litellm_tools or None
+
+
+@retry(
+    retry=(retry_if_exception_type(Exception)),
+    wait=wait_random_exponential(min=1, max=10),
+    stop=stop_after_attempt(2),
+    before_sleep=before_sleep_log(logger, logging.DEBUG),
+    reraise=True,
+)
+def litellm_completion_with_backoff(
+    messages: List[ChatMessage],
+    model_name: str,
+    api_key: str,
+    api_base_url: Optional[str] = None,
+    temperature: float = 0.6,
+    deepthought: bool = False,
+    model_kwargs: dict = {},
+    tracer: dict = {},
+) -> ResponseWithThought:
+    import litellm
+
+    formatted_messages = format_messages_for_litellm(messages)
+
+    model_kwargs["temperature"] = temperature
+    model_kwargs["max_tokens"] = model_kwargs.get("max_tokens", MAX_COMPLETION_TOKENS)
+
+    response = litellm.completion(
+        model=model_name,
+        messages=formatted_messages,
+        api_key=api_key,
+        api_base=api_base_url,
+        stream=False,
+        **model_kwargs,
+    )
+
+    aggregated_response = response.choices[0].message.content or ""
+    thoughts = ""
+    if hasattr(response.choices[0].message, "reasoning_content"):
+        thoughts = response.choices[0].message.reasoning_content or ""
+
+    tool_calls: list[ToolCall] = []
+    raw_tool_calls = response.choices[0].message.tool_calls
+    if raw_tool_calls:
+        for tool in raw_tool_calls:
+            args = tool.function.arguments
+            if isinstance(args, str):
+                args = json.loads(args)
+            tool_calls.append(ToolCall(name=tool.function.name, args=args, id=tool.id))
+        if thoughts and aggregated_response:
+            thoughts = "\n".join([f"*{line.strip()}*" for line in thoughts.splitlines() if line.strip()])
+            thoughts = f"{thoughts}\n\n{aggregated_response}"
+        else:
+            thoughts = thoughts or aggregated_response
+        aggregated_response = json.dumps([tc.__dict__ for tc in tool_calls])
+
+    # Calculate cost
+    input_tokens = getattr(response.usage, "prompt_tokens", 0) if response.usage else 0
+    output_tokens = getattr(response.usage, "completion_tokens", 0) if response.usage else 0
+    tracer["usage"] = get_chat_usage_metrics(model_name, input_tokens, output_tokens, usage=tracer.get("usage"))
+
+    if is_none_or_empty(aggregated_response):
+        raise ValueError(f"Empty or no response by {model_name} via LiteLLM. Retry if needed.")
+
+    tracer["chat_model"] = model_name
+    tracer["temperature"] = temperature
+    if is_promptrace_enabled():
+        commit_conversation_trace(messages, aggregated_response, tracer)
+
+    return ResponseWithThought(text=aggregated_response, thought=thoughts)
+
+
+@retry(
+    retry=(retry_if_exception_type(Exception)),
+    wait=wait_random_exponential(min=1, max=10),
+    stop=stop_after_attempt(3),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+    reraise=False,
+)
+async def litellm_chat_completion_with_backoff(
+    messages: List[ChatMessage],
+    model_name: str,
+    api_key: str,
+    api_base_url: Optional[str] = None,
+    temperature: float = 0.6,
+    deepthought: bool = False,
+    tracer: dict = {},
+) -> AsyncGenerator[ResponseWithThought, None]:
+    import litellm
+
+    formatted_messages = format_messages_for_litellm(messages)
+
+    model_kwargs: dict = {
+        "temperature": temperature,
+        "max_tokens": MAX_COMPLETION_TOKENS,
+    }
+
+    aggregated_response = ""
+    response_started = False
+    start_time = perf_counter()
+
+    response = await litellm.acompletion(
+        model=model_name,
+        messages=formatted_messages,
+        api_key=api_key,
+        api_base=api_base_url,
+        stream=True,
+        stream_options={"include_usage": True},
+        **model_kwargs,
+    )
+
+    input_tokens, output_tokens = 0, 0
+    async for chunk in response:
+        if not response_started:
+            response_started = True
+            logger.info(f"First response took: {perf_counter() - start_time:.3f} seconds")
+
+        if hasattr(chunk, "usage") and chunk.usage:
+            input_tokens = getattr(chunk.usage, "prompt_tokens", 0) or input_tokens
+            output_tokens = getattr(chunk.usage, "completion_tokens", 0) or output_tokens
+
+        if not chunk.choices:
+            continue
+
+        delta = chunk.choices[0].delta
+        if delta and delta.content:
+            response_chunk = ResponseWithThought(text=delta.content)
+            aggregated_response += delta.content
+            yield response_chunk
+        elif delta and hasattr(delta, "reasoning_content") and delta.reasoning_content:
+            yield ResponseWithThought(thought=delta.reasoning_content)
+
+    tracer["usage"] = get_chat_usage_metrics(model_name, input_tokens, output_tokens, usage=tracer.get("usage"))
+    tracer["chat_model"] = model_name
+    tracer["temperature"] = temperature
+    if is_promptrace_enabled():
+        commit_conversation_trace(messages, aggregated_response, tracer)

--- a/src/khoj/processor/conversation/litellm/utils.py
+++ b/src/khoj/processor/conversation/litellm/utils.py
@@ -7,7 +7,7 @@ from langchain_core.messages.chat import ChatMessage
 from tenacity import (
     before_sleep_log,
     retry,
-    retry_if_exception_type,
+    retry_if_exception,
     stop_after_attempt,
     wait_random_exponential,
 )
@@ -27,6 +27,27 @@ from khoj.utils.helpers import (
 logger = logging.getLogger(__name__)
 
 MAX_COMPLETION_TOKENS = 16000
+
+
+def _is_transient_litellm_error(exc: BaseException) -> bool:
+    """Matches the OpenAI provider's retry policy: retry only on transient /
+    server-side failures. Avoids retrying on user errors (bad API key, malformed
+    request) which would just waste time and confuse debugging.
+
+    Checked by string name to keep the module importable when ``litellm`` is
+    not installed (litellm is an optional extra).
+    """
+    if isinstance(exc, ValueError):
+        # Covers our own "Empty response" ValueError raised below.
+        return True
+    qualname = f"{type(exc).__module__}.{type(exc).__name__}"
+    return qualname in {
+        "litellm.exceptions.APIConnectionError",
+        "litellm.exceptions.Timeout",
+        "litellm.exceptions.RateLimitError",
+        "litellm.exceptions.InternalServerError",
+        "litellm.exceptions.ServiceUnavailableError",
+    }
 
 
 def format_messages_for_litellm(raw_messages: List[ChatMessage]) -> List[dict]:
@@ -91,7 +112,7 @@ def to_litellm_tools(tools: List[ToolDefinition]) -> List[Dict] | None:
 
 
 @retry(
-    retry=(retry_if_exception_type(Exception)),
+    retry=retry_if_exception(_is_transient_litellm_error),
     wait=wait_random_exponential(min=1, max=10),
     stop=stop_after_attempt(2),
     before_sleep=before_sleep_log(logger, logging.DEBUG),
@@ -160,7 +181,7 @@ def litellm_completion_with_backoff(
 
 
 @retry(
-    retry=(retry_if_exception_type(Exception)),
+    retry=retry_if_exception(_is_transient_litellm_error),
     wait=wait_random_exponential(min=1, max=10),
     stop=stop_after_attempt(3),
     before_sleep=before_sleep_log(logger, logging.WARNING),

--- a/src/khoj/routers/helpers.py
+++ b/src/khoj/routers/helpers.py
@@ -91,6 +91,10 @@ from khoj.processor.conversation.google.gemini_chat import (
     converse_gemini,
     gemini_send_message_to_model,
 )
+from khoj.processor.conversation.litellm.litellm_chat import (
+    converse_litellm,
+    litellm_send_message_to_model,
+)
 from khoj.processor.conversation.openai.gpt import (
     converse_openai,
     openai_send_message_to_model,
@@ -179,6 +183,7 @@ async def is_ready_to_chat(user: KhojUser):
                 ChatModel.ModelType.OPENAI,
                 ChatModel.ModelType.ANTHROPIC,
                 ChatModel.ModelType.GOOGLE,
+                ChatModel.ModelType.LITELLM,
             ]
         )
         and user_chat_model.ai_model_api
@@ -1620,6 +1625,18 @@ def send_message_to_model(
             api_base_url=api_base_url,
             tracer=tracer,
         )
+    elif model_type == ChatModel.ModelType.LITELLM:
+        return litellm_send_message_to_model(
+            messages=truncated_messages,
+            api_key=api_key,
+            model=chat_model_name,
+            response_type=response_type,
+            response_schema=response_schema,
+            tools=tools,
+            deepthought=deepthought,
+            api_base_url=api_base_url,
+            tracer=tracer,
+        )
     else:
         raise HTTPException(status_code=500, detail=f"Invalid model type: {model_type}")
 
@@ -1784,6 +1801,16 @@ def send_message_to_model_wrapper_sync(
             model=chat_model_name,
             response_type=response_type,
             response_schema=response_schema,
+            tracer=tracer,
+        )
+    elif model_type == ChatModel.ModelType.LITELLM:
+        return litellm_send_message_to_model(
+            messages=truncated_messages,
+            api_key=api_key,
+            model=chat_model_name,
+            response_type=response_type,
+            response_schema=response_schema,
+            api_base_url=api_base_url,
             tracer=tracer,
         )
     else:
@@ -1994,6 +2021,19 @@ async def agenerate_chat_response(
             api_key = chat_model.ai_model_api.api_key
             api_base_url = chat_model.ai_model_api.api_base_url
             chat_response_generator = converse_gemini(
+                # Query + Context Messages
+                messages,
+                # Model
+                model=chat_model.name,
+                api_key=api_key,
+                api_base_url=api_base_url,
+                deepthought=deepthought,
+                tracer=tracer,
+            )
+        elif chat_model.model_type == ChatModel.ModelType.LITELLM:
+            api_key = chat_model.ai_model_api.api_key
+            api_base_url = chat_model.ai_model_api.api_base_url
+            chat_response_generator = converse_litellm(
                 # Query + Context Messages
                 messages,
                 # Model

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12.4' and sys_platform == 'darwin'",
@@ -771,6 +771,47 @@ wheels = [
 ]
 
 [[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/b2/731a6696e37cd20eed353f69a09f37a984a43c9713764ee3f7ad5f57f7f9/fastuuid-0.14.0-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6e6243d40f6c793c3e2ee14c13769e341b90be5ef0c23c82fa6515a96145181a", size = 516760, upload-time = "2025-10-19T22:25:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/79/c73c47be2a3b8734d16e628982653517f80bbe0570e27185d91af6096507/fastuuid-0.14.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:13ec4f2c3b04271f62be2e1ce7e95ad2dd1cf97e94503a3760db739afbd48f00", size = 264748, upload-time = "2025-10-19T22:41:52.873Z" },
+    { url = "https://files.pythonhosted.org/packages/24/c5/84c1eea05977c8ba5173555b0133e3558dc628bcf868d6bf1689ff14aedc/fastuuid-0.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b2fdd48b5e4236df145a149d7125badb28e0a383372add3fbaac9a6b7a394470", size = 254537, upload-time = "2025-10-19T22:33:55.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/23/4e362367b7fa17dbed646922f216b9921efb486e7abe02147e4b917359f8/fastuuid-0.14.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f74631b8322d2780ebcf2d2d75d58045c3e9378625ec51865fe0b5620800c39d", size = 278994, upload-time = "2025-10-19T22:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/72/3985be633b5a428e9eaec4287ed4b873b7c4c53a9639a8b416637223c4cd/fastuuid-0.14.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83cffc144dc93eb604b87b179837f2ce2af44871a7b323f2bfed40e8acb40ba8", size = 280003, upload-time = "2025-10-19T22:23:45.415Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/6d/6ef192a6df34e2266d5c9deb39cd3eea986df650cbcfeaf171aa52a059c3/fastuuid-0.14.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a771f135ab4523eb786e95493803942a5d1fc1610915f131b363f55af53b219", size = 303583, upload-time = "2025-10-19T22:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/11/8a2ea753c68d4fece29d5d7c6f3f903948cc6e82d1823bc9f7f7c0355db3/fastuuid-0.14.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4edc56b877d960b4eda2c4232f953a61490c3134da94f3c28af129fb9c62a4f6", size = 460955, upload-time = "2025-10-19T22:36:25.196Z" },
+    { url = "https://files.pythonhosted.org/packages/23/42/7a32c93b6ce12642d9a152ee4753a078f372c9ebb893bc489d838dd4afd5/fastuuid-0.14.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:bcc96ee819c282e7c09b2eed2b9bd13084e3b749fdb2faf58c318d498df2efbe", size = 480763, upload-time = "2025-10-19T22:24:28.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e9/a5f6f686b46e3ed4ed3b93770111c233baac87dd6586a411b4988018ef1d/fastuuid-0.14.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7a3c0bca61eacc1843ea97b288d6789fbad7400d16db24e36a66c28c268cfe3d", size = 452613, upload-time = "2025-10-19T22:25:06.827Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c9/18abc73c9c5b7fc0e476c1733b678783b2e8a35b0be9babd423571d44e98/fastuuid-0.14.0-cp310-cp310-win32.whl", hash = "sha256:7f2f3efade4937fae4e77efae1af571902263de7b78a0aee1a1653795a093b2a", size = 155045, upload-time = "2025-10-19T22:28:32.732Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8a/d9e33f4eb4d4f6d9f2c5c7d7e96b5cdbb535c93f3b1ad6acce97ee9d4bf8/fastuuid-0.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:ae64ba730d179f439b0736208b4c279b8bc9c089b102aec23f86512ea458c8a4", size = 156122, upload-time = "2025-10-19T22:23:15.59Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f3/12481bda4e5b6d3e698fbf525df4443cc7dce746f246b86b6fcb2fba1844/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:73946cb950c8caf65127d4e9a325e2b6be0442a224fd51ba3b6ac44e1912ce34", size = 516386, upload-time = "2025-10-19T22:42:40.176Z" },
+    { url = "https://files.pythonhosted.org/packages/59/19/2fc58a1446e4d72b655648eb0879b04e88ed6fa70d474efcf550f640f6ec/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:12ac85024637586a5b69645e7ed986f7535106ed3013640a393a03e461740cb7", size = 264569, upload-time = "2025-10-19T22:25:50.977Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/3c74756e5b02c40cfcc8b1d8b5bac4edbd532b55917a6bcc9113550e99d1/fastuuid-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:05a8dde1f395e0c9b4be515b7a521403d1e8349443e7641761af07c7ad1624b1", size = 254366, upload-time = "2025-10-19T22:29:49.166Z" },
+    { url = "https://files.pythonhosted.org/packages/52/96/d761da3fccfa84f0f353ce6e3eb8b7f76b3aa21fd25e1b00a19f9c80a063/fastuuid-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09378a05020e3e4883dfdab438926f31fea15fd17604908f3d39cbeb22a0b4dc", size = 278978, upload-time = "2025-10-19T22:35:41.306Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c2/f84c90167cc7765cb82b3ff7808057608b21c14a38531845d933a4637307/fastuuid-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbb0c4b15d66b435d2538f3827f05e44e2baafcc003dd7d8472dc67807ab8fd8", size = 279692, upload-time = "2025-10-19T22:25:36.997Z" },
+    { url = "https://files.pythonhosted.org/packages/af/7b/4bacd03897b88c12348e7bd77943bac32ccf80ff98100598fcff74f75f2e/fastuuid-0.14.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cd5a7f648d4365b41dbf0e38fe8da4884e57bed4e77c83598e076ac0c93995e7", size = 303384, upload-time = "2025-10-19T22:29:46.578Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a2/584f2c29641df8bd810d00c1f21d408c12e9ad0c0dafdb8b7b29e5ddf787/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:c0a94245afae4d7af8c43b3159d5e3934c53f47140be0be624b96acd672ceb73", size = 460921, upload-time = "2025-10-19T22:36:42.006Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/c6b77443bb7764c760e211002c8638c0c7cce11cb584927e723215ba1398/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:2b29e23c97e77c3a9514d70ce343571e469098ac7f5a269320a0f0b3e193ab36", size = 480575, upload-time = "2025-10-19T22:28:18.975Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/87/93f553111b33f9bb83145be12868c3c475bf8ea87c107063d01377cc0e8e/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:1e690d48f923c253f28151b3a6b4e335f2b06bf669c68a02665bc150b7839e94", size = 452317, upload-time = "2025-10-19T22:25:32.75Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8c/a04d486ca55b5abb7eaa65b39df8d891b7b1635b22db2163734dc273579a/fastuuid-0.14.0-cp311-cp311-win32.whl", hash = "sha256:a6f46790d59ab38c6aa0e35c681c0484b50dc0acf9e2679c005d61e019313c24", size = 154804, upload-time = "2025-10-19T22:24:15.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b2/2d40bf00820de94b9280366a122cbaa60090c8cf59e89ac3938cf5d75895/fastuuid-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:e150eab56c95dc9e3fefc234a0eedb342fac433dacc273cd4d150a5b0871e1fa", size = 156099, upload-time = "2025-10-19T22:24:31.646Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.24.3"
 source = { registry = "https://pypi.org/simple" }
@@ -940,7 +981,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/92/db/b4c12cff13ebac2786f4f217f06588bccd8b53d260453404ef22b121fc3a/greenlet-3.2.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:1afd685acd5597349ee6d7a88a8bec83ce13c106ac78c196ee9dde7c04fe87be", size = 268977, upload-time = "2025-06-05T16:10:24.001Z" },
     { url = "https://files.pythonhosted.org/packages/52/61/75b4abd8147f13f70986df2801bf93735c1bd87ea780d70e3b3ecda8c165/greenlet-3.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:761917cac215c61e9dc7324b2606107b3b292a8349bdebb31503ab4de3f559ac", size = 627351, upload-time = "2025-06-05T16:38:50.685Z" },
     { url = "https://files.pythonhosted.org/packages/35/aa/6894ae299d059d26254779a5088632874b80ee8cf89a88bca00b0709d22f/greenlet-3.2.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a433dbc54e4a37e4fff90ef34f25a8c00aed99b06856f0119dcf09fbafa16392", size = 638599, upload-time = "2025-06-05T16:41:34.057Z" },
-    { url = "https://files.pythonhosted.org/packages/30/64/e01a8261d13c47f3c082519a5e9dbf9e143cc0498ed20c911d04e54d526c/greenlet-3.2.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:72e77ed69312bab0434d7292316d5afd6896192ac4327d44f3d613ecb85b037c", size = 634482, upload-time = "2025-06-05T16:48:16.26Z" },
     { url = "https://files.pythonhosted.org/packages/47/48/ff9ca8ba9772d083a4f5221f7b4f0ebe8978131a9ae0909cf202f94cd879/greenlet-3.2.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:68671180e3849b963649254a882cd544a3c75bfcd2c527346ad8bb53494444db", size = 633284, upload-time = "2025-06-05T16:13:01.599Z" },
     { url = "https://files.pythonhosted.org/packages/e9/45/626e974948713bc15775b696adb3eb0bd708bec267d6d2d5c47bb47a6119/greenlet-3.2.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49c8cfb18fb419b3d08e011228ef8a25882397f3a859b9fe1436946140b6756b", size = 582206, upload-time = "2025-06-05T16:12:48.51Z" },
     { url = "https://files.pythonhosted.org/packages/b1/8e/8b6f42c67d5df7db35b8c55c9a850ea045219741bb14416255616808c690/greenlet-3.2.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:efc6dc8a792243c31f2f5674b670b3a95d46fa1c6a912b8e310d6f542e7b0712", size = 1111412, upload-time = "2025-06-05T16:36:45.479Z" },
@@ -949,7 +989,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/2e/d4fcb2978f826358b673f779f78fa8a32ee37df11920dc2bb5589cbeecef/greenlet-3.2.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:784ae58bba89fa1fa5733d170d42486580cab9decda3484779f4759345b29822", size = 270219, upload-time = "2025-06-05T16:10:10.414Z" },
     { url = "https://files.pythonhosted.org/packages/16/24/929f853e0202130e4fe163bc1d05a671ce8dcd604f790e14896adac43a52/greenlet-3.2.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0921ac4ea42a5315d3446120ad48f90c3a6b9bb93dd9b3cf4e4d84a66e42de83", size = 630383, upload-time = "2025-06-05T16:38:51.785Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b2/0320715eb61ae70c25ceca2f1d5ae620477d246692d9cc284c13242ec31c/greenlet-3.2.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:d2971d93bb99e05f8c2c0c2f4aa9484a18d98c4c3bd3c62b65b7e6ae33dfcfaf", size = 642422, upload-time = "2025-06-05T16:41:35.259Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/49/445fd1a210f4747fedf77615d941444349c6a3a4a1135bba9701337cd966/greenlet-3.2.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c667c0bf9d406b77a15c924ef3285e1e05250948001220368e039b6aa5b5034b", size = 638375, upload-time = "2025-06-05T16:48:18.235Z" },
     { url = "https://files.pythonhosted.org/packages/7e/c8/ca19760cf6eae75fa8dc32b487e963d863b3ee04a7637da77b616703bc37/greenlet-3.2.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:592c12fb1165be74592f5de0d70f82bc5ba552ac44800d632214b76089945147", size = 637627, upload-time = "2025-06-05T16:13:02.858Z" },
     { url = "https://files.pythonhosted.org/packages/65/89/77acf9e3da38e9bcfca881e43b02ed467c1dedc387021fc4d9bd9928afb8/greenlet-3.2.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29e184536ba333003540790ba29829ac14bb645514fbd7e32af331e8202a62a5", size = 585502, upload-time = "2025-06-05T16:12:49.642Z" },
     { url = "https://files.pythonhosted.org/packages/97/c6/ae244d7c95b23b7130136e07a9cc5aadd60d59b5951180dc7dc7e8edaba7/greenlet-3.2.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:93c0bb79844a367782ec4f429d07589417052e621aa39a5ac1fb99c5aa308edc", size = 1114498, upload-time = "2025-06-05T16:36:46.598Z" },
@@ -958,7 +997,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/94/ad0d435f7c48debe960c53b8f60fb41c2026b1d0fa4a99a1cb17c3461e09/greenlet-3.2.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:25ad29caed5783d4bd7a85c9251c651696164622494c00802a139c00d639242d", size = 271992, upload-time = "2025-06-05T16:11:23.467Z" },
     { url = "https://files.pythonhosted.org/packages/93/5d/7c27cf4d003d6e77749d299c7c8f5fd50b4f251647b5c2e97e1f20da0ab5/greenlet-3.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88cd97bf37fe24a6710ec6a3a7799f3f81d9cd33317dcf565ff9950c83f55e0b", size = 638820, upload-time = "2025-06-05T16:38:52.882Z" },
     { url = "https://files.pythonhosted.org/packages/c6/7e/807e1e9be07a125bb4c169144937910bf59b9d2f6d931578e57f0bce0ae2/greenlet-3.2.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:baeedccca94880d2f5666b4fa16fc20ef50ba1ee353ee2d7092b383a243b0b0d", size = 653046, upload-time = "2025-06-05T16:41:36.343Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/ab/158c1a4ea1068bdbc78dba5a3de57e4c7aeb4e7fa034320ea94c688bfb61/greenlet-3.2.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:be52af4b6292baecfa0f397f3edb3c6092ce071b499dd6fe292c9ac9f2c8f264", size = 647701, upload-time = "2025-06-05T16:48:19.604Z" },
     { url = "https://files.pythonhosted.org/packages/cc/0d/93729068259b550d6a0288da4ff72b86ed05626eaf1eb7c0d3466a2571de/greenlet-3.2.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0cc73378150b8b78b0c9fe2ce56e166695e67478550769536a6742dca3651688", size = 649747, upload-time = "2025-06-05T16:13:04.628Z" },
     { url = "https://files.pythonhosted.org/packages/f6/f6/c82ac1851c60851302d8581680573245c8fc300253fc1ff741ae74a6c24d/greenlet-3.2.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:706d016a03e78df129f68c4c9b4c4f963f7d73534e48a24f5f5a7101ed13dbbb", size = 605461, upload-time = "2025-06-05T16:12:50.792Z" },
     { url = "https://files.pythonhosted.org/packages/98/82/d022cf25ca39cf1200650fc58c52af32c90f80479c25d1cbf57980ec3065/greenlet-3.2.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:419e60f80709510c343c57b4bb5a339d8767bf9aef9b8ce43f4f143240f88b7c", size = 1121190, upload-time = "2025-06-05T16:36:48.59Z" },
@@ -1091,6 +1129,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
 ]
 
 [[package]]
@@ -1318,6 +1368,9 @@ dev = [
     { name = "stripe" },
     { name = "twilio" },
 ]
+litellm = [
+    { name = "litellm" },
+]
 local = [
     { name = "pgserver" },
 ]
@@ -1365,6 +1418,7 @@ requires-dist = [
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "langchain-community", specifier = "==0.3.31" },
     { name = "langchain-text-splitters", specifier = "==0.3.11" },
+    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.30.0" },
     { name = "lxml", specifier = "==4.9.3" },
     { name = "magika", specifier = "~=0.5.1" },
     { name = "markdown-it-py", specifier = "~=3.0.0" },
@@ -1412,7 +1466,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.31.1" },
     { name = "websockets", specifier = "==13.0" },
 ]
-provides-extras = ["dev", "local", "prod"]
+provides-extras = ["dev", "litellm", "local", "prod"]
 
 [[package]]
 name = "langchain"
@@ -1505,6 +1559,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/b1/a1514b6fe33dc956bee1e6aba88470999d53a6ed02ec8fd14d6d409b8fb7/langsmith-0.7.6.tar.gz", hash = "sha256:e8646f8429d3c1641c7bae3c01bfdc3dfa27625994b0ef4303714d6b06fe1ef9", size = 1041741, upload-time = "2026-02-21T01:26:34.296Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/89/47/9865e5f0c49d74e3f4ea5697dadf11f2b9c9ae037f0bff599583ebe59189/langsmith-0.7.6-py3-none-any.whl", hash = "sha256:28d256584969db723b68189a7dbb065836572728ab4d9597ec5379fe0a1e1641", size = 325475, upload-time = "2026-02-21T01:26:32.504Z" },
+]
+
+[[package]]
+name = "litellm"
+version = "1.83.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/92/6ce9737554994ca8e536e5f4f6a87cc7c4774b656c9eb9add071caf7d54b/litellm-1.83.0.tar.gz", hash = "sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a", size = 17333062, upload-time = "2026-03-31T05:08:25.331Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/2c/a670cc050fcd6f45c6199eb99e259c73aea92edba8d5c2fc1b3686d36217/litellm-1.83.0-py3-none-any.whl", hash = "sha256:88c536d339248f3987571493015784671ba3f193a328e1ea6780dbebaa2094a8", size = 15610306, upload-time = "2026-03-31T05:08:21.987Z" },
 ]
 
 [[package]]
@@ -4000,6 +4077,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/2a/dd7ed1aa23fea996834278d7ff178f215b24324ee527df53d45e34d21d28/yarl-1.20.0-cp312-cp312-win32.whl", hash = "sha256:839de4c574169b6598d47ad61534e6981979ca2c820ccb77bf70f4311dd2cc64", size = 86355, upload-time = "2025-04-17T00:43:11.311Z" },
     { url = "https://files.pythonhosted.org/packages/ca/c6/333fe0338305c0ac1c16d5aa7cc4841208d3252bbe62172e0051006b5445/yarl-1.20.0-cp312-cp312-win_amd64.whl", hash = "sha256:3d7dbbe44b443b0c4aa0971cb07dcb2c2060e4a9bf8d1301140a33a93c98e18c", size = 92904, upload-time = "2025-04-17T00:43:13.087Z" },
     { url = "https://files.pythonhosted.org/packages/ea/1f/70c57b3d7278e94ed22d85e09685d3f0a38ebdd8c5c73b65ba4c0d0fe002/yarl-1.20.0-py3-none-any.whl", hash = "sha256:5d0fe6af927a47a230f31e6004621fd0959eaa915fc62acfafa67ff7229a3124", size = 46124, upload-time = "2025-04-17T00:45:12.199Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                                                                                                                                              
  - Add LiteLLM as a new `ChatModel.ModelType` alongside OpenAI, Anthropic, and Google                                                                                                                                                                                                                                                                                    
  - Create `processor/conversation/litellm/` with chat completion and streaming support via `litellm.completion()` / `litellm.acompletion()`                                                                                                                                                                                                                              
  - Add routing in `routers/helpers.py` for all three call paths (sync structured, sync plain, async streaming)                                                                                                                                                                                                                                                           
  - Add `litellm` as an optional dependency (`pip install khoj[litellm]`)                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                          
  ## Why                                                                                                                                                                                                                                                                                                                                                                  
  LiteLLM provides a unified API to 100+ LLM providers (AWS Bedrock, Azure, Ollama, Mistral, Cohere, Groq, DeepSeek, etc.) through a single OpenAI-compatible interface.   
  
                                                                                                                                                                                                                                                
  Resolves #1315                                                                 