### PR TITLE
Fix contributor guide typos

### DIFF
--- a/documentation/docs/contributing/development.mdx
+++ b/documentation/docs/contributing/development.mdx
@@ -4,7 +4,7 @@ sidebar_position: 0
 
 # Development
 
-Welcome to the development docs of Khoj! Thanks for your interest in being a contributor ❤️. Open source contributors are a corner-store of the Khoj community. We welcome all contributions, big or small.
+Welcome to the development docs of Khoj! Thanks for your interest in being a contributor ❤️. Open source contributors are a cornerstone of the Khoj community. We welcome all contributions, big or small.
 
 To get started with contributing, check out the official GitHub docs on [contributing to an open-source project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project).
 
@@ -203,10 +203,10 @@ In whichever clients you're using for testing, you'll need to update the server 
 ### Before Creating PR
 
 :::tip[Note]
-You should be in an active virtual environment for Khoj in order to run the unit tests and linter. The `dev_setup.sh` script wil automatically create and activate it for you.
+You should be in an active virtual environment for Khoj in order to run the unit tests and linter. The `dev_setup.sh` script will automatically create and activate it for you.
 :::
 
-1. Ensure that you have a [Github Issue](https://github.com/khoj-ai/khoj/issues) that can be linked to the PR. If not, create one. Make sure you've tagged one of the maintainers to the issue. This will ensure that the maintainers are notified of the PR and can review it. It's best discuss the code design on an existing issue or Discord thread before creating a PR. This helps get your PR merged faster.
+1. Ensure that you have a [Github Issue](https://github.com/khoj-ai/khoj/issues) that can be linked to the PR. If not, create one. Make sure you've tagged one of the maintainers to the issue. This will ensure that the maintainers are notified of the PR and can review it. It's best to discuss the code design on an existing issue or Discord thread before creating a PR. This helps get your PR merged faster.
 1. Run unit tests.
    ```shell
    pytest


### PR DESCRIPTION
## Fixes a few small typos in the contributor development guide.

This updates “corner-store” to “cornerstone”, fixes “wil” to “will”, and makes the PR guidance sentence grammatical. No behavior changes.
