### PR TITLE
docs: add OrcaRouter integration guide

### DIFF
--- a/documentation/docs/advanced/orcarouter.md
+++ b/documentation/docs/advanced/orcarouter.md
@@ -1,0 +1,30 @@
+# OrcaRouter
+:::info
+This is only helpful for self-hosted users. If you're using [Khoj Cloud](https://app.khoj.dev), you're limited to our first-party models.
+:::
+
+[OrcaRouter](https://www.orcarouter.ai) is a unified OpenAI-compatible API that routes requests across 150+ chat models from OpenAI, Anthropic, Google, DeepSeek, xAI, Qwen, Kimi, MiniMax, Z-AI and more behind a single API key.
+
+It also exposes a virtual `orcarouter/auto` router that picks an upstream model per-request based on configurable strategies (cheapest, balanced, quality, adaptive, gated-adaptive). See the [routing console](https://www.orcarouter.ai/console/routing) for strategy details.
+
+Using OrcaRouter with Khoj lets you experiment with many chat models from a single account and key, including the latest frontier models, without managing separate provider credentials.
+
+## Setup
+1. Create an account at [orcarouter.ai](https://www.orcarouter.ai) and generate an API key.
+2. Create a new [AI Model API](http://localhost:42110/server/admin/database/aimodelapi/add) on your Khoj admin panel
+   - **Name**: `orcarouter`
+   - **Api Key**: *your OrcaRouter API key*
+   - **Api Base Url**: `https://api.orcarouter.ai/v1`
+3. Create a new [Chat Model](http://localhost:42110/server/admin/database/chatmodel/add) on your Khoj admin panel.
+   - **Name**: `openai/gpt-5` (or any model ID from the [OrcaRouter catalog](https://www.orcarouter.ai/models), e.g. `anthropic/claude-opus-4.7`, `google/gemini-3-flash-preview`, `deepseek/deepseek-v4-pro`, or `orcarouter/auto` for adaptive routing)
+   - **Model Type**: `Openai`
+   - **Ai Model Api**: *the orcarouter Ai Model API you created in step 2*
+   - **Max prompt size**: `20000` (replace with the max prompt size of your chosen model)
+   - **Tokenizer**: *Do not set for OpenAI, Anthropic, Gemini and similar API-based models*
+4. Go to [your config](http://localhost:42110/settings) and select the model you just created in the chat model dropdown.
+
+That's it! You can repeat step 3 to register additional models from the OrcaRouter catalog.
+
+:::tip
+The full model list and pricing is available at [orcarouter.ai/models](https://www.orcarouter.ai/models). API and routing reference: [docs.orcarouter.ai](https://docs.orcarouter.ai).
+:::

--- a/documentation/docs/advanced/use-openai-proxy.md
+++ b/documentation/docs/advanced/use-openai-proxy.md
@@ -11,7 +11,7 @@ This is only helpful for self-hosted users. If you're using [Khoj Cloud](https:/
 Khoj natively supports local LLMs [available on HuggingFace in GGUF format](https://huggingface.co/models?library=gguf). Using an OpenAI API proxy with Khoj maybe useful for ease of setup, trying new models or using commercial LLMs via API.
 :::
 
-Khoj can use any OpenAI API compatible server including local providers like [Ollama](/advanced/ollama), [LMStudio](/advanced/lmstudio) and [LiteLLM](/advanced/litellm) and commercial providers like [HuggingFace](https://huggingface.co/docs/api-inference/tasks/chat-completion#using-the-api), [OpenRouter](https://openrouter.ai/docs/quick-start) etc.
+Khoj can use any OpenAI API compatible server including local providers like [Ollama](/advanced/ollama), [LMStudio](/advanced/lmstudio) and [LiteLLM](/advanced/litellm) and commercial providers like [HuggingFace](https://huggingface.co/docs/api-inference/tasks/chat-completion#using-the-api), [OpenRouter](https://openrouter.ai/docs/quick-start), [OrcaRouter](/advanced/orcarouter) etc.
 Configuring this allows you to use non-standard, open or commercial, local or hosted LLM models for Khoj.
 
 Combine them with Khoj can turn your favorite LLM into an AI agent. Allowing you to chat with your docs, find answers from the internet, build custom agents and run automations.


### PR DESCRIPTION
## Summary

Adds a dedicated setup doc for using [OrcaRouter](https://www.orcarouter.ai) — an OpenAI-compatible aggregator that routes requests across 150+ chat models (OpenAI, Anthropic, Google, DeepSeek, xAI, Qwen, Kimi, MiniMax, Z-AI, etc.) behind a single API key, with an optional virtual `orcarouter/auto` router for adaptive multi-model routing.

This follows the existing pattern in `documentation/docs/advanced/` for OpenAI-compatible providers (Ollama, LMStudio, LiteLLM). No server code changes — OrcaRouter is configured as an `AI Model API` + `Chat Model` in the Khoj admin panel exactly like any other OpenAI-compatible endpoint.

## Changes

- New page: `documentation/docs/advanced/orcarouter.md` with step-by-step admin panel setup, API base (`https://api.orcarouter.ai/v1`), and example model IDs (`openai/gpt-5`, `anthropic/claude-opus-4.7`, `orcarouter/auto`, etc.).
- Updated `documentation/docs/advanced/use-openai-proxy.md` to list OrcaRouter alongside OpenRouter as an example commercial proxy.

Docusaurus auto-generates the sidebar from the filesystem, so no `sidebars.js` change is needed; the page will appear under **Advanced Self Hosting**.

## Verification

- Followed the same structure as the existing `litellm.md` / `ollama.mdx` / `lmstudio.md` pages.
- Configuration steps were validated against a self-hosted Khoj instance: register `AI Model API` (base URL `https://api.orcarouter.ai/v1`, key from orcarouter.ai), register `Chat Model` of type `Openai` referencing it, select it in `/settings`, and chat works end-to-end.
- Markdown only — no Python / lint impact; `ruff` and `mypy` hooks are unaffected.

## Disclosure

I'm an engineer on the OrcaRouter team. Happy to adjust wording, drop the cross-link in `use-openai-proxy.md`, or rework the page if maintainers prefer a different placement.
