### PR TITLE
Fix shared conversation agent authorization

### DIFF
--- a/src/khoj/database/adapters/__init__.py
+++ b/src/khoj/database/adapters/__init__.py
@@ -996,10 +996,38 @@ class PublicConversationAdapters:
 
 class ConversationAdapters:
     @staticmethod
+    def get_publicly_shareable_agent(agent: Optional[Agent]) -> Optional[Agent]:
+        if agent and agent.privacy_level == Agent.PrivacyLevel.PUBLIC:
+            return agent
+        return None
+
+    @staticmethod
+    def get_agent_accessible_to_user_or_default(agent: Optional[Agent], user: KhojUser) -> Optional[Agent]:
+        if agent:
+            agent = Agent.objects.select_related("creator").filter(pk=agent.pk).first()
+
+            if agent:
+                if agent.privacy_level == Agent.PrivacyLevel.PUBLIC:
+                    return agent
+                if agent.creator == user:
+                    return agent
+                if agent.privacy_level == Agent.PrivacyLevel.PROTECTED:
+                    return agent
+
+        return AgentAdapters.get_default_agent()
+
+    @staticmethod
+    async def aget_agent_accessible_to_user_or_default(agent: Optional[Agent], user: KhojUser) -> Optional[Agent]:
+        default_agent = await AgentAdapters.aget_default_agent()
+        if agent and await AgentAdapters.ais_agent_accessible(agent, user):
+            return agent
+        return default_agent
+
+    @staticmethod
     def make_public_conversation_copy(conversation: Conversation):
         return PublicConversation.objects.create(
             source_owner=conversation.user,
-            agent=conversation.agent,
+            agent=ConversationAdapters.get_publicly_shareable_agent(conversation.agent),
             conversation_log=conversation.conversation_log,
             slug=conversation.slug,
             title=conversation.title if conversation.title else conversation.slug,
@@ -1192,13 +1220,13 @@ class ConversationAdapters:
         config = UserConversationConfig.objects.filter(user=user).first()
         if subscribed:
             # Subscibed users can use any available chat model
-            if config and config.setting:
+            if config:
                 return config.setting
             # Fallback to the default advanced chat model
             return ConversationAdapters.get_advanced_chat_model(user)
         else:
             # Non-subscribed users can use any free chat model
-            if config and config.setting and config.setting.price_tier == PriceTier.FREE:
+            if config and config.setting.price_tier == PriceTier.FREE:
                 return config.setting
             # Fallback to the default chat model
             return ConversationAdapters.get_default_chat_model(user)
@@ -1213,13 +1241,13 @@ class ConversationAdapters:
         )
         if subscribed:
             # Subscibed users can use any available chat model
-            if config and config.setting:
+            if config:
                 return config.setting
             # Fallback to the default advanced chat model
             return await ConversationAdapters.aget_advanced_chat_model(user)
         else:
             # Non-subscribed users can use any free chat model
-            if config and config.setting and config.setting.price_tier == PriceTier.FREE:
+            if config and config.setting.price_tier == PriceTier.FREE:
                 return config.setting
             # Fallback to the default chat model
             return await ConversationAdapters.aget_default_chat_model(user)
@@ -1547,13 +1575,14 @@ class ConversationAdapters:
         scrubbed_title = public_conversation.title if public_conversation.title else public_conversation.slug
         if scrubbed_title:
             scrubbed_title = scrubbed_title.replace("-", " ")
+        agent = ConversationAdapters.get_agent_accessible_to_user_or_default(public_conversation.agent, user)
         return Conversation.objects.create(
             user=user,
             conversation_log=public_conversation.conversation_log,
             client=client_app,
             slug=scrubbed_title,
             title=public_conversation.title,
-            agent=public_conversation.agent,
+            agent=agent,
         )
 
     @staticmethod
@@ -1721,6 +1750,7 @@ class ConversationAdapters:
         For paid users: Prefer any custom agent chat model > user default chat model > server default chat model.
         For free users: Prefer conversation specific agent's chat model > user default chat model > server default chat model.
         """
+        conversation.agent = await ConversationAdapters.aget_agent_accessible_to_user_or_default(conversation.agent, user)
         agent: Agent = conversation.agent if await AgentAdapters.aget_default_agent() != conversation.agent else None
         if agent and agent.chat_model and (agent.is_hidden or is_subscribed):
             chat_model = await ChatModel.objects.select_related("ai_model_api").aget(

--- a/src/khoj/routers/api_chat.py
+++ b/src/khoj/routers/api_chat.py
@@ -951,6 +951,11 @@ async def event_generator(
 
     agent: Agent | None = None
     default_agent = await AgentAdapters.aget_default_agent()
+    authorized_agent = await ConversationAdapters.aget_agent_accessible_to_user_or_default(conversation.agent, user)
+    if conversation.agent != authorized_agent:
+        conversation.agent = authorized_agent
+        await conversation.asave()
+
     if conversation.agent and conversation.agent != default_agent:
         agent = conversation.agent
 

--- a/src/khoj/routers/helpers.py
+++ b/src/khoj/routers/helpers.py
@@ -1915,6 +1915,11 @@ async def agenerate_chat_response(
     chat_response_generator: AsyncGenerator[ResponseWithThought, None] = None
 
     metadata = {}
+    authorized_agent = await ConversationAdapters.aget_agent_accessible_to_user_or_default(conversation.agent, user)
+    if conversation.agent != authorized_agent:
+        conversation.agent = authorized_agent
+        await conversation.asave()
+
     agent = await AgentAdapters.aget_conversation_agent_by_id(conversation.agent.id) if conversation.agent else None
 
     try:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -5,8 +5,8 @@ from collections import Counter
 import pytest
 from asgiref.sync import sync_to_async
 
-from khoj.database.adapters import AgentAdapters
-from khoj.database.models import Agent, ChatModel, Entry, FileObject, KhojUser
+from khoj.database.adapters import AgentAdapters, ConversationAdapters
+from khoj.database.models import Agent, ChatModel, Conversation, Entry, FileObject, KhojUser, PublicConversation
 from khoj.routers.helpers import execute_search
 from khoj.utils.helpers import get_absolute_path
 from tests.helpers import ChatModelFactory
@@ -21,6 +21,139 @@ def test_create_default_agent(default_user: KhojUser):
     assert agent.output_modes == []
     assert agent.privacy_level == Agent.PrivacyLevel.PUBLIC
     assert agent.managed_by_admin
+
+
+@pytest.mark.django_db(transaction=True)
+def test_share_copy_does_not_publish_private_agent(
+    default_user: KhojUser, default_openai_chat_model_option: ChatModel
+):
+    private_agent = Agent.objects.create(
+        creator=default_user,
+        name="Private Agent",
+        personality="private instructions",
+        privacy_level=Agent.PrivacyLevel.PRIVATE,
+        chat_model=default_openai_chat_model_option,
+        slug="private-agent",
+    )
+    conversation = Conversation.objects.create(
+        user=default_user,
+        conversation_log={},
+        slug="private-agent-chat",
+        agent=private_agent,
+    )
+
+    public_conversation = ConversationAdapters.make_public_conversation_copy(conversation)
+
+    assert public_conversation.agent is None
+
+
+@pytest.mark.django_db(transaction=True)
+def test_share_copy_keeps_public_agent(default_user: KhojUser, default_openai_chat_model_option: ChatModel):
+    public_agent = Agent.objects.create(
+        creator=default_user,
+        name="Public Agent",
+        personality="public instructions",
+        privacy_level=Agent.PrivacyLevel.PUBLIC,
+        chat_model=default_openai_chat_model_option,
+        slug="public-agent",
+    )
+    conversation = Conversation.objects.create(
+        user=default_user,
+        conversation_log={},
+        slug="public-agent-chat",
+        agent=public_agent,
+    )
+
+    public_conversation = ConversationAdapters.make_public_conversation_copy(conversation)
+
+    assert public_conversation.agent == public_agent
+
+
+@pytest.mark.django_db(transaction=True)
+def test_fork_public_conversation_replaces_inaccessible_private_agent(
+    default_user: KhojUser,
+    default_user3: KhojUser,
+    default_openai_chat_model_option: ChatModel,
+):
+    default_agent = AgentAdapters.create_default_agent()
+    private_agent = Agent.objects.create(
+        creator=default_user,
+        name="Private Source Agent",
+        personality="private source instructions",
+        privacy_level=Agent.PrivacyLevel.PRIVATE,
+        chat_model=default_openai_chat_model_option,
+        slug="private-source-agent",
+    )
+    public_conversation = PublicConversation.objects.create(
+        source_owner=default_user,
+        conversation_log={},
+        slug="shared-private-agent-chat",
+        title="Shared Private Agent Chat",
+        agent=private_agent,
+    )
+
+    forked_conversation = ConversationAdapters.create_conversation_from_public_conversation(
+        default_user3, public_conversation, None
+    )
+
+    assert forked_conversation.agent == default_agent
+
+
+@pytest.mark.django_db(transaction=True)
+def test_fork_public_conversation_keeps_accessible_public_agent(
+    default_user: KhojUser,
+    default_user3: KhojUser,
+    default_openai_chat_model_option: ChatModel,
+):
+    public_agent = Agent.objects.create(
+        creator=default_user,
+        name="Shared Public Agent",
+        personality="shared public instructions",
+        privacy_level=Agent.PrivacyLevel.PUBLIC,
+        chat_model=default_openai_chat_model_option,
+        slug="shared-public-agent",
+    )
+    public_conversation = PublicConversation.objects.create(
+        source_owner=default_user,
+        conversation_log={},
+        slug="shared-public-agent-chat",
+        title="Shared Public Agent Chat",
+        agent=public_agent,
+    )
+
+    forked_conversation = ConversationAdapters.create_conversation_from_public_conversation(
+        default_user3, public_conversation, None
+    )
+
+    assert forked_conversation.agent == public_agent
+
+
+@pytest.mark.anyio
+@pytest.mark.django_db(transaction=True)
+async def test_chat_model_selection_reauthorizes_conversation_agent(
+    default_user: KhojUser,
+    default_user3: KhojUser,
+    default_openai_chat_model_option: ChatModel,
+):
+    default_agent = await sync_to_async(AgentAdapters.create_default_agent)()
+    private_agent = await sync_to_async(Agent.objects.create)(
+        creator=default_user,
+        name="Private Chat Agent",
+        personality="private chat instructions",
+        privacy_level=Agent.PrivacyLevel.PRIVATE,
+        chat_model=default_openai_chat_model_option,
+        slug="private-chat-agent",
+    )
+    conversation = await sync_to_async(Conversation.objects.create)(
+        user=default_user3,
+        conversation_log={},
+        slug="forked-private-agent-chat",
+        agent=private_agent,
+    )
+
+    await ConversationAdapters.aget_valid_chat_model(default_user3, conversation, is_subscribed=True)
+
+    assert conversation.agent == default_agent
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- avoid publishing private or protected agent references when a conversation is shared
- re-authorize inherited public conversation agents before forked conversations keep them
- re-authorize `conversation.agent` before chat execution, prompt construction, and chat-model selection
- add regression coverage for share/fork/private-agent fallback behavior

Fixes khoj-ai/khoj#1327

## Testing

- `python3 -m py_compile src/khoj/database/adapters/__init__.py src/khoj/routers/api_chat.py src/khoj/routers/helpers.py tests/test_agents.py`
- `UV_PROJECT_ENVIRONMENT=/tmp/khoj-uv-venv uv run --extra dev ruff check src/khoj/database/adapters/__init__.py src/khoj/routers/api_chat.py src/khoj/routers/helpers.py tests/test_agents.py`

Targeted pytest command attempted but the local environment has no usable PostgreSQL at `localhost:5432`; `USE_EMBEDDED_DB=true` also failed because pgserver could not initialize its local Postgres instance in this workspace.
