### PR TITLE
fix: log a warning when khoj falls back from a budget model to a flagship model

### DIFF
--- a/src/khoj/utils/helpers.py
+++ b/src/khoj/utils/helpers.py
@@ -1053,6 +1053,7 @@ def get_chat_usage_metrics(
     thought_tokens: int = 0,
     usage: dict = {},
     cost: float = None,
+    requested_model: Optional[str] = None,
 ):
     """
     Get usage metrics for chat message based on input and output tokens and cost
@@ -1082,6 +1083,11 @@ def get_chat_usage_metrics(
             prev_cost=prev_usage["cost"],
         ),
     }
+    if requested_model and requested_model != model_name:
+        logger.warning(
+            f"Chat model fallback: requested {requested_model}, used {model_name}. "
+            "Cost calculated at the fallback model's rate."
+        )
     logger.debug(f"AI API usage by {model_name}: {current_usage}")
     return current_usage
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import secrets
 
@@ -42,6 +43,51 @@ def test_merge_dicts():
 
     # do not override existing key in priority_dict with default dict
     assert helpers.merge_dicts(priority_dict={"a": 1}, default_dict={"a": 2}) == {"a": 1}
+
+
+def test_get_chat_usage_metrics_without_requested_model_does_not_warn(caplog):
+    with caplog.at_level(logging.WARNING, logger=helpers.logger.name):
+        usage = helpers.get_chat_usage_metrics(model_name="gpt-4o", input_tokens=1_000_000, output_tokens=1_000_000)
+
+    assert usage["cost"] == pytest.approx(12.5)
+    assert caplog.records == []
+
+
+def test_get_chat_usage_metrics_warns_on_model_fallback(caplog):
+    with caplog.at_level(logging.WARNING, logger=helpers.logger.name):
+        usage = helpers.get_chat_usage_metrics(
+            model_name="gpt-4o",
+            requested_model="minimax-m2",
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+        )
+
+    assert usage["cost"] == pytest.approx(12.5)
+    assert [record.message for record in caplog.records] == [
+        "Chat model fallback: requested minimax-m2, used gpt-4o. "
+        "Cost calculated at the fallback model's rate."
+    ]
+
+
+def test_get_chat_usage_metrics_does_not_warn_when_requested_model_matches(caplog):
+    with caplog.at_level(logging.WARNING, logger=helpers.logger.name):
+        usage = helpers.get_chat_usage_metrics(
+            model_name="gpt-4o",
+            requested_model="gpt-4o",
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+        )
+
+    assert usage["cost"] == pytest.approx(12.5)
+    assert caplog.records == []
+
+
+def test_get_chat_usage_metrics_unknown_model_preserves_zero_cost(caplog):
+    with caplog.at_level(logging.WARNING, logger=helpers.logger.name):
+        usage = helpers.get_chat_usage_metrics(model_name="brand-new-model", input_tokens=1_000_000)
+
+    assert usage["cost"] == 0
+    assert caplog.records == []
 
 
 def test_lru_cache():


### PR DESCRIPTION
## Summary

fix: log a warning when khoj falls back from a budget model to a flagship model

Closes khoj-ai/pipali#41

---
AI was used for assistance.