### PR TITLE
fix: check conversation existence before accessing .title in generate_chat_title

### DIFF
--- a/src/khoj/routers/api_chat.py
+++ b/src/khoj/routers/api_chat.py
@@ -637,12 +637,12 @@ async def generate_chat_title(
     user: KhojUser = request.user.object
     conversation = await ConversationAdapters.aget_conversation_by_user(user=user, conversation_id=conversation_id)
 
+    if not conversation:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
     # Conversation.title is explicitly set by the user. Do not override.
     if conversation.title:
         return {"status": "ok", "title": conversation.title}
-
-    if not conversation:
-        raise HTTPException(status_code=404, detail="Conversation not found")
 
     new_title = await acreate_title_from_history(request.user.object, conversation=conversation)
     conversation.slug = clean_text_for_db(new_title[:200])
@@ -650,7 +650,6 @@ async def generate_chat_title(
     await conversation.asave()
 
     return {"status": "ok", "title": new_title}
-
 
 @api_chat.delete("/conversation/message", response_class=Response)
 @requires(["authenticated"])


### PR DESCRIPTION
## What
Fixes an AttributeError crash in `generate_chat_title`.

## Why
If `aget_conversation_by_user` returns `None`, the current code accesses
`conversation.title` before the `None` check, raising an AttributeError
before the 404 guard is ever reached.

## Fix
Swapped the order of the two checks so `None` is handled first.