### PR TITLE
Fix DeepSeek chat models failing with unavailable response_format (#1336)

### DIFF
--- a/src/khoj/processor/conversation/openai/utils.py
+++ b/src/khoj/processor/conversation/openai/utils.py
@@ -732,6 +732,11 @@ def get_structured_output_support(model_name: str, api_base_url: str = None) -> 
             return StructuredOutputSupport.OBJECT
         if host == "api.deepinfra.com":
             return StructuredOutputSupport.OBJECT
+        # The official DeepSeek API only supports response_format={"type": "json_object"}.
+        # It rejects tool/json_schema structured output with "This response_format type is
+        # unavailable now", so gate it to OBJECT support (deepseek-reasoner handled above).
+        if host == "api.deepseek.com":
+            return StructuredOutputSupport.OBJECT
     return StructuredOutputSupport.TOOL
 
 

--- a/tests/test_conversation_utils.py
+++ b/tests/test_conversation_utils.py
@@ -4,6 +4,8 @@ import tiktoken
 from langchain_core.messages.chat import ChatMessage
 
 from khoj.processor.conversation import utils
+from khoj.processor.conversation.openai.utils import get_structured_output_support
+from khoj.processor.conversation.utils import StructuredOutputSupport
 
 
 class TestTruncateMessage:
@@ -214,6 +216,36 @@ class TestLoadComplexJson:
 
         # Assert
         assert parsed_json == expected_json
+
+
+class TestGetStructuredOutputSupport:
+    """Regression tests for https://github.com/khoj-ai/khoj/issues/1336.
+
+    The DeepSeek API only supports ``response_format={"type": "json_object"}`` (i.e.
+    ``StructuredOutputSupport.OBJECT``). Non-reasoner DeepSeek models such as
+    ``deepseek-chat`` must not be advertised as supporting tool/json_schema structured
+    output, otherwise Khoj sends an unsupported ``response_format`` and DeepSeek returns
+    HTTP 400 "This response_format type is unavailable now".
+    """
+
+    deepseek_api_base_url = "https://api.deepseek.com/v1"
+
+    def test_deepseek_chat_supports_object_output(self):
+        # deepseek-chat (DeepSeek V3) supports json_object but not tool/json_schema output
+        assert (
+            get_structured_output_support("deepseek-chat", self.deepseek_api_base_url) == StructuredOutputSupport.OBJECT
+        )
+
+    def test_deepseek_reasoner_still_supports_no_structured_output(self):
+        # deepseek-reasoner remains gated to NONE
+        assert (
+            get_structured_output_support("deepseek-reasoner", self.deepseek_api_base_url)
+            == StructuredOutputSupport.NONE
+        )
+
+    def test_non_deepseek_openai_model_still_supports_tool_output(self):
+        # Ensure the default OpenAI path is unchanged
+        assert get_structured_output_support("gpt-4o", "https://api.openai.com/v1") == StructuredOutputSupport.TOOL
 
 
 def generate_content(count, suffix=""):


### PR DESCRIPTION
Closes #1336.

## Problem
Any DeepSeek OpenAI-compatible chat model that is not `deepseek-reasoner` (e.g. `deepseek-chat`, the flagship V3) fails every request over the official `api.deepseek.com` endpoint with HTTP 400 `invalid_request_error: This response_format type is unavailable now`, so the chat turn is saved with an empty Khoj response.

## Fix
`get_structured_output_support` in `src/khoj/processor/conversation/openai/utils.py` only special-cased `deepseek-reasoner` (→ `NONE`); every other DeepSeek model fell through to `StructuredOutputSupport.TOOL`. The official DeepSeek API only supports `response_format={"type": "json_object"}` and rejects tool/json_schema structured output. The fix gates the `api.deepseek.com` host to `StructuredOutputSupport.OBJECT`, mirroring the existing `api.deepinfra.com` / `*.ai.azure.com` handling in the same function (1 file, 5 LOC, no new deps).

## Test
Added `tests/test_conversation_utils.py::TestGetStructuredOutputSupport` (DB-free, pure-function). `test_deepseek_chat_supports_object_output` asserts `get_structured_output_support("deepseek-chat", "https://api.deepseek.com/v1") == StructuredOutputSupport.OBJECT` — it fails before the fix (function returns `TOOL`) and passes after. Two guard tests keep `deepseek-reasoner → NONE` and the default OpenAI path `gpt-4o → TOOL` green.

## Verification
- `pytest tests/test_conversation_utils.py -k TestGetStructuredOutputSupport` — green (also full file: 14 passed)
- `mypy src/khoj/processor/conversation/openai/utils.py` — no new errors introduced (pre-existing baseline unchanged)
- `ruff check` / `ruff format --check` — clean

> Note: khoj is AGPL-3.0; this contribution is offered under the same license.

🤖 AI-assistance disclosure: drafted with assistance from Claude (Opus 4.8). All changes reviewed for correctness before submission.