### PR TITLE
Fix KeyError on missing image/docx keys in configure_content (#1317)

### DIFF
--- a/src/khoj/routers/helpers.py
+++ b/src/khoj/routers/helpers.py
@@ -3139,9 +3139,9 @@ def configure_content(
 
     try:
         # Initialize Image Search
-        if (search_type == state.SearchType.All.value or search_type == state.SearchType.Image.value) and files[
+        if (search_type == state.SearchType.All.value or search_type == state.SearchType.Image.value) and files.get(
             "image"
-        ]:
+        ):
             logger.info("🖼️ Setting up search for images")
             # Extract Entries, Generate Image Embeddings
             text_search.setup(
@@ -3154,7 +3154,9 @@ def configure_content(
         logger.error(f"🚨 Failed to setup images: {e}", exc_info=True)
         success = False
     try:
-        if (search_type == state.SearchType.All.value or search_type == state.SearchType.Docx.value) and files["docx"]:
+        if (search_type == state.SearchType.All.value or search_type == state.SearchType.Docx.value) and files.get(
+            "docx"
+        ):
             logger.info("📄 Setting up search for docx")
             text_search.setup(
                 DocxToEntries,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -11,7 +11,9 @@ from khoj.processor.tools.online_search import (
     read_webpage_at_url,
     read_webpage_with_olostep,
 )
+from khoj.routers.helpers import configure_content
 from khoj.utils import helpers
+from khoj.utils.config import SearchType
 
 
 def test_get_from_null_dict():
@@ -116,3 +118,27 @@ async def test_reading_webpage_with_olostep():
         "An alarm sent from the area near the fire also failed to register at the courthouse where the fire watchmen were"
         in response
     )
+
+
+# Regression tests for https://github.com/khoj-ai/khoj/issues/1317.
+# When the indexed `files` dict omits the "image"/"docx" keys, configure_content used a
+# bracket lookup (files["image"] / files["docx"]) in the guard conditions while every
+# other content type used the safe files.get(...). The missing key raised KeyError, which
+# was swallowed into success=False and surfaced as an HTTP 500 from /api/update.
+# Passing a non-empty unrelated file type keeps no_client_sent_documents False so the
+# Github/Notion server-side indexing branches (which hit the DB) are skipped, keeping the
+# test DB-free.
+def test_configure_content_handles_missing_image_key():
+    files = {"markdown": {"note.md": "# hi"}}
+
+    success = configure_content(user=None, files=files, regenerate=False, t=SearchType.Image)
+
+    assert success is True
+
+
+def test_configure_content_handles_missing_docx_key():
+    files = {"markdown": {"note.md": "# hi"}}
+
+    success = configure_content(user=None, files=files, regenerate=False, t=SearchType.Docx)
+
+    assert success is True


### PR DESCRIPTION
Closes #1317.

## Problem
`GET /api/update` returns HTTP 500 (`Failed to update content index`) on a fresh install with the default `t=all`. The inner handler logs `Failed to setup images: 'image'` / `Failed to setup docx: 'docx'`, sets `success=False`, and the outer caller raises 500. Scoping to a single type such as `t=markdown` avoids the crash.

## Fix
In `src/khoj/routers/helpers.py::configure_content()`, the image and docx guard conditions used a bracket lookup on a possibly-missing key (`files["image"]`, `files["docx"]`), while every other content type — and even the bodies of these same two blocks — already used the safe `files.get(...)`. When `files` lacks those keys the guard raises `KeyError`. The fix changes the two guards to `files.get("image")` / `files.get("docx")`, matching the convention used throughout the function (1 file, no new deps, no behavior change on the happy path).

## Test
Added two DB-free regression tests in `tests/test_helpers.py`. Each calls `configure_content` with a `files` dict that omits the `image`/`docx` keys (and a non-empty unrelated key so the Github/Notion server-side branches, which hit the DB, are skipped) and asserts it returns `True`. Both fail before the fix (`KeyError` → `success=False`) and pass after.

## Verification
- `pytest tests/test_helpers.py -k configure_content` — green (full file: 6 passed, 2 skipped — network tests skipped without API keys)
- `mypy src/khoj/routers/helpers.py` — no new errors introduced (pre-existing baseline unchanged)
- `ruff check` / `ruff format --check` on touched lines — clean

> Note: khoj is AGPL-3.0; this contribution is offered under the same license.

🤖 AI-assistance disclosure: drafted with assistance from Claude (Opus 4.8). All changes reviewed for correctness before submission.