### PR TITLE
fix: avoid blocking the event loop during OAuth token exchange

### DIFF
--- a/src/khoj/routers/auth.py
+++ b/src/khoj/routers/auth.py
@@ -247,7 +247,8 @@ async def auth(request: Request):
     }
 
     # Request the token from Google
-    verified_data = requests.post(
+    verified_data = await asyncio.to_thread(
+        requests.post,
         "https://oauth2.googleapis.com/token",
         headers={"Content-Type": "application/x-www-form-urlencoded"},
         data=payload,


### PR DESCRIPTION
## Overview

The Google OAuth callback (`src/khoj/routers/auth.py`, the async `auth` route) exchanges the authorization code for a token using a **synchronous** `requests.post`:

```python
async def auth(request: Request):
    ...
    verified_data = requests.post("https://oauth2.googleapis.com/token", ...)
```

A blocking call inside an `async` handler blocks the **entire event loop** for the duration of the network round-trip. So during every login's token exchange, all other in-flight requests the server is handling are frozen.

## Fix

Offload the blocking call to a worker thread with `asyncio.to_thread`, keeping the loop responsive:

```python
verified_data = await asyncio.to_thread(
    requests.post,
    "https://oauth2.googleapis.com/token",
    headers={"Content-Type": "application/x-www-form-urlencoded"},
    data=payload,
)
```

`asyncio` is already imported in this module; no new dependency, behavior unchanged.

- [x] `python -m py_compile` clean.
