### PR TITLE
docs: add EmpirioLabs as an OpenAI compatible provider

### DIFF
--- a/documentation/docs/advanced/empiriolabs.md
+++ b/documentation/docs/advanced/empiriolabs.md
@@ -1,0 +1,26 @@
+# EmpirioLabs
+:::info
+This is only helpful for self-hosted users. If you're using [Khoj Cloud](https://app.khoj.dev), you're limited to our first-party models.
+:::
+
+:::info
+Khoj natively supports local LLMs [available on HuggingFace in GGUF format](https://huggingface.co/models?library=gguf). Using an OpenAI API proxy with Khoj maybe useful for ease of setup, trying new models or using commercial LLMs via API.
+:::
+
+[EmpirioLabs](https://empiriolabs.ai) exposes an OpenAI compatible API that gives you access to many frontier open and commercial LLMs behind a single API key. This provides a standardized API to interact with a wide range of models without managing a separate provider for each one.
+
+Using EmpirioLabs with Khoj makes it possible to turn any of these LLMs into your personal AI agent.
+
+## Setup
+1. Create an account on [EmpirioLabs](https://empiriolabs.ai) and generate an API key from the [API keys page](https://platform.empiriolabs.ai/dashboard/api-keys)
+2. Create a new [AI Model API](http://localhost:42110/server/admin/database/aimodelapi/add) on your Khoj admin panel
+   - **Name**: `empiriolabs`
+   - **Api Key**: `your EmpirioLabs API key`
+   - **Api Base Url**: `https://api.empiriolabs.ai/v1`
+3. Create a new [Chat Model](http://localhost:42110/server/admin/database/chatmodel/add) on your Khoj admin panel.
+   - **Name**: `qwen3-7-plus` (replace with any [model](https://docs.empiriolabs.ai) you want to use, e.g. `deepseek-v4-pro`, `glm-5-1`, `kimi-k2-7-code`)
+   - **Model Type**: `Openai`
+   - **Ai Model Api**: *the empiriolabs AI Model API you created in step 2*
+   - **Max prompt size**: `20000` (replace with the max prompt size of your chosen model)
+   - **Tokenizer**: *Do not set for OpenAI, Mistral, Llama3 based models*
+4. Go to [your config](http://localhost:42110/settings) and select the model you just created in the chat model dropdown.

--- a/documentation/docs/advanced/use-openai-proxy.md
+++ b/documentation/docs/advanced/use-openai-proxy.md
@@ -11,12 +11,12 @@ This is only helpful for self-hosted users. If you're using [Khoj Cloud](https:/
 Khoj natively supports local LLMs [available on HuggingFace in GGUF format](https://huggingface.co/models?library=gguf). Using an OpenAI API proxy with Khoj maybe useful for ease of setup, trying new models or using commercial LLMs via API.
 :::
 
-Khoj can use any OpenAI API compatible server including local providers like [Ollama](/advanced/ollama), [LMStudio](/advanced/lmstudio) and [LiteLLM](/advanced/litellm) and commercial providers like [HuggingFace](https://huggingface.co/docs/api-inference/tasks/chat-completion#using-the-api), [OpenRouter](https://openrouter.ai/docs/quick-start) etc.
+Khoj can use any OpenAI API compatible server including local providers like [Ollama](/advanced/ollama), [LMStudio](/advanced/lmstudio) and [LiteLLM](/advanced/litellm) and commercial providers like [HuggingFace](https://huggingface.co/docs/api-inference/tasks/chat-completion#using-the-api), [OpenRouter](https://openrouter.ai/docs/quick-start), [EmpirioLabs](https://empiriolabs.ai) etc.
 Configuring this allows you to use non-standard, open or commercial, local or hosted LLM models for Khoj.
 
 Combine them with Khoj can turn your favorite LLM into an AI agent. Allowing you to chat with your docs, find answers from the internet, build custom agents and run automations.
 
-For specific integrations, see our [Ollama](/advanced/ollama), [LMStudio](/advanced/lmstudio) and [LiteLLM](/advanced/litellm) setup docs. For general instructions to setup Khoj with an OpenAI API proxy see below.
+For specific integrations, see our [Ollama](/advanced/ollama), [LMStudio](/advanced/lmstudio), [LiteLLM](/advanced/litellm) and [EmpirioLabs](/advanced/empiriolabs) setup docs. For general instructions to setup Khoj with an OpenAI API proxy see below.
 
 ## General Setup
 


### PR DESCRIPTION
## Summary

Adds [EmpirioLabs](https://empiriolabs.ai), an OpenAI API compatible provider, to the self-hosting docs so users can wire it up as a Chat Model in Khoj.

- New page `documentation/docs/advanced/empiriolabs.md` with the admin-panel setup steps (create an AI Model API pointing at `https://api.empiriolabs.ai/v1`, then a Chat Model with `Model Type: Openai`). It mirrors the existing `litellm.md` / `lmstudio.md` per-provider doc pattern.
- Lists EmpirioLabs alongside the other commercial providers (HuggingFace, OpenRouter) on `use-openai-proxy.md`, and cross-links the new setup page next to Ollama / LMStudio / LiteLLM.

The sidebar is autogenerated (`type: 'autogenerated'` in `sidebars.js`), so the new page appears automatically under Advanced Self Hosting with no manual nav change needed.

## Why

Khoj already documents OpenAI API compatible providers (LiteLLM, LMStudio, Ollama) and mentions commercial ones (OpenRouter, HuggingFace). EmpirioLabs is a hosted OpenAI compatible API that exposes many open and commercial models behind a single key, so it fits the same flow and gives self-hosted users one more documented option.

## Notes

- Docs-only change. No code paths touched.
- No new dependencies.