### PR TITLE
Fix exclude file filters leaking into query in FileFilter.defilter

### DIFF
--- a/src/khoj/search_filter/file_filter.py
+++ b/src/khoj/search_filter/file_filter.py
@@ -29,4 +29,7 @@ class FileFilter(BaseFilter):
         return file_filter.replace(".", r"\.").replace("*", r".*")
 
     def defilter(self, query: str) -> str:
-        return re.sub(self.file_filter_regex, "", query).strip()
+        # Remove both include (file:"...") and exclude (-file:"...") file filters from the query
+        query = re.sub(self.excluded_file_filter_regex, "", query)
+        query = re.sub(self.file_filter_regex, "", query)
+        return query.strip()

--- a/tests/test_file_filter.py
+++ b/tests/test_file_filter.py
@@ -132,6 +132,42 @@ def test_get_multiple_include_exclude_file_filter_terms():
     assert filter_terms == ["file 1.org", "/path/to/dir/.*.org", "-file 1.org", "-/path/to/dir/*.org"]
 
 
+def test_defilter_removes_include_file_filter():
+    # Arrange
+    file_filter = FileFilter()
+    q_with_filter = 'head file:"file 1.org" tail'
+
+    # Act
+    defiltered_query = file_filter.defilter(q_with_filter)
+
+    # Assert
+    assert defiltered_query == "head tail"
+
+
+def test_defilter_removes_exclude_file_filter():
+    # Arrange
+    file_filter = FileFilter()
+    q_with_filter = 'head -file:"file 1.org" tail'
+
+    # Act
+    defiltered_query = file_filter.defilter(q_with_filter)
+
+    # Assert
+    assert defiltered_query == "head tail"
+
+
+def test_defilter_removes_mixed_include_exclude_file_filters():
+    # Arrange
+    file_filter = FileFilter()
+    q_with_filter = 'head -file:"file 1.org" file:"/path/to/dir/*.org" tail'
+
+    # Act
+    defiltered_query = file_filter.defilter(q_with_filter)
+
+    # Assert
+    assert defiltered_query == "head tail"
+
+
 def arrange_content():
     entries = [
         Entry(compiled="", raw="First Entry", file="file 1.org"),


### PR DESCRIPTION
### Bug

`FileFilter.defilter()` only removes *include* file filters (`file:"..."`) from a query. Its `file_filter_regex` carries a `(?<!-)` negative lookbehind, so *exclude* filters of the form `-file:"..."` are never matched and stay in the query.

`defilter_query()` (`khoj/processor/conversation/utils.py`) runs every filter's `defilter()` to strip filter syntax before the query is sent to search and the chat model. Because exclude file filters aren't stripped, raw filter syntax like `-file:"notes.org"` leaks into the search/LLM query. This is inconsistent with `WordFilter.defilter()`, which removes both required (`+"..."`) and blocked (`-"..."`) terms.

### Fix

Strip the excluded file filter regex in addition to the include regex, so both `file:"..."` and `-file:"..."` are removed from the defiltered query.

### Verification

Added unit tests covering include, exclude, and mixed file filters in `tests/test_file_filter.py`, then ran them offline:

```
python -m pytest tests/test_file_filter.py
...
13 passed
```

Before the fix the two new exclude/mixed cases failed (`'head -file:"file 1.org" tail' != 'head tail'`); after the fix all 13 pass.
