### PR TITLE
Require opt-in to run operator terminal commands on the host

### DIFF
--- a/src/khoj/processor/operator/operator_environment_computer.py
+++ b/src/khoj/processor/operator/operator_environment_computer.py
@@ -15,7 +15,7 @@ from khoj.processor.operator.operator_environment_base import (
     EnvState,
     EnvStepResult,
 )
-from khoj.utils.helpers import convert_image_to_webp
+from khoj.utils.helpers import convert_image_to_webp, is_operator_local_shell_allowed
 
 logger = logging.getLogger(__name__)
 
@@ -344,7 +344,7 @@ class ComputerEnvironment(Environment):
 
                 case "terminal":
                     # Execute terminal command
-                    result = await self._execute_shell_command(action.command)
+                    result = await self._run_terminal_command(action.command)
                     if result["success"]:
                         output = f"Command executed successfully:\n{result['output']}"
                     else:
@@ -492,6 +492,26 @@ class ComputerEnvironment(Environment):
             current_url=after_state.url,
             screenshot_base64=after_state.screenshot,
         )
+
+    async def _run_terminal_command(self, command: str) -> dict:
+        """Run an operator-issued terminal command, gating host execution.
+
+        The terminal action runs whatever command the model emits. With the docker
+        provider this is sandboxed in a container; on the host it runs unsandboxed,
+        so it is refused unless explicitly allowed via KHOJ_OPERATOR_ALLOW_LOCAL_SHELL.
+        """
+        if self.provider != "docker" and not is_operator_local_shell_allowed():
+            return {
+                "success": False,
+                "output": "",
+                "error": (
+                    "Local shell execution is disabled. Set KHOJ_OPERATOR_ALLOW_LOCAL_SHELL=true "
+                    "to allow running terminal commands on the host, or use the docker provider."
+                ),
+            }
+        if self.provider != "docker":
+            logger.warning(f"Operator executing terminal command on the host: {command}")
+        return await self._execute_shell_command(command)
 
     async def _execute_shell_command(self, command: str, new: bool = True) -> dict:
         """Execute a shell command and return the result."""

--- a/src/khoj/utils/helpers.py
+++ b/src/khoj/utils/helpers.py
@@ -781,6 +781,14 @@ def is_operator_enabled():
     return is_env_var_true("KHOJ_OPERATOR_ENABLED")
 
 
+def is_operator_local_shell_allowed():
+    """Check if the operator may run terminal commands directly on the host.
+    Host shell execution runs unsandboxed as the Khoj process user, so it is
+    disabled by default. Set KHOJ_OPERATOR_ALLOW_LOCAL_SHELL env var to true to
+    allow it, or use the docker provider to run commands inside a container."""
+    return is_env_var_true("KHOJ_OPERATOR_ALLOW_LOCAL_SHELL")
+
+
 def is_code_sandbox_enabled():
     """Check if Khoj can run code in sandbox.
     Set KHOJ_TERRARIUM_URL or E2B api key via env var to enable it."""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -116,3 +116,14 @@ async def test_reading_webpage_with_olostep():
         "An alarm sent from the area near the fire also failed to register at the courthouse where the fire watchmen were"
         in response
     )
+
+
+def test_is_operator_local_shell_allowed(monkeypatch):
+    monkeypatch.delenv("KHOJ_OPERATOR_ALLOW_LOCAL_SHELL", raising=False)
+    assert helpers.is_operator_local_shell_allowed() is False
+
+    monkeypatch.setenv("KHOJ_OPERATOR_ALLOW_LOCAL_SHELL", "true")
+    assert helpers.is_operator_local_shell_allowed() is True
+
+    monkeypatch.setenv("KHOJ_OPERATOR_ALLOW_LOCAL_SHELL", "false")
+    assert helpers.is_operator_local_shell_allowed() is False

--- a/tests/test_operator_computer.py
+++ b/tests/test_operator_computer.py
@@ -1,0 +1,51 @@
+import pytest
+
+from khoj.processor.operator.operator_environment_computer import ComputerEnvironment
+
+
+def _stub_executor(record):
+    async def _execute(command, new=True):
+        record["command"] = command
+        return {"success": True, "output": "ran", "error": None}
+
+    return _execute
+
+
+@pytest.mark.asyncio
+async def test_local_terminal_refused_by_default(monkeypatch):
+    monkeypatch.delenv("KHOJ_OPERATOR_ALLOW_LOCAL_SHELL", raising=False)
+    env = ComputerEnvironment(provider="local")
+    record = {}
+    monkeypatch.setattr(env, "_execute_shell_command", _stub_executor(record))
+
+    result = await env._run_terminal_command("touch /tmp/pwned")
+
+    assert result["success"] is False
+    assert "disabled" in result["error"].lower()
+    assert "command" not in record
+
+
+@pytest.mark.asyncio
+async def test_local_terminal_runs_when_allowed(monkeypatch):
+    monkeypatch.setenv("KHOJ_OPERATOR_ALLOW_LOCAL_SHELL", "true")
+    env = ComputerEnvironment(provider="local")
+    record = {}
+    monkeypatch.setattr(env, "_execute_shell_command", _stub_executor(record))
+
+    result = await env._run_terminal_command("echo hi")
+
+    assert result["success"] is True
+    assert record["command"] == "echo hi"
+
+
+@pytest.mark.asyncio
+async def test_docker_terminal_not_gated(monkeypatch):
+    monkeypatch.delenv("KHOJ_OPERATOR_ALLOW_LOCAL_SHELL", raising=False)
+    env = ComputerEnvironment(provider="docker")
+    record = {}
+    monkeypatch.setattr(env, "_execute_shell_command", _stub_executor(record))
+
+    result = await env._run_terminal_command("echo hi")
+
+    assert result["success"] is True
+    assert record["command"] == "echo hi"


### PR DESCRIPTION
## Summary

Closes #1347.

The operator's `terminal` action runs whatever command the model emits. With the `docker` provider this runs inside a container (`bash -c ...`), but with the default `local` provider it ran on the host via `subprocess.run(command, shell=True)` with no gating. A prompt-injected model could therefore execute arbitrary commands as the Khoj process user, and `_execute_shell_command` returned success with no log, so it happened silently.

This gates host execution of the `terminal` action behind an explicit opt-in:

- Host (`local` provider) terminal commands are refused unless `KHOJ_OPERATOR_ALLOW_LOCAL_SHELL=true` is set, via a new `is_operator_local_shell_allowed()` helper that mirrors the existing `is_operator_enabled()`.
- The `docker` provider is unchanged; commands stay sandboxed in the container.
- When a host command does run, it is logged with `logger.warning` so execution is no longer silent.

Execution is otherwise unchanged; this only adds a default-safe gate around the host path, extracted into `_run_terminal_command` so it is easy to test. The `text_editor_*` actions build their own commands with quoted paths and are out of scope here.

This is the minimal default-safe mitigation. If you would prefer a different posture, for example an interactive confirmation step or restricting the operator to the `docker` provider entirely, I am happy to adjust.

## Test plan

- `tests/test_operator_computer.py`: `_run_terminal_command` refuses on the host by default (the executor is not called), runs when `KHOJ_OPERATOR_ALLOW_LOCAL_SHELL=true`, and is ungated for the `docker` provider.
- `tests/test_helpers.py`: `is_operator_local_shell_allowed()` env var behavior.
