### PR TITLE
feat: add 'obsidian' EntrySource to distinguish plugin-imported content

### DIFF
--- a/src/khoj/database/adapters/__init__.py
+++ b/src/khoj/database/adapters/__init__.py
@@ -1795,7 +1795,9 @@ class ConversationAdapters:
     @staticmethod
     def add_files_to_filter(user: KhojUser, conversation_id: str, files: List[str]):
         conversation = ConversationAdapters.get_conversation_by_user(user, conversation_id=conversation_id)
-        file_list = EntryAdapters.get_all_filenames_by_source(user, "computer")
+        file_list = set(EntryAdapters.get_all_filenames_by_source(user, Entry.EntrySource.COMPUTER)) | set(
+            EntryAdapters.get_all_filenames_by_source(user, Entry.EntrySource.OBSIDIAN)
+        )
         if not conversation:
             return []
         for filename in files:
@@ -1819,7 +1821,9 @@ class ConversationAdapters:
         conversation.save()
 
         # remove files from conversation.file_filters that are not in file_list
-        file_list = EntryAdapters.get_all_filenames_by_source(user, "computer")
+        file_list = set(EntryAdapters.get_all_filenames_by_source(user, Entry.EntrySource.COMPUTER)) | set(
+            EntryAdapters.get_all_filenames_by_source(user, Entry.EntrySource.OBSIDIAN)
+        )
         conversation.file_filters = [file for file in conversation.file_filters if file in file_list]
         conversation.save()
         return conversation.file_filters

--- a/src/khoj/database/models/__init__.py
+++ b/src/khoj/database/models/__init__.py
@@ -781,6 +781,7 @@ class Entry(DbBaseModel):
         COMPUTER = "computer"
         NOTION = "notion"
         GITHUB = "github"
+        OBSIDIAN = "obsidian"
 
     user = models.ForeignKey(KhojUser, on_delete=models.CASCADE, default=None, null=True, blank=True)
     agent = models.ForeignKey(Agent, on_delete=models.CASCADE, default=None, null=True, blank=True)

--- a/src/khoj/processor/content/docx/docx_to_entries.py
+++ b/src/khoj/processor/content/docx/docx_to_entries.py
@@ -18,7 +18,9 @@ class DocxToEntries(TextToEntries):
         super().__init__()
 
     # Define Functions
-    def process(self, files: dict[str, str], user: KhojUser, regenerate: bool = False) -> Tuple[int, int]:
+    def process(
+        self, files: dict[str, str], user: KhojUser, regenerate: bool = False, file_source: str = None
+    ) -> Tuple[int, int]:
         # Extract required fields from config
         deletion_file_names = set([file for file in files if files[file] == b""])
         files_to_process = set(files) - deletion_file_names
@@ -38,7 +40,7 @@ class DocxToEntries(TextToEntries):
                 user,
                 current_entries,
                 DbEntry.EntryType.DOCX,
-                DbEntry.EntrySource.COMPUTER,
+                file_source or DbEntry.EntrySource.COMPUTER,
                 "compiled",
                 logger,
                 deletion_file_names,

--- a/src/khoj/processor/content/github/github_to_entries.py
+++ b/src/khoj/processor/content/github/github_to_entries.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import requests
 from magika import Magika
@@ -49,7 +49,9 @@ class GithubToEntries(TextToEntries):
         else:
             return
 
-    def process(self, files: dict[str, str], user: KhojUser, regenerate: bool = False) -> Tuple[int, int]:
+    def process(
+        self, files: dict[str, str], user: KhojUser, regenerate: bool = False, file_source: Optional[str] = None
+    ) -> Tuple[int, int]:
         if is_none_or_empty(self.config.pat_token):
             logger.warning(
                 "Github PAT token is not set. Private repositories cannot be indexed and lower rate limits apply."

--- a/src/khoj/processor/content/images/image_to_entries.py
+++ b/src/khoj/processor/content/images/image_to_entries.py
@@ -17,7 +17,9 @@ class ImageToEntries(TextToEntries):
         super().__init__()
 
     # Define Functions
-    def process(self, files: dict[str, str], user: KhojUser, regenerate: bool = False) -> Tuple[int, int]:
+    def process(
+        self, files: dict[str, str], user: KhojUser, regenerate: bool = False, file_source: str = None
+    ) -> Tuple[int, int]:
         # Extract required fields from config
         deletion_file_names = set([file for file in files if files[file] == b""])
         files_to_process = set(files) - deletion_file_names
@@ -37,7 +39,7 @@ class ImageToEntries(TextToEntries):
                 user,
                 current_entries,
                 DbEntry.EntryType.IMAGE,
-                DbEntry.EntrySource.COMPUTER,
+                file_source or DbEntry.EntrySource.COMPUTER,
                 "compiled",
                 logger,
                 deletion_file_names,

--- a/src/khoj/processor/content/markdown/markdown_to_entries.py
+++ b/src/khoj/processor/content/markdown/markdown_to_entries.py
@@ -18,7 +18,9 @@ class MarkdownToEntries(TextToEntries):
         super().__init__()
 
     # Define Functions
-    def process(self, files: dict[str, str], user: KhojUser, regenerate: bool = False) -> Tuple[int, int]:
+    def process(
+        self, files: dict[str, str], user: KhojUser, regenerate: bool = False, file_source: str = None
+    ) -> Tuple[int, int]:
         # Extract required fields from config
         deletion_file_names = set([file for file in files if files[file] == ""])
         files_to_process = set(files) - deletion_file_names
@@ -39,7 +41,7 @@ class MarkdownToEntries(TextToEntries):
                 user,
                 current_entries,
                 DbEntry.EntryType.MARKDOWN,
-                DbEntry.EntrySource.COMPUTER,
+                file_source or DbEntry.EntrySource.COMPUTER,
                 "compiled",
                 logger,
                 deletion_file_names,

--- a/src/khoj/processor/content/notion/notion_to_entries.py
+++ b/src/khoj/processor/content/notion/notion_to_entries.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum
-from typing import Tuple
+from typing import Optional, Tuple
 
 import requests
 
@@ -79,7 +79,9 @@ class NotionToEntries(TextToEntries):
 
         self.body_params = {"page_size": 100}
 
-    def process(self, files: dict[str, str], user: KhojUser, regenerate: bool = False) -> Tuple[int, int]:
+    def process(
+        self, files: dict[str, str], user: KhojUser, regenerate: bool = False, file_source: Optional[str] = None
+    ) -> Tuple[int, int]:
         current_entries = []
 
         # Get all pages

--- a/src/khoj/processor/content/org_mode/org_to_entries.py
+++ b/src/khoj/processor/content/org_mode/org_to_entries.py
@@ -19,7 +19,9 @@ class OrgToEntries(TextToEntries):
         super().__init__()
 
     # Define Functions
-    def process(self, files: dict[str, str], user: KhojUser, regenerate: bool = False) -> Tuple[int, int]:
+    def process(
+        self, files: dict[str, str], user: KhojUser, regenerate: bool = False, file_source: str = None
+    ) -> Tuple[int, int]:
         deletion_file_names = set([file for file in files if files[file] == ""])
         files_to_process = set(files) - deletion_file_names
         files = {file: files[file] for file in files_to_process}
@@ -38,7 +40,7 @@ class OrgToEntries(TextToEntries):
                 user,
                 current_entries,
                 DbEntry.EntryType.ORG,
-                DbEntry.EntrySource.COMPUTER,
+                file_source or DbEntry.EntrySource.COMPUTER,
                 "compiled",
                 logger,
                 deletion_file_names,

--- a/src/khoj/processor/content/pdf/pdf_to_entries.py
+++ b/src/khoj/processor/content/pdf/pdf_to_entries.py
@@ -21,7 +21,9 @@ class PdfToEntries(TextToEntries):
         super().__init__()
 
     # Define Functions
-    def process(self, files: dict[str, str], user: KhojUser, regenerate: bool = False) -> Tuple[int, int]:
+    def process(
+        self, files: dict[str, str], user: KhojUser, regenerate: bool = False, file_source: str = None
+    ) -> Tuple[int, int]:
         # Extract required fields from config
         deletion_file_names = set([file for file in files if files[file] == b""])
         files_to_process = set(files) - deletion_file_names
@@ -41,7 +43,7 @@ class PdfToEntries(TextToEntries):
                 user,
                 current_entries,
                 DbEntry.EntryType.PDF,
-                DbEntry.EntrySource.COMPUTER,
+                file_source or DbEntry.EntrySource.COMPUTER,
                 "compiled",
                 logger,
                 deletion_file_names,

--- a/src/khoj/processor/content/plaintext/plaintext_to_entries.py
+++ b/src/khoj/processor/content/plaintext/plaintext_to_entries.py
@@ -19,7 +19,9 @@ class PlaintextToEntries(TextToEntries):
         super().__init__()
 
     # Define Functions
-    def process(self, files: dict[str, str], user: KhojUser, regenerate: bool = False) -> Tuple[int, int]:
+    def process(
+        self, files: dict[str, str], user: KhojUser, regenerate: bool = False, file_source: str = None
+    ) -> Tuple[int, int]:
         deletion_file_names = set([file for file in files if files[file] == ""])
         files_to_process = set(files) - deletion_file_names
         files = {file: files[file] for file in files_to_process}
@@ -38,7 +40,7 @@ class PlaintextToEntries(TextToEntries):
                 user,
                 current_entries,
                 DbEntry.EntryType.PLAINTEXT,
-                DbEntry.EntrySource.COMPUTER,
+                file_source or DbEntry.EntrySource.COMPUTER,
                 key="compiled",
                 logger=logger,
                 deletion_filenames=deletion_file_names,

--- a/src/khoj/processor/content/text_to_entries.py
+++ b/src/khoj/processor/content/text_to_entries.py
@@ -30,7 +30,9 @@ class TextToEntries(ABC):
         self.date_filter = DateFilter()
 
     @abstractmethod
-    def process(self, files: dict[str, str], user: KhojUser, regenerate: bool = False) -> Tuple[int, int]: ...
+    def process(
+        self, files: dict[str, str], user: KhojUser, regenerate: bool = False, file_source: str = None
+    ) -> Tuple[int, int]: ...
 
     @staticmethod
     def hash_func(key: str) -> Callable:

--- a/src/khoj/routers/api_chat.py
+++ b/src/khoj/routers/api_chat.py
@@ -33,6 +33,7 @@ from khoj.database.adapters import (
     aget_user_name,
 )
 from khoj.database.models import Agent, KhojUser
+from khoj.database.models import Entry as DbEntry
 from khoj.processor.conversation import prompts
 from khoj.processor.conversation.openai.utils import is_local_api
 from khoj.processor.conversation.prompts import no_entries_found
@@ -128,8 +129,10 @@ def get_file_filter(request: Request, conversation_id: str) -> Response:
     if not conversation:
         return Response(content=json.dumps({"status": "error", "message": "Conversation not found"}), status_code=404)
 
-    # get all files from "computer"
-    file_list = EntryAdapters.get_all_filenames_by_source(request.user.object, "computer")
+    # get all files from "computer" and "obsidian" sources
+    file_list = set(EntryAdapters.get_all_filenames_by_source(request.user.object, DbEntry.EntrySource.COMPUTER)) | set(
+        EntryAdapters.get_all_filenames_by_source(request.user.object, DbEntry.EntrySource.OBSIDIAN)
+    )
     file_filters = []
     for file in conversation.file_filters:
         if file in file_list:

--- a/src/khoj/routers/api_content.py
+++ b/src/khoj/routers/api_content.py
@@ -581,6 +581,11 @@ async def indexer(
             docx=index_files["docx"],
         )
 
+        # Determine file_source based on client type
+        file_source = DbEntry.EntrySource.COMPUTER
+        if client and client.lower() == "obsidian":
+            file_source = DbEntry.EntrySource.OBSIDIAN
+
         loop = asyncio.get_event_loop()
         success = await loop.run_in_executor(
             None,
@@ -589,6 +594,7 @@ async def indexer(
             indexer_input.model_dump(),
             regenerate,
             t,
+            file_source,
         )
         if not success:
             raise RuntimeError(f"Failed to {method} {t} data sent by {client} client into content index")
@@ -633,4 +639,7 @@ def map_config_to_object(content_source: str):
     if content_source == DbEntry.EntrySource.NOTION:
         return NotionConfig
     if content_source == DbEntry.EntrySource.COMPUTER:
+        return "Computer"
+    if content_source == DbEntry.EntrySource.OBSIDIAN:
+        # Obsidian has no dedicated config object; delete via file objects + entries path (same as Computer)
         return "Computer"

--- a/src/khoj/routers/helpers.py
+++ b/src/khoj/routers/helpers.py
@@ -2910,6 +2910,7 @@ def get_user_config(user: KhojUser, request: Request, is_detailed: bool = False)
         "computer": ("computer" in enabled_content_sources_set),
         "github": ("github" in enabled_content_sources_set),
         "notion": ("notion" in enabled_content_sources_set),
+        "obsidian": ("obsidian" in enabled_content_sources_set),
     }
 
     notion_oauth_url = get_notion_auth_url(user)
@@ -3012,6 +3013,7 @@ def configure_content(
     files: Optional[dict[str, dict[str, str]]],
     regenerate: bool = False,
     t: Optional[state.SearchType] = state.SearchType.All,
+    file_source: Optional[str] = None,
 ) -> bool:
     success = True
     if t is None:
@@ -3045,6 +3047,7 @@ def configure_content(
                 files.get("org"),
                 regenerate=regenerate,
                 user=user,
+                file_source=file_source,
             )
     except Exception as e:
         logger.error(f"🚨 Failed to setup org: {e}", exc_info=True)
@@ -3062,6 +3065,7 @@ def configure_content(
                 files.get("markdown"),
                 regenerate=regenerate,
                 user=user,
+                file_source=file_source,
             )
 
     except Exception as e:
@@ -3080,6 +3084,7 @@ def configure_content(
                 files.get("pdf"),
                 regenerate=regenerate,
                 user=user,
+                file_source=file_source,
             )
 
     except Exception as e:
@@ -3098,6 +3103,7 @@ def configure_content(
                 files.get("plaintext"),
                 regenerate=regenerate,
                 user=user,
+                file_source=file_source,
             )
 
     except Exception as e:
@@ -3158,6 +3164,7 @@ def configure_content(
                 files.get("image"),
                 regenerate=regenerate,
                 user=user,
+                file_source=file_source,
             )
     except Exception as e:
         logger.error(f"🚨 Failed to setup images: {e}", exc_info=True)
@@ -3170,6 +3177,7 @@ def configure_content(
                 files.get("docx"),
                 regenerate=regenerate,
                 user=user,
+                file_source=file_source,
             )
     except Exception as e:
         logger.error(f"🚨 Failed to setup docx: {e}", exc_info=True)

--- a/src/khoj/search_type/text_search.py
+++ b/src/khoj/search_type/text_search.py
@@ -212,14 +212,15 @@ def setup(
     regenerate: bool,
     user: KhojUser,
     config=None,
+    file_source: str = None,
 ) -> Tuple[int, int]:
     if config:
         num_new_embeddings, num_deleted_embeddings = text_to_entries(config).process(
-            files=files, user=user, regenerate=regenerate
+            files=files, user=user, regenerate=regenerate, file_source=file_source
         )
     else:
         num_new_embeddings, num_deleted_embeddings = text_to_entries().process(
-            files=files, user=user, regenerate=regenerate
+            files=files, user=user, regenerate=regenerate, file_source=file_source
         )
 
     if files:


### PR DESCRIPTION
## Summary

Adds a granular `OBSIDIAN` value to the `EntrySource` enum and threads a `file_source` parameter through the content indexing pipeline (`indexer` → `configure_content` → `text_search.setup` → content processors). When the Obsidian plugin client syncs content, entries are now persisted with `file_source='obsidian'` instead of the generic `'computer'`, enabling targeted delete/filter/query operations on Obsidian-imported content without affecting imports from the desktop client or other sources.

This re-submits the intent of #1243 (closed by the original author due to inactivity, with no technical objection), rebased onto the latest `master` and extended to address downstream consumers of `EntrySource` so the change is non-regressing.

Resolves #1239.

## Changes

- **`database/models/__init__.py`**: add `EntrySource.OBSIDIAN = "obsidian"`.
- **`text_to_entries.py`**: add `file_source: str = None` to the abstract `process()` signature.
- **6 content processors** (markdown/org/pdf/plaintext/image/docx): accept `file_source` and pass `file_source or DbEntry.EntrySource.COMPUTER` to `update_embeddings()`.
- **`notion_to_entries.py` / `github_to_entries.py`**: also accept `file_source` to keep the abstract signature consistent. They continue to use their dedicated `EntrySource.NOTION` / `EntrySource.GITHUB` and ignore the parameter — this prevents a silent `TypeError` in `setup()` that was previously swallowed by `configure_content`'s try/except (GitHub/Notion indexing would silently fail).
- **`routers/helpers.py`**: `configure_content()` accepts `file_source: Optional[str] = None` and forwards it to the 6 file-type `text_search.setup()` calls (GitHub/Notion blocks untouched — they use their own sources). Also exposes `"obsidian"` in `enabled_content_sources` so the backend reports it as a content source the user has indexed.
- **`search_type/text_search.py`**: `setup()` accepts `file_source` and forwards it to `process()`.
- **`routers/api_content.py`**: `indexer()` derives `file_source` from the `client` arg (`obsidian` → `EntrySource.OBSIDIAN`, else `COMPUTER`) and passes it through `run_in_executor`. `map_config_to_object()` gets an explicit `OBSIDIAN` branch returning the `"Computer"` sentinel (Obsidian has no dedicated config object, same as Computer) so `delete_content_source("obsidian")` routes through the file-objects + entries deletion path instead of raising `ValueError`. All downstream deletes use the original `content_source="obsidian"`, so only Obsidian entries/file-objects are removed — Computer content is not affected.
- **`routers/api_chat.py`** + **`database/adapters/__init__.py`**: `get_file_filter`, `add_files_to_filter`, and `remove_files_from_filter` now query both `EntrySource.COMPUTER` and `EntrySource.OBSIDIAN` files (set-unioned). Previously they only queried `"computer"`, which would silently drop Obsidian-imported files from the chat file-filter list and erase existing Obsidian filter entries when users added/removed any filter entry (data-loss regression introduced by tagging Obsidian content with `'obsidian'`).

## Backward compatibility

All existing call sites default to `file_source or EntrySource.COMPUTER` (or `None` → falls back to `COMPUTER`), preserving current behavior for the desktop client, manual ingestion, and server-side GitHub/Notion indexing. No database migration is needed — `TextChoices` is application-layer validation and the underlying `CharField(max_length=30)` already accommodates the `"obsidian"` value.

## Validation

- `ruff check` — passed
- `ruff format --check` — passed (222 files already formatted)
- `python -m py_compile` — all 15 modified files compile
- AST verification confirms `EntrySource.OBSIDIAN == "obsidian"` and `file_source` parameter present in all expected signatures
- Static scan of all 24 `EntrySource` reference sites confirms no call site requires updating for the new value

## Out of scope (potential follow-ups)

These were intentionally left out to keep the PR focused; happy to send follow-up PRs if useful:

- Unit tests covering the obsidian path (`client=obsidian` tagging, `delete_content_source("obsidian")`, file-filter preservation).
- Frontend `SyncedContent` TypeScript type and `disconnectContent` handler do not yet include `obsidian` — runtime is unaffected (extra backend keys are ignored), but the Obsidian source won't have a disconnect button in the web settings UI. The Obsidian plugin self-manages its content via `/api/content?client=obsidian`, so this is cosmetic.
- Optional micro-optimization: replace the two `get_all_filenames_by_source` calls with a single `file_source__in=[COMPUTER, OBSIDIAN]` query.

## References

- Issue: #1239
- Prior art (closed, not merged): #1243
