### PR TITLE
Add MiniMax chat model defaults

### DIFF
--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -94,6 +94,8 @@ model_to_prompt_size = {
     "claude-sonnet-4-20250514": 60000,
     "claude-opus-4-0": 60000,
     "claude-opus-4-20250514": 60000,
+    # MiniMax Models
+    "MiniMax-M3": 1000000,
 }
 model_to_tokenizer: Dict[str, str] = {}
 

--- a/src/khoj/utils/constants.py
+++ b/src/khoj/utils/constants.py
@@ -14,6 +14,7 @@ content_directory = "~/.khoj/content/"
 default_openai_chat_models = ["gpt-4o-mini", "gpt-4.1", "o3", "o4-mini"]
 default_gemini_chat_models = ["gemini-2.0-flash", "gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.5-flash-lite"]
 default_anthropic_chat_models = ["claude-sonnet-4-0", "claude-3-5-haiku-latest"]
+default_minimax_chat_models = ["MiniMax-M3"]
 
 empty_config = {
     "search-type": {

--- a/src/khoj/utils/helpers.py
+++ b/src/khoj/utils/helpers.py
@@ -1175,7 +1175,7 @@ def get_openai_async_client(api_key: str, api_base_url: str) -> Union[openai.Asy
 def get_anthropic_client(api_key, api_base_url=None) -> anthropic.Anthropic | anthropic.AnthropicVertex:
     api_info = get_ai_api_info(api_key, api_base_url)
     if api_info.api_key:
-        client = anthropic.Anthropic(api_key=api_info.api_key)
+        client = anthropic.Anthropic(api_key=api_info.api_key, base_url=api_base_url)
     else:
         client = anthropic.AnthropicVertex(
             region=api_info.region,
@@ -1188,7 +1188,7 @@ def get_anthropic_client(api_key, api_base_url=None) -> anthropic.Anthropic | an
 def get_anthropic_async_client(api_key, api_base_url=None) -> anthropic.AsyncAnthropic | anthropic.AsyncAnthropicVertex:
     api_info = get_ai_api_info(api_key, api_base_url)
     if api_info.api_key:
-        client = anthropic.AsyncAnthropic(api_key=api_info.api_key)
+        client = anthropic.AsyncAnthropic(api_key=api_info.api_key, base_url=api_base_url)
     else:
         client = anthropic.AsyncAnthropicVertex(
             region=api_info.region,

--- a/src/khoj/utils/initialization.py
+++ b/src/khoj/utils/initialization.py
@@ -160,7 +160,7 @@ def initialization(interactive: bool = True):
             ChatModel.ModelType.ANTHROPIC,
             default_minimax_chat_models,
             default_api_key=minimax_anthropic_api_key,
-            api_base_url=os.getenv("MINIMAX_ANTHROPIC_BASE_URL", "https://api.minimax.io/anthropic/v1"),
+            api_base_url=os.getenv("MINIMAX_ANTHROPIC_BASE_URL", "https://api.minimax.io/anthropic"),
             interactive=interactive,
             provider_name="MiniMax Anthropic",
         )

--- a/src/khoj/utils/initialization.py
+++ b/src/khoj/utils/initialization.py
@@ -16,6 +16,7 @@ from khoj.processor.conversation.utils import model_to_prompt_size, model_to_tok
 from khoj.utils.constants import (
     default_anthropic_chat_models,
     default_gemini_chat_models,
+    default_minimax_chat_models,
     default_openai_chat_models,
 )
 
@@ -71,6 +72,17 @@ def initialization(interactive: bool = True):
             vision_enabled=True,
             interactive=interactive,
             provider_name=provider,
+        )
+
+        minimax_base_url = os.getenv("MINIMAX_BASE_URL", "https://api.minimax.io/v1")
+        minimax_api_key = os.getenv("MINIMAX_API_KEY")
+        _setup_chat_model_provider(
+            ChatModel.ModelType.OPENAI,
+            default_minimax_chat_models,
+            default_api_key=minimax_api_key,
+            api_base_url=minimax_base_url,
+            interactive=interactive,
+            provider_name="MiniMax",
         )
 
         # Setup OpenAI speech to text model
@@ -143,6 +155,16 @@ def initialization(interactive: bool = True):
             interactive=interactive,
         )
 
+        minimax_anthropic_api_key = os.getenv("MINIMAX_ANTHROPIC_API_KEY")
+        _setup_chat_model_provider(
+            ChatModel.ModelType.ANTHROPIC,
+            default_minimax_chat_models,
+            default_api_key=minimax_anthropic_api_key,
+            api_base_url=os.getenv("MINIMAX_ANTHROPIC_BASE_URL", "https://api.minimax.io/anthropic/v1"),
+            interactive=interactive,
+            provider_name="MiniMax Anthropic",
+        )
+
         logger.info("🗣️ Chat model configuration complete")
 
     def _setup_chat_model_provider(
@@ -155,7 +177,10 @@ def initialization(interactive: bool = True):
         provider_name: str = None,
     ) -> Tuple[bool, AiModelApi]:
         supported_vision_models = (
-            default_openai_chat_models + default_anthropic_chat_models + default_gemini_chat_models
+            default_openai_chat_models
+            + default_anthropic_chat_models
+            + default_gemini_chat_models
+            + default_minimax_chat_models
         )
         provider_name = provider_name or model_type.name.capitalize()
 
@@ -213,9 +238,9 @@ def initialization(interactive: bool = True):
             # Get OpenAI configs with custom base URLs
             custom_configs = AiModelApi.objects.exclude(api_base_url__isnull=True)
 
-            # Only enable for whitelisted provider names (i.e Ollama) for now
+            # Only enable for whitelisted OpenAI-compatible providers for now
             # TODO: This is hacky. Will be replaced with more robust solution based on provider type enum
-            custom_configs = custom_configs.filter(name__in=["Ollama"])
+            custom_configs = custom_configs.filter(name__in=["Ollama", "MiniMax"])
 
             for config in custom_configs:
                 try:


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Add MiniMax-M3 as a default MiniMax chat model.
- Configure MiniMax OpenAI-compatible and Anthropic-compatible setup defaults.
- Set MiniMax-M3 context and allow custom Anthropic base URLs.

## Test plan
- python3 -m py_compile src/khoj/utils/constants.py src/khoj/utils/initialization.py src/khoj/processor/conversation/utils.py src/khoj/utils/helpers.py

Generated with Claude Code.