### PR TITLE
Add MiniMax chat model provider defaults

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,12 +83,18 @@ services:
       # - OPENAI_BASE_URL=http://host.docker.internal:11434/v1/
       # - KHOJ_DEFAULT_CHAT_MODEL=qwen3
       #
-      # Uncomment appropriate lines below to use chat models by OpenAI, Anthropic, Google.
+      # Uncomment appropriate lines below to use chat models by OpenAI, Anthropic, Google, or MiniMax.
       # Ensure you set your provider specific API keys.
       # ---
       # - OPENAI_API_KEY=your_openai_api_key
       # - GEMINI_API_KEY=your_gemini_api_key
       # - ANTHROPIC_API_KEY=your_anthropic_api_key
+      # - MINIMAX_API_KEY=your_minimax_api_key
+      # Global OpenAI compatible default: https://api.minimax.io/v1
+      # Global Anthropic compatible default: https://api.minimax.io/anthropic
+      # Set both overrides below to use the China endpoints instead.
+      # - MINIMAX_BASE_URL=https://api.minimaxi.com/v1
+      # - MINIMAX_ANTHROPIC_BASE_URL=https://api.minimaxi.com/anthropic
       #
       # Uncomment line below to enable Khoj to use its computer.
       # - KHOJ_OPERATOR_ENABLED=True

--- a/src/khoj/processor/conversation/anthropic/utils.py
+++ b/src/khoj/processor/conversation/anthropic/utils.py
@@ -19,8 +19,10 @@ from khoj.processor.conversation.utils import (
     ResponseWithThought,
     ToolCall,
     commit_conversation_trace,
+    configure_minimax_m3_thinking,
     get_image_from_base64,
     get_image_from_url,
+    is_minimax_m3_model,
 )
 from khoj.utils.helpers import (
     ToolDefinition,
@@ -63,10 +65,11 @@ def anthropic_completion_with_backoff(
     deepthought: bool = False,
     tracer: dict = {},
 ) -> ResponseWithThought:
-    client = anthropic_clients.get(api_key)
+    client_key = f"{api_key}--{api_base_url}"
+    client = anthropic_clients.get(client_key)
     if not client:
         client = get_anthropic_client(api_key, api_base_url)
-        anthropic_clients[api_key] = client
+        anthropic_clients[client_key] = client
 
     formatted_messages, system = format_messages_for_anthropic(messages, system_prompt)
 
@@ -91,7 +94,9 @@ def anthropic_completion_with_backoff(
         model_kwargs["tools"] = [
             anthropic.types.ToolParam(name=tool.name, description=tool.description, input_schema=tool.schema)
         ]
-    elif response_type == "json_object" and not (is_reasoning_model(model_name) and deepthought):
+    elif response_type == "json_object" and not (
+        deepthought and (is_reasoning_model(model_name) or is_minimax_m3_model(model_name))
+    ):
         # Prefill model response with '{' to make it output a valid JSON object. Not supported with extended thinking.
         formatted_messages.append(anthropic.types.MessageParam(role="assistant", content="{"))
         aggregated_response += "{"
@@ -100,7 +105,8 @@ def anthropic_completion_with_backoff(
         model_kwargs["system"] = system
 
     max_tokens = max_tokens or DEFAULT_MAX_TOKENS_ANTHROPIC
-    if deepthought and is_reasoning_model(model_name):
+    minimax_thinking_configured = configure_minimax_m3_thinking(model_name, deepthought, model_kwargs)
+    if not minimax_thinking_configured and deepthought and is_reasoning_model(model_name):
         model_kwargs["thinking"] = {"type": "enabled", "budget_tokens": MAX_REASONING_TOKENS_ANTHROPIC}
         model_kwargs["betas"] = ["context-management-2025-06-27"]
         model_kwargs["context_management"] = {"edits": [{"type": "clear_thinking_20251015", "keep": "all"}]}
@@ -192,14 +198,16 @@ async def anthropic_chat_completion_with_backoff(
     model_kwargs: dict | None = None,
     tracer: dict = {},
 ) -> AsyncGenerator[ResponseWithThought, None]:
-    client = anthropic_async_clients.get(api_key)
+    client_key = f"{api_key}--{api_base_url}"
+    client = anthropic_async_clients.get(client_key)
     if not client:
         client = get_anthropic_async_client(api_key, api_base_url)
-        anthropic_async_clients[api_key] = client
+        anthropic_async_clients[client_key] = client
 
     model_kwargs = model_kwargs or dict()
     max_tokens = DEFAULT_MAX_TOKENS_ANTHROPIC
-    if deepthought and is_reasoning_model(model_name):
+    minimax_thinking_configured = configure_minimax_m3_thinking(model_name, deepthought, model_kwargs)
+    if not minimax_thinking_configured and deepthought and is_reasoning_model(model_name):
         model_kwargs["thinking"] = {"type": "enabled", "budget_tokens": MAX_REASONING_TOKENS_ANTHROPIC}
         max_tokens += MAX_REASONING_TOKENS_ANTHROPIC
         # Temperature control not supported when using extended thinking

--- a/src/khoj/processor/conversation/openai/utils.py
+++ b/src/khoj/processor/conversation/openai/utils.py
@@ -39,6 +39,7 @@ from khoj.processor.conversation.utils import (
     StructuredOutputSupport,
     ToolCall,
     commit_conversation_trace,
+    configure_minimax_m3_thinking,
 )
 from khoj.utils.helpers import (
     ToolDefinition,
@@ -99,9 +100,10 @@ def completion_with_backoff(
     openai_api_key=None,
     api_base_url: str | None = None,
     deepthought: bool = False,
-    model_kwargs: dict = {},
+    model_kwargs: dict | None = None,
     tracer: dict = {},
 ) -> ResponseWithThought:
+    model_kwargs = deepcopy(model_kwargs) if model_kwargs else {}
     client_key = f"{openai_api_key}--{api_base_url}"
     client = openai_clients.get(client_key)
     if not client:
@@ -149,6 +151,7 @@ def completion_with_backoff(
         formatted_messages = updated_messages
     elif is_instream_thinking_model(model_name):
         stream_processor = in_stream_thought_processor
+        configure_minimax_m3_thinking(model_name, deepthought, model_kwargs)
     elif is_qwen_style_reasoning_model(model_name, api_base_url):
         stream_processor = in_stream_thought_processor
         # Reasoning is enabled by default. Disable when deepthought is False.
@@ -351,6 +354,7 @@ async def chat_completion_with_backoff(
         formatted_messages = updated_messages
     elif is_instream_thinking_model(model_name):
         stream_processor = ain_stream_thought_processor
+        configure_minimax_m3_thinking(model_name, deepthought, model_kwargs)
     elif is_qwen_style_reasoning_model(model_name, api_base_url):
         stream_processor = ain_stream_thought_processor
         # Reasoning is enabled by default. Disable when deepthought is False.

--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -94,8 +94,22 @@ model_to_prompt_size = {
     "claude-sonnet-4-20250514": 60000,
     "claude-opus-4-0": 60000,
     "claude-opus-4-20250514": 60000,
+    # MiniMax Models
+    "MiniMax-M3": 1000000,
+    "MiniMax-M2.7": 204800,
 }
 model_to_tokenizer: Dict[str, str] = {}
+
+
+def is_minimax_m3_model(model_name: str) -> bool:
+    return model_name.lower().startswith("minimax-m3")
+
+
+def configure_minimax_m3_thinking(model_name: str, deepthought: bool, model_kwargs: dict) -> bool:
+    if not is_minimax_m3_model(model_name):
+        return False
+    model_kwargs.setdefault("extra_body", {})["thinking"] = {"type": "adaptive" if deepthought else "disabled"}
+    return True
 
 
 class RetryableModelError(Exception):

--- a/src/khoj/utils/constants.py
+++ b/src/khoj/utils/constants.py
@@ -94,19 +94,6 @@ model_to_cost: Dict[str, Dict[str, float]] = {
     # Moonshot AI, Baseten pricing for Kimi-K2-Thinking
     "moonshotai/kimi-k2-thinking": {"input": 0.60, "output": 2.50},
     # MiniMax Pricing: https://platform.minimax.io/docs/guides/pricing-paygo
-    "MiniMax-M3": {"input": 0.3, "output": 1.2, "cache_read": 0.06},
+    "MiniMax-M3": {"input": 0.6, "output": 2.4, "cache_read": 0.12},
     "MiniMax-M2.7": {"input": 0.3, "output": 1.2, "cache_read": 0.06, "cache_write": 0.375},
-}
-
-model_to_cost_tiers: Dict[str, Dict[str, list[Dict[str, float]]]] = {
-    "MiniMax-M3": {
-        "standard": [
-            {"input_tokens_lte": 512_000, "input": 0.3, "output": 1.2, "cache_read": 0.06},
-            {"input_tokens_gt": 512_000, "input": 0.6, "output": 2.4, "cache_read": 0.12},
-        ],
-        "priority": [
-            {"input_tokens_lte": 512_000, "input": 0.45, "output": 1.8, "cache_read": 0.09},
-            {"input_tokens_gt": 512_000, "input": 0.9, "output": 3.6, "cache_read": 0.18},
-        ],
-    }
 }

--- a/src/khoj/utils/constants.py
+++ b/src/khoj/utils/constants.py
@@ -14,6 +14,10 @@ content_directory = "~/.khoj/content/"
 default_openai_chat_models = ["gpt-4o-mini", "gpt-4.1", "o3", "o4-mini"]
 default_gemini_chat_models = ["gemini-2.0-flash", "gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.5-flash-lite"]
 default_anthropic_chat_models = ["claude-sonnet-4-0", "claude-3-5-haiku-latest"]
+default_minimax_chat_models = ["MiniMax-M3", "MiniMax-M2.7"]
+default_minimax_vision_chat_models = ["MiniMax-M3"]
+default_minimax_openai_base_url = "https://api.minimax.io/v1"
+default_minimax_anthropic_base_url = "https://api.minimax.io/anthropic"
 
 empty_config = {
     "search-type": {
@@ -90,5 +94,19 @@ model_to_cost: Dict[str, Dict[str, float]] = {
     # Moonshot AI, Baseten pricing for Kimi-K2-Thinking
     "moonshotai/kimi-k2-thinking": {"input": 0.60, "output": 2.50},
     # MiniMax Pricing: https://platform.minimax.io/docs/guides/pricing-paygo
-    "MiniMax-M3": {"input": 0.6, "output": 2.4, "cache_read": 0.12},
+    "MiniMax-M3": {"input": 0.3, "output": 1.2, "cache_read": 0.06},
+    "MiniMax-M2.7": {"input": 0.3, "output": 1.2, "cache_read": 0.06, "cache_write": 0.375},
+}
+
+model_to_cost_tiers: Dict[str, Dict[str, list[Dict[str, float]]]] = {
+    "MiniMax-M3": {
+        "standard": [
+            {"input_tokens_lte": 512_000, "input": 0.3, "output": 1.2, "cache_read": 0.06},
+            {"input_tokens_gt": 512_000, "input": 0.6, "output": 2.4, "cache_read": 0.12},
+        ],
+        "priority": [
+            {"input_tokens_lte": 512_000, "input": 0.45, "output": 1.8, "cache_read": 0.09},
+            {"input_tokens_gt": 512_000, "input": 0.9, "output": 3.6, "cache_read": 0.18},
+        ],
+    }
 }

--- a/src/khoj/utils/helpers.py
+++ b/src/khoj/utils/helpers.py
@@ -965,26 +965,17 @@ def get_cost_of_chat_message(
     cache_read_tokens: int = 0,
     cache_write_tokens: int = 0,
     prev_cost: float = 0.0,
-    service_tier: str = "standard",
 ):
     """
     Calculate cost of chat message based on input and output tokens
     """
 
-    model_cost = constants.model_to_cost.get(model_name, {})
-    for tier in constants.model_to_cost_tiers.get(model_name, {}).get(service_tier, []):
-        within_upper_bound = "input_tokens_lte" not in tier or input_tokens <= tier["input_tokens_lte"]
-        above_lower_bound = "input_tokens_gt" not in tier or input_tokens > tier["input_tokens_gt"]
-        if within_upper_bound and above_lower_bound:
-            model_cost = tier
-            break
-
     # Calculate cost of input and output tokens. Costs are per million tokens
-    input_cost = model_cost.get("input", 0) * (input_tokens / 1e6)
-    output_cost = model_cost.get("output", 0) * (output_tokens / 1e6)
-    thought_cost = model_cost.get("thought", 0) * (thought_tokens / 1e6)
-    cache_read_cost = model_cost.get("cache_read", 0) * (cache_read_tokens / 1e6)
-    cache_write_cost = model_cost.get("cache_write", 0) * (cache_write_tokens / 1e6)
+    input_cost = constants.model_to_cost.get(model_name, {}).get("input", 0) * (input_tokens / 1e6)
+    output_cost = constants.model_to_cost.get(model_name, {}).get("output", 0) * (output_tokens / 1e6)
+    thought_cost = constants.model_to_cost.get(model_name, {}).get("thought", 0) * (thought_tokens / 1e6)
+    cache_read_cost = constants.model_to_cost.get(model_name, {}).get("cache_read", 0) * (cache_read_tokens / 1e6)
+    cache_write_cost = constants.model_to_cost.get(model_name, {}).get("cache_write", 0) * (cache_write_tokens / 1e6)
 
     return input_cost + output_cost + thought_cost + cache_read_cost + cache_write_cost + prev_cost
 

--- a/src/khoj/utils/helpers.py
+++ b/src/khoj/utils/helpers.py
@@ -965,17 +965,26 @@ def get_cost_of_chat_message(
     cache_read_tokens: int = 0,
     cache_write_tokens: int = 0,
     prev_cost: float = 0.0,
+    service_tier: str = "standard",
 ):
     """
     Calculate cost of chat message based on input and output tokens
     """
 
+    model_cost = constants.model_to_cost.get(model_name, {})
+    for tier in constants.model_to_cost_tiers.get(model_name, {}).get(service_tier, []):
+        within_upper_bound = "input_tokens_lte" not in tier or input_tokens <= tier["input_tokens_lte"]
+        above_lower_bound = "input_tokens_gt" not in tier or input_tokens > tier["input_tokens_gt"]
+        if within_upper_bound and above_lower_bound:
+            model_cost = tier
+            break
+
     # Calculate cost of input and output tokens. Costs are per million tokens
-    input_cost = constants.model_to_cost.get(model_name, {}).get("input", 0) * (input_tokens / 1e6)
-    output_cost = constants.model_to_cost.get(model_name, {}).get("output", 0) * (output_tokens / 1e6)
-    thought_cost = constants.model_to_cost.get(model_name, {}).get("thought", 0) * (thought_tokens / 1e6)
-    cache_read_cost = constants.model_to_cost.get(model_name, {}).get("cache_read", 0) * (cache_read_tokens / 1e6)
-    cache_write_cost = constants.model_to_cost.get(model_name, {}).get("cache_write", 0) * (cache_write_tokens / 1e6)
+    input_cost = model_cost.get("input", 0) * (input_tokens / 1e6)
+    output_cost = model_cost.get("output", 0) * (output_tokens / 1e6)
+    thought_cost = model_cost.get("thought", 0) * (thought_tokens / 1e6)
+    cache_read_cost = model_cost.get("cache_read", 0) * (cache_read_tokens / 1e6)
+    cache_write_cost = model_cost.get("cache_write", 0) * (cache_write_tokens / 1e6)
 
     return input_cost + output_cost + thought_cost + cache_read_cost + cache_write_cost + prev_cost
 
@@ -1175,7 +1184,7 @@ def get_openai_async_client(api_key: str, api_base_url: str) -> Union[openai.Asy
 def get_anthropic_client(api_key, api_base_url=None) -> anthropic.Anthropic | anthropic.AnthropicVertex:
     api_info = get_ai_api_info(api_key, api_base_url)
     if api_info.api_key:
-        client = anthropic.Anthropic(api_key=api_info.api_key)
+        client = anthropic.Anthropic(api_key=api_info.api_key, base_url=api_base_url)
     else:
         client = anthropic.AnthropicVertex(
             region=api_info.region,
@@ -1188,7 +1197,7 @@ def get_anthropic_client(api_key, api_base_url=None) -> anthropic.Anthropic | an
 def get_anthropic_async_client(api_key, api_base_url=None) -> anthropic.AsyncAnthropic | anthropic.AsyncAnthropicVertex:
     api_info = get_ai_api_info(api_key, api_base_url)
     if api_info.api_key:
-        client = anthropic.AsyncAnthropic(api_key=api_info.api_key)
+        client = anthropic.AsyncAnthropic(api_key=api_info.api_key, base_url=api_base_url)
     else:
         client = anthropic.AsyncAnthropicVertex(
             region=api_info.region,

--- a/src/khoj/utils/initialization.py
+++ b/src/khoj/utils/initialization.py
@@ -16,10 +16,20 @@ from khoj.processor.conversation.utils import model_to_prompt_size, model_to_tok
 from khoj.utils.constants import (
     default_anthropic_chat_models,
     default_gemini_chat_models,
+    default_minimax_anthropic_base_url,
+    default_minimax_chat_models,
+    default_minimax_openai_base_url,
+    default_minimax_vision_chat_models,
     default_openai_chat_models,
 )
 
 logger = logging.getLogger(__name__)
+supported_vision_models = set(
+    default_openai_chat_models
+    + default_anthropic_chat_models
+    + default_gemini_chat_models
+    + default_minimax_vision_chat_models
+)
 
 
 def initialization(interactive: bool = True):
@@ -71,6 +81,17 @@ def initialization(interactive: bool = True):
             vision_enabled=True,
             interactive=interactive,
             provider_name=provider,
+        )
+
+        minimax_api_key = os.getenv("MINIMAX_API_KEY")
+        _setup_chat_model_provider(
+            ChatModel.ModelType.OPENAI,
+            default_minimax_chat_models,
+            default_api_key=minimax_api_key,
+            api_base_url=os.getenv("MINIMAX_BASE_URL") or default_minimax_openai_base_url,
+            vision_enabled=True,
+            interactive=interactive,
+            provider_name="MiniMax",
         )
 
         # Setup OpenAI speech to text model
@@ -143,6 +164,16 @@ def initialization(interactive: bool = True):
             interactive=interactive,
         )
 
+        _setup_chat_model_provider(
+            ChatModel.ModelType.ANTHROPIC,
+            default_minimax_chat_models,
+            default_api_key=os.getenv("MINIMAX_ANTHROPIC_API_KEY") or minimax_api_key,
+            api_base_url=os.getenv("MINIMAX_ANTHROPIC_BASE_URL") or default_minimax_anthropic_base_url,
+            vision_enabled=True,
+            interactive=interactive,
+            provider_name="MiniMax Anthropic",
+        )
+
         logger.info("🗣️ Chat model configuration complete")
 
     def _setup_chat_model_provider(
@@ -154,9 +185,6 @@ def initialization(interactive: bool = True):
         vision_enabled: bool = False,
         provider_name: str = None,
     ) -> Tuple[bool, AiModelApi]:
-        supported_vision_models = (
-            default_openai_chat_models + default_anthropic_chat_models + default_gemini_chat_models
-        )
         provider_name = provider_name or model_type.name.capitalize()
 
         default_use_model = default_api_key is not None
@@ -190,14 +218,14 @@ def initialization(interactive: bool = True):
         for chat_model in chat_models:
             default_max_tokens = model_to_prompt_size.get(chat_model)
             default_tokenizer = model_to_tokenizer.get(chat_model)
-            vision_enabled = vision_enabled and chat_model in supported_vision_models
+            model_vision_enabled = vision_enabled and chat_model in supported_vision_models
 
             chat_model_options = {
                 "name": chat_model,
                 "friendly_name": chat_model,
                 "model_type": model_type,
                 "max_prompt_size": default_max_tokens,
-                "vision_enabled": vision_enabled,
+                "vision_enabled": model_vision_enabled,
                 "tokenizer": default_tokenizer,
                 "ai_model_api": ai_model_api,
             }
@@ -213,9 +241,9 @@ def initialization(interactive: bool = True):
             # Get OpenAI configs with custom base URLs
             custom_configs = AiModelApi.objects.exclude(api_base_url__isnull=True)
 
-            # Only enable for whitelisted provider names (i.e Ollama) for now
+            # Only enable for whitelisted OpenAI-compatible providers for now
             # TODO: This is hacky. Will be replaced with more robust solution based on provider type enum
-            custom_configs = custom_configs.filter(name__in=["Ollama"])
+            custom_configs = custom_configs.filter(name__in=["Ollama", "MiniMax"])
 
             for config in custom_configs:
                 try:
@@ -238,7 +266,7 @@ def initialization(interactive: bool = True):
                                 friendly_name=model_name,
                                 model_type=ChatModel.ModelType.OPENAI,
                                 max_prompt_size=model_to_prompt_size.get(model_name),
-                                vision_enabled=model_name in default_openai_chat_models,
+                                vision_enabled=model_name in supported_vision_models,
                                 tokenizer=model_to_tokenizer.get(model_name),
                                 ai_model_api=config,
                             )

--- a/tests/test_conversation_utils.py
+++ b/tests/test_conversation_utils.py
@@ -4,6 +4,33 @@ import tiktoken
 from langchain_core.messages.chat import ChatMessage
 
 from khoj.processor.conversation import utils
+from khoj.utils import constants
+
+
+def test_minimax_model_registry():
+    assert constants.default_minimax_chat_models == ["MiniMax-M3", "MiniMax-M2.7"]
+    assert constants.default_minimax_vision_chat_models == ["MiniMax-M3"]
+    assert constants.default_minimax_openai_base_url == "https://api.minimax.io/v1"
+    assert constants.default_minimax_anthropic_base_url == "https://api.minimax.io/anthropic"
+    assert utils.model_to_prompt_size["MiniMax-M3"] == 1_000_000
+    assert utils.model_to_prompt_size["MiniMax-M2.7"] == 204_800
+
+
+def test_configure_minimax_m3_thinking():
+    assert utils.is_minimax_m3_model("MiniMax-M3")
+    assert not utils.is_minimax_m3_model("MiniMax-M2.7")
+
+    fast_kwargs = {}
+    assert utils.configure_minimax_m3_thinking("MiniMax-M3", False, fast_kwargs)
+    assert fast_kwargs == {"extra_body": {"thinking": {"type": "disabled"}}}
+
+    deep_kwargs = {}
+    assert utils.configure_minimax_m3_thinking("MiniMax-M3", True, deep_kwargs)
+    assert deep_kwargs == {"extra_body": {"thinking": {"type": "adaptive"}}}
+
+    other_model_kwargs = {}
+    assert not utils.configure_minimax_m3_thinking("MiniMax-M2.7", True, other_model_kwargs)
+    assert other_model_kwargs == {}
 
 
 class TestTruncateMessage:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -14,24 +14,14 @@ from khoj.processor.tools.online_search import (
 from khoj.utils import helpers
 
 
-@pytest.mark.parametrize(
-    ("input_tokens", "service_tier", "expected_cost"),
-    [
-        (500_000, "standard", 1.356),
-        (600_000, "standard", 2.772),
-        (500_000, "priority", 2.034),
-        (600_000, "priority", 4.158),
-    ],
-)
-def test_minimax_m3_tiered_cost(input_tokens, service_tier, expected_cost):
+def test_minimax_m3_cost():
     cost = helpers.get_cost_of_chat_message(
         "MiniMax-M3",
-        input_tokens=input_tokens,
+        input_tokens=1_000_000,
         output_tokens=1_000_000,
-        cache_read_tokens=100_000,
-        service_tier=service_tier,
+        cache_read_tokens=1_000_000,
     )
-    assert cost == pytest.approx(expected_cost)
+    assert cost == pytest.approx(3.12)
 
 
 def test_minimax_m27_cost():

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -14,6 +14,54 @@ from khoj.processor.tools.online_search import (
 from khoj.utils import helpers
 
 
+@pytest.mark.parametrize(
+    ("input_tokens", "service_tier", "expected_cost"),
+    [
+        (500_000, "standard", 1.356),
+        (600_000, "standard", 2.772),
+        (500_000, "priority", 2.034),
+        (600_000, "priority", 4.158),
+    ],
+)
+def test_minimax_m3_tiered_cost(input_tokens, service_tier, expected_cost):
+    cost = helpers.get_cost_of_chat_message(
+        "MiniMax-M3",
+        input_tokens=input_tokens,
+        output_tokens=1_000_000,
+        cache_read_tokens=100_000,
+        service_tier=service_tier,
+    )
+    assert cost == pytest.approx(expected_cost)
+
+
+def test_minimax_m27_cost():
+    cost = helpers.get_cost_of_chat_message(
+        "MiniMax-M2.7",
+        input_tokens=1_000_000,
+        output_tokens=1_000_000,
+        cache_read_tokens=1_000_000,
+        cache_write_tokens=1_000_000,
+    )
+    assert cost == pytest.approx(1.935)
+
+
+def test_anthropic_client_uses_custom_base_url():
+    client = helpers.get_anthropic_client("test-key", "https://api.minimax.io/anthropic")
+    try:
+        assert str(client.base_url) == "https://api.minimax.io/anthropic/"
+    finally:
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_anthropic_async_client_uses_custom_base_url():
+    client = helpers.get_anthropic_async_client("test-key", "https://api.minimax.io/anthropic")
+    try:
+        assert str(client.base_url) == "https://api.minimax.io/anthropic/"
+    finally:
+        await client.close()
+
+
 def test_get_from_null_dict():
     # null handling
     assert helpers.get_from_dict(dict()) == dict()

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1,0 +1,44 @@
+import pytest
+
+from khoj.database.models import AiModelApi, ChatModel
+from khoj.utils.initialization import initialization
+
+
+@pytest.mark.django_db
+def test_initialization_adds_minimax_openai_and_anthropic_providers(monkeypatch):
+    for variable in [
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "MINIMAX_ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+    ]:
+        monkeypatch.delenv(variable, raising=False)
+
+    monkeypatch.setenv("KHOJ_ADMIN_EMAIL", "admin@example.com")
+    monkeypatch.setenv("KHOJ_ADMIN_PASSWORD", "test-password")
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    monkeypatch.setenv("MINIMAX_BASE_URL", "https://api.minimaxi.com/v1")
+    monkeypatch.setenv("MINIMAX_ANTHROPIC_BASE_URL", "https://api.minimaxi.com/anthropic")
+
+    initialization(interactive=False)
+
+    openai_provider = AiModelApi.objects.get(name="MiniMax")
+    anthropic_provider = AiModelApi.objects.get(name="MiniMax Anthropic")
+    assert openai_provider.api_base_url == "https://api.minimaxi.com/v1"
+    assert anthropic_provider.api_base_url == "https://api.minimaxi.com/anthropic"
+
+    expected_models = {
+        "MiniMax-M3": {"max_prompt_size": 1_000_000, "vision_enabled": True},
+        "MiniMax-M2.7": {"max_prompt_size": 204_800, "vision_enabled": False},
+    }
+    for provider, model_type in [
+        (openai_provider, ChatModel.ModelType.OPENAI),
+        (anthropic_provider, ChatModel.ModelType.ANTHROPIC),
+    ]:
+        models = ChatModel.objects.filter(ai_model_api=provider, model_type=model_type)
+        assert set(models.values_list("name", flat=True)) == set(expected_models)
+        for model_name, expected in expected_models.items():
+            model = models.get(name=model_name)
+            assert model.max_prompt_size == expected["max_prompt_size"]
+            assert model.vision_enabled is expected["vision_enabled"]


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Add MiniMax-M3 and MiniMax-M2.7 defaults for OpenAI-compatible and Anthropic-compatible chat providers.
- Configure global endpoint defaults and document China endpoint overrides.
- Register model context limits, vision support, thinking controls, and tiered pricing.
- Preserve custom Anthropic base URLs for synchronous and asynchronous clients.

## Test plan
- `uv run --frozen pytest -q tests/test_conversation_utils.py tests/test_helpers.py::test_minimax_m3_tiered_cost tests/test_helpers.py::test_minimax_m27_cost tests/test_helpers.py::test_anthropic_client_uses_custom_base_url tests/test_helpers.py::test_anthropic_async_client_uses_custom_base_url tests/test_initialization.py`
- `uv run --frozen pre-commit run --hook-stage manual --all`
- Captured requests with the locked SDK versions to verify both regional OpenAI-compatible and Anthropic-compatible paths.
