### PR TITLE
Replace eval with ast.literal_eval for safety

### DIFF
--- a/src/khoj/processor/operator/grounding_agent_uitars.py
+++ b/src/khoj/processor/operator/grounding_agent_uitars.py
@@ -679,10 +679,10 @@ class GroundingAgentUitars:
                 start_box = action_inputs.get("start_box")
                 end_box = action_inputs.get("end_box")
                 if start_box and end_box:
-                    x1, y1, x2, y2 = eval(start_box)  # Assuming box is in [x1, y1, x2, y2]
+                    x1, y1, x2, y2 = ast.literal_eval(start_box)  # Assuming box is in [x1, y1, x2, y2]
                     sx = round(float((x1 + x2) / 2) * image_width, 3)
                     sy = round(float((y1 + y2) / 2) * image_height, 3)
-                    x1, y1, x2, y2 = eval(end_box)  # Assuming box is in [x1, y1, x2, y2]
+                    x1, y1, x2, y2 = ast.literal_eval(end_box)  # Assuming box is in [x1, y1, x2, y2]
                     ex = round(float((x1 + x2) / 2) * image_width, 3)
                     ey = round(float((y1 + y2) / 2) * image_height, 3)
                     actions.append(MoveAction(x=sx, y=sy))
@@ -692,7 +692,7 @@ class GroundingAgentUitars:
                 # Parsing scroll action
                 start_box = action_inputs.get("start_box")
                 if start_box:
-                    x1, y1, x2, y2 = eval(start_box)  # Assuming box is in [x1, y1, x2, y2]
+                    x1, y1, x2, y2 = ast.literal_eval(start_box)  # Assuming box is in [x1, y1, x2, y2]
                     x = round(float((x1 + x2) / 2) * image_width, 3)
                     y = round(float((y1 + y2) / 2) * image_height, 3)
 
@@ -717,7 +717,7 @@ class GroundingAgentUitars:
                 start_box = action_inputs.get("start_box")
                 start_box = str(start_box)
                 if start_box:
-                    start_box = eval(start_box)
+                    start_box = ast.literal_eval(start_box)
                     if len(start_box) == 4:
                         x1, y1, x2, y2 = start_box  # Assuming box is in [x1, y1, x2, y2]
                     elif len(start_box) == 2:
@@ -876,10 +876,10 @@ class GroundingAgentUitars:
                 start_box = action_inputs.get("start_box")
                 end_box = action_inputs.get("end_box")
                 if start_box and end_box:
-                    x1, y1, x2, y2 = eval(start_box)  # Assuming box is in [x1, y1, x2, y2]
+                    x1, y1, x2, y2 = ast.literal_eval(start_box)  # Assuming box is in [x1, y1, x2, y2]
                     sx = round(float((x1 + x2) / 2) * image_width, 3)
                     sy = round(float((y1 + y2) / 2) * image_height, 3)
-                    x1, y1, x2, y2 = eval(end_box)  # Assuming box is in [x1, y1, x2, y2]
+                    x1, y1, x2, y2 = ast.literal_eval(end_box)  # Assuming box is in [x1, y1, x2, y2]
                     ex = round(float((x1 + x2) / 2) * image_width, 3)
                     ey = round(float((y1 + y2) / 2) * image_height, 3)
                     pyautogui_code += f"\npyautogui.moveTo({sx}, {sy})\n\npyautogui.dragTo({ex}, {ey}, duration=1.0)\n"
@@ -888,7 +888,7 @@ class GroundingAgentUitars:
                 # Parsing scroll action
                 start_box = action_inputs.get("start_box")
                 if start_box:
-                    x1, y1, x2, y2 = eval(start_box)  # Assuming box is in [x1, y1, x2, y2]
+                    x1, y1, x2, y2 = ast.literal_eval(start_box)  # Assuming box is in [x1, y1, x2, y2]
                     x = round(float((x1 + x2) / 2) * image_width, 3)
                     y = round(float((y1 + y2) / 2) * image_height, 3)
 
@@ -915,7 +915,7 @@ class GroundingAgentUitars:
                 start_box = action_inputs.get("start_box")
                 start_box = str(start_box)
                 if start_box:
-                    start_box = eval(start_box)
+                    start_box = ast.literal_eval(start_box)
                     if len(start_box) == 4:
                         x1, y1, x2, y2 = start_box  # Assuming box is in [x1, y1, x2, y2]
                     elif len(start_box) == 2:


### PR DESCRIPTION
### Summary

The UI-TARS grounding agent parses coordinate boxes out of the model's own
action output and evaluates them with `eval()`. `eval` on model-derived data is
a code-execution anti-pattern; `ast.literal_eval` parses the same list/tuple
literals but cannot execute code, so this is a safe, behavior-preserving swap.

### Where

`src/khoj/processor/operator/grounding_agent_uitars.py` — 8 call sites
(lines 682, 685, 695, 720, 879, 882, 891, 918). For example:

```python
start_box = action_inputs.get("start_box")
...
x1, y1, x2, y2 = eval(start_box)   # start_box originates from the model's action string
```

`action_inputs` is populated by `parse_action_to_structure_output(text=...)`
from the model's generated text, so the value reaching `eval()` is model-derived.
For a computer-use agent that acts on screenshots, that output is influenceable
by on-screen content (a page the agent views can carry injected instructions),
so in any path where a raw box value reaches `eval` unnormalized, a steered
model could emit something other than `[x1, y1, x2, y2]`. Even where the value
is numeric-normalized first, `eval` is the wrong tool here.

### Fix

Replace `eval(...)` with `ast.literal_eval(...)` at these sites (`ast` is
already imported in this file). Verified parse-equivalent on the real inputs
(`[0.1, 0.2, 0.3, 0.4]`, `(0.12, 0.34)`), and that a non-literal string now
raises `ValueError` instead of executing.
