### PR TITLE
Drop client IP (client_host) from usage telemetry payload

### DIFF
--- a/src/khoj/routers/helpers.py
+++ b/src/khoj/routers/helpers.py
@@ -208,7 +208,6 @@ def update_telemetry_state(
     client_app: ClientApplication = request.user.client_app if request.user.is_authenticated else None
     subscription: Subscription = user.subscription if user and hasattr(user, "subscription") else None
     user_state = {
-        "client_host": request.client.host if request.client else None,
         "user_agent": user_agent or "unknown",
         "referer": referer or "unknown",
         "host": host or "unknown",


### PR DESCRIPTION
## Summary

The self-hosted Khoj server builds its usage-telemetry payload with the
requesting client's IP address under the `client_host` key in
`update_telemetry_state` (`src/khoj/routers/helpers.py`), and uploads it
verbatim to the telemetry endpoint. This contradicts the privacy
documentation (`documentation/docs/get-started/privacy-security.md`), which
states:

> **We do not log your IP address**, nor upload any of your personal data to PostHog.

As reported in #1374, `request.client.host` is the client IP, and it was
present in the payload the open-source server uploads. A privacy-conscious
self-hoster reading that guarantee would not expect the IP to leave their
machine.

Per the maintainer's confirmation on the issue ("we do drop client I.P at
posthog layer ... We should stop passing client host as telemetry so it
agrees with the docs"), this removes the field at the source rather than
adding a surrogate.

## Changes

- Remove the `client_host` entry from the `user_state` dict in
  `update_telemetry_state`. This was the sole producer of the field; it
  flowed unchanged through `log_telemetry` into the uploaded `request_body`.

No other behaviour changes. The field had no in-repo consumer (it was
write-only into the uploaded payload), and `update_telemetry_state`'s
signature is unchanged, so none of its call sites are affected.

## Test plan

- `ruff check src/khoj/routers/helpers.py` — passes.
- `ruff format --check src/khoj/routers/helpers.py` — already formatted.
- `python -m py_compile` on the changed file — valid syntax.
- Confirmed `client_host` now has zero references under `src/`.

There is no existing test covering telemetry payload composition, and the
full pytest suite requires a Postgres-backed Django setup that I could not
provision locally, so I did not add a new test. Happy to add a focused
regression test asserting the payload no longer includes the client IP if
you'd prefer one.

Fixes #1374