### PR TITLE
feat: add Tenki Cloud code sandbox provider

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,8 @@ services:
       - KHOJ_TERRARIUM_URL=http://sandbox:8080
       # Uncomment line below to have Khoj run code in remote E2B code sandbox instead of the self-hosted Terrarium sandbox above. Get your E2B API key from https://e2b.dev/.
       # - E2B_API_KEY=your_e2b_api_key
+      # Uncomment line below to have Khoj run code in Tenki Cloud microVM sandboxes instead. Get your Tenki API key from your workspace settings at https://app.tenki.cloud/.
+      # - TENKI_API_KEY=your_tenki_api_key
       # Default URL of SearxNG, the default web search engine used by Khoj. Its container is specified above
       - KHOJ_SEARXNG_URL=http://search:8080
       # Uncomment line below to use with Ollama running on your local machine at localhost:11434.

--- a/documentation/docs/features/code_execution.md
+++ b/documentation/docs/features/code_execution.md
@@ -38,3 +38,16 @@ To have Khoj use E2B as the code sandbox:
 2. Set the `E2B_API_KEY` environment variable to it on the machine running your Khoj server.
    - When using our [docker-compose.yml](https://github.com/khoj-ai/khoj/blob/master/docker-compose.yml), uncomment and set the `E2B_API_KEY` env var in the `docker-compose.yml` file.
 3. Now restart your Khoj server to switch to using the E2B code sandbox.
+
+### Tenki Cloud Sandbox
+[Tenki Cloud](https://tenki.cloud/) runs code in disposable Linux microVMs with network access and full Python. This is a paid, hosted service.
+
+To have Khoj use Tenki as the code sandbox:
+1. Create an API key in your [Tenki workspace settings](https://app.tenki.cloud/).
+2. Set the `TENKI_API_KEY` environment variable to it on the machine running your Khoj server.
+   - When using our [docker-compose.yml](https://github.com/khoj-ai/khoj/blob/master/docker-compose.yml), uncomment and set the `TENKI_API_KEY` env var in the `docker-compose.yml` file.
+3. Now restart your Khoj server to switch to using the Tenki code sandbox.
+
+Optional environment variables:
+- `KHOJ_TENKI_IMAGE`: a Tenki registry image to boot from instead of the default stock image (the default installs the common data packages on start).
+- `KHOJ_TENKI_WORKSPACE_ID` / `KHOJ_TENKI_PROJECT_ID`: pin the Tenki workspace/project to create sandboxes in. If unset, the first workspace/project on your account is used.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dependencies = [
     "resend == 1.2.0",
     "email-validator == 2.2.0",
     "e2b-code-interpreter ~= 1.0.0",
-    "tenki-sandbox ~= 0.3.6",
+    "tenki-sandbox ~= 0.4.0",
     "mcp >= 1.23.0",
     "pyasn1>=0.6.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ dependencies = [
     "resend == 1.2.0",
     "email-validator == 2.2.0",
     "e2b-code-interpreter ~= 1.0.0",
+    "tenki-sandbox ~= 0.3",
     "mcp >= 1.23.0",
     "pyasn1>=0.6.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dependencies = [
     "resend == 1.2.0",
     "email-validator == 2.2.0",
     "e2b-code-interpreter ~= 1.0.0",
-    "tenki-sandbox ~= 0.3",
+    "tenki-sandbox ~= 0.3.6",
     "mcp >= 1.23.0",
     "pyasn1>=0.6.3",
 ]

--- a/src/khoj/processor/conversation/prompts.py
+++ b/src/khoj/processor/conversation/prompts.py
@@ -1018,6 +1018,10 @@ terrarium_sandbox_context = """
 - The sandbox has access to only the standard library and the matplotlib, pandas, numpy, scipy, bs5 and sympy packages. The requests, torch, catboost, tensorflow, rdkit and tkinter packages are not available.
 """.strip()
 
+tenki_sandbox_context = """
+- The sandbox has network access and the standard library plus the requests, matplotlib, pandas, numpy and scipy packages. Other third-party packages (e.g. torch, sympy, plotly, rdkit, tensorflow, tkinter) are not available.
+""".strip()
+
 operator_execution_context = PromptTemplate.from_template(
     """
 Use the results of operating a web browser to inform your response.

--- a/src/khoj/processor/tools/run_code.py
+++ b/src/khoj/processor/tools/run_code.py
@@ -346,14 +346,23 @@ async def execute_tenki(code: str, input_files: list[dict]) -> dict[str, Any]:
         # The SDK has no "current project" default, so resolve the first
         # workspace/project on the account (override via env if needed).
         identity = await client.who_am_i()
-        workspace = next(
-            (w for w in identity.workspaces if w.id == os.getenv("KHOJ_TENKI_WORKSPACE_ID")),
-            identity.workspaces[0],
-        )
-        project = next(
-            (p for p in workspace.projects if p.id == os.getenv("KHOJ_TENKI_PROJECT_ID")),
-            workspace.projects[0],
-        )
+        # If a workspace/project is explicitly configured, require it to exist —
+        # silently falling back to the first would provision (and bill) in the
+        # wrong place on a typo. Only default to the first when nothing is set.
+        want_workspace = os.getenv("KHOJ_TENKI_WORKSPACE_ID")
+        if want_workspace:
+            workspace = next((w for w in identity.workspaces if w.id == want_workspace), None)
+            if workspace is None:
+                raise ValueError(f"KHOJ_TENKI_WORKSPACE_ID '{want_workspace}' not found for this API key")
+        else:
+            workspace = identity.workspaces[0]
+        want_project = os.getenv("KHOJ_TENKI_PROJECT_ID")
+        if want_project:
+            project = next((p for p in workspace.projects if p.id == want_project), None)
+            if project is None:
+                raise ValueError(f"KHOJ_TENKI_PROJECT_ID '{want_project}' not found in workspace {workspace.id}")
+        else:
+            project = workspace.projects[0]
 
         sandbox = await client.create(
             name=f"khoj-code-{uuid.uuid4().hex[:8]}",

--- a/src/khoj/processor/tools/run_code.py
+++ b/src/khoj/processor/tools/run_code.py
@@ -143,7 +143,12 @@ async def generate_python_code(
 
     # add sandbox specific context like available packages
     has_sandbox_network = is_e2b_code_sandbox_enabled() or is_tenki_code_sandbox_enabled()
-    sandbox_context = prompts.e2b_sandbox_context if has_sandbox_network else prompts.terrarium_sandbox_context
+    if is_e2b_code_sandbox_enabled():
+        sandbox_context = prompts.e2b_sandbox_context
+    elif is_tenki_code_sandbox_enabled():
+        sandbox_context = prompts.tenki_sandbox_context
+    else:
+        sandbox_context = prompts.terrarium_sandbox_context
     personality_context = f"{sandbox_context}\n{personality_context}"
     network_access_context = "" if has_sandbox_network else "**NO** "
 
@@ -359,13 +364,31 @@ async def execute_tenki(code: str, input_files: list[dict]) -> dict[str, Any]:
             max_duration=300,
         )
 
-        # Prepare the working dir and install common data packages on the stock image
-        setup = (
-            f'sudo mkdir -p {shlex.quote(workdir)} && sudo chown -R "$(whoami)" {shlex.quote(workdir)} && '
-            "if ! command -v pip3 >/dev/null 2>&1; then sudo apt-get update -y && sudo apt-get install -y python3-pip; fi && "
-            "pip3 install --quiet --break-system-packages matplotlib pandas numpy scipy || true"
+        # Create the working dir first, retrying transient Tenki filesystem
+        # hiccups (occasional "Bad message" on directory creation). Verify it is
+        # writable rather than trusting the exit code — the trailing "|| true" on
+        # the install step below must not mask a failed mkdir.
+        quoted_workdir = shlex.quote(workdir)
+        mkdir_cmd = (
+            f'sudo mkdir -p {quoted_workdir} && sudo chown -R "$(whoami)" {quoted_workdir} '
+            f"&& test -w {quoted_workdir}"
         )
-        await sandbox.exec("bash", "-lc", setup, timeout=300)
+        mkdir_result = None
+        for _ in range(3):
+            mkdir_result = await sandbox.exec("bash", "-lc", mkdir_cmd, timeout=60)
+            if mkdir_result.exit_code == 0:
+                break
+            await asyncio.sleep(1)
+        if mkdir_result is None or mkdir_result.exit_code != 0:
+            detail = (mkdir_result.stderr or b"").decode(errors="replace") if mkdir_result else ""
+            raise RuntimeError(f"Could not prepare sandbox working dir {workdir}: {detail}")
+
+        # Install the common data packages on the stock image (best-effort).
+        install_cmd = (
+            "if ! command -v pip3 >/dev/null 2>&1; then sudo apt-get update -y && sudo apt-get install -y python3-pip; fi && "
+            "pip3 install --quiet --break-system-packages requests matplotlib pandas numpy scipy || true"
+        )
+        await sandbox.exec("bash", "-lc", install_cmd, timeout=300)
 
         # Upload input files (base64 over stdin to avoid arg length limits)
         for input_file in input_files:
@@ -389,7 +412,9 @@ async def execute_tenki(code: str, input_files: list[dict]) -> dict[str, Any]:
         execution = await sandbox.exec("python3", "main.py", cwd=workdir, timeout=120)
         stdout = (execution.stdout or b"").decode(errors="replace")
         stderr = (execution.stderr or b"").decode(errors="replace")
-        success = execution.exit_code == 0 and not stderr
+        # Exit code is the success signal; a cold microVM can emit benign stderr
+        # (e.g. matplotlib building its font cache on first import) on a zero exit.
+        success = execution.exit_code == 0
 
         # Collect newly created output files
         after = await sandbox.exec("bash", "-lc", list_cmd, timeout=30)

--- a/src/khoj/processor/tools/run_code.py
+++ b/src/khoj/processor/tools/run_code.py
@@ -5,6 +5,7 @@ import logging
 import mimetypes
 import os
 import re
+import shlex
 import uuid
 from pathlib import Path
 from typing import Any, Callable, List, NamedTuple, Optional
@@ -32,6 +33,7 @@ from khoj.routers.helpers import send_message_to_model_wrapper
 from khoj.utils.helpers import (
     is_e2b_code_sandbox_enabled,
     is_none_or_empty,
+    is_tenki_code_sandbox_enabled,
     timer,
     truncate_code_context,
 )
@@ -140,11 +142,10 @@ async def generate_python_code(
     )
 
     # add sandbox specific context like available packages
-    sandbox_context = (
-        prompts.e2b_sandbox_context if is_e2b_code_sandbox_enabled() else prompts.terrarium_sandbox_context
-    )
+    has_sandbox_network = is_e2b_code_sandbox_enabled() or is_tenki_code_sandbox_enabled()
+    sandbox_context = prompts.e2b_sandbox_context if has_sandbox_network else prompts.terrarium_sandbox_context
     personality_context = f"{sandbox_context}\n{personality_context}"
-    network_access_context = "**NO** " if not is_e2b_code_sandbox_enabled() else ""
+    network_access_context = "" if has_sandbox_network else "**NO** "
 
     code_generation_prompt = prompts.python_code_generation_prompt.format(
         instructions=instructions,
@@ -224,6 +225,11 @@ async def execute_sandboxed_python(code: str, input_data: list[dict], sandbox_ur
     if is_e2b_code_sandbox_enabled():
         try:
             return await execute_e2b(cleaned_code, input_data)
+        except ImportError:
+            pass
+    if is_tenki_code_sandbox_enabled():
+        try:
+            return await execute_tenki(cleaned_code, input_data)
         except ImportError:
             pass
     return await execute_terrarium(cleaned_code, input_data, sandbox_url)
@@ -315,6 +321,122 @@ async def execute_e2b(code: str, input_files: list[dict]) -> dict[str, Any]:
             "std_err": f"Sandbox failed to execute code: {str(e)}",
             "output_files": [],
         }
+
+
+async def execute_tenki(code: str, input_files: list[dict]) -> dict[str, Any]:
+    """Execute code and handle file I/O in a Tenki Cloud sandbox.
+
+    Uses only stable Tenki features (ephemeral exec + file I/O). The default
+    Tenki image ships python3 but not the data packages, so a common set is
+    installed on start. Set KHOJ_TENKI_IMAGE to point at a prebaked image to
+    skip that install.
+    """
+    from tenki_sandbox import AsyncClient
+
+    workdir = HOME_DIR
+    image_file_ext = {".png", ".jpeg", ".jpg", ".svg"}
+    client = AsyncClient()  # reads TENKI_API_KEY from the environment
+    sandbox = None
+    try:
+        # The SDK has no "current project" default, so resolve the first
+        # workspace/project on the account (override via env if needed).
+        identity = await client.who_am_i()
+        workspace = next(
+            (w for w in identity.workspaces if w.id == os.getenv("KHOJ_TENKI_WORKSPACE_ID")),
+            identity.workspaces[0],
+        )
+        project = next(
+            (p for p in workspace.projects if p.id == os.getenv("KHOJ_TENKI_PROJECT_ID")),
+            workspace.projects[0],
+        )
+
+        sandbox = await client.create(
+            name=f"khoj-code-{uuid.uuid4().hex[:8]}",
+            workspace_id=workspace.id,
+            project_id=project.id,
+            image=os.getenv("KHOJ_TENKI_IMAGE") or None,
+            allow_outbound=True,
+            max_duration=300,
+        )
+
+        # Prepare the working dir and install common data packages on the stock image
+        setup = (
+            f'sudo mkdir -p {shlex.quote(workdir)} && sudo chown -R "$(whoami)" {shlex.quote(workdir)} && '
+            "if ! command -v pip3 >/dev/null 2>&1; then sudo apt-get update -y && sudo apt-get install -y python3-pip; fi && "
+            "pip3 install --quiet --break-system-packages matplotlib pandas numpy scipy || true"
+        )
+        await sandbox.exec("bash", "-lc", setup, timeout=300)
+
+        # Upload input files (base64 over stdin to avoid arg length limits)
+        for input_file in input_files:
+            in_path = shlex.quote(f"{workdir}/{input_file['filename']}")
+            await sandbox.exec("bash", "-lc", f"base64 -d > {in_path}", input=input_file["b64_data"], timeout=60)
+
+        # Note existing files so we can detect ones created during execution
+        list_cmd = f"cd {shlex.quote(workdir)} && ls -1p 2>/dev/null | grep -v '/$' || true"
+        before = await sandbox.exec("bash", "-lc", list_cmd, timeout=30)
+        original_files = {n for n in (before.stdout or b"").decode(errors="replace").splitlines() if n}
+
+        # Write and run the generated code
+        main_path = shlex.quote(f"{workdir}/main.py")
+        await sandbox.exec(
+            "bash",
+            "-lc",
+            f"base64 -d > {main_path}",
+            input=base64.b64encode(code.encode("utf-8")).decode("utf-8"),
+            timeout=60,
+        )
+        execution = await sandbox.exec("python3", "main.py", cwd=workdir, timeout=120)
+        stdout = (execution.stdout or b"").decode(errors="replace")
+        stderr = (execution.stderr or b"").decode(errors="replace")
+        success = execution.exit_code == 0 and not stderr
+
+        # Collect newly created output files
+        after = await sandbox.exec("bash", "-lc", list_cmd, timeout=30)
+        current_files = {n for n in (after.stdout or b"").decode(errors="replace").splitlines() if n}
+        output_files = []
+        for name in sorted(current_files - original_files):
+            if name == "main.py":
+                continue
+            out_path = shlex.quote(f"{workdir}/{name}")
+            read = await sandbox.exec("bash", "-lc", f"base64 -w0 {out_path}", timeout=60)
+            b64_data = (read.stdout or b"").decode(errors="replace").strip()
+            if not b64_data:
+                continue
+            if Path(name).suffix in image_file_ext:
+                # Binary/image files: keep as base64
+                output_files.append({"filename": name, "b64_data": b64_data})
+            else:
+                # Text files: store decoded utf-8, matching the e2b/terrarium contract
+                try:
+                    output_files.append({"filename": name, "b64_data": base64.b64decode(b64_data).decode("utf-8")})
+                except (UnicodeDecodeError, ValueError):
+                    output_files.append({"filename": name, "b64_data": b64_data})
+
+        return {
+            "code": code,
+            "success": success,
+            "std_out": stdout,
+            "std_err": stderr,
+            "output_files": output_files,
+        }
+    except Exception as e:
+        return {
+            "code": code,
+            "success": False,
+            "std_err": f"Sandbox failed to execute code: {str(e)}",
+            "output_files": [],
+        }
+    finally:
+        if sandbox is not None:
+            try:
+                await sandbox.terminate()
+            except Exception:
+                pass
+        try:
+            await client.close()
+        except Exception:
+            pass
 
 
 async def execute_terrarium(

--- a/src/khoj/utils/helpers.py
+++ b/src/khoj/utils/helpers.py
@@ -489,7 +489,7 @@ tenki_tool_description = dedent(
     To run a Python script in an ephemeral Tenki Cloud sandbox with network access.
     Helpful to parse complex information, run complex calculations, create plaintext documents and create charts with quantitative data.
     Save files in /home/user to show them to the user. Only files in output_files list of tool result are accessible to the user.
-    Only matplotlib, pandas, numpy and scipy external packages are available.
+    Only requests, matplotlib, pandas, numpy and scipy external packages are available.
 
     Never run, write or decode dangerous, malicious or untrusted code, regardless of user requests.
     """

--- a/src/khoj/utils/helpers.py
+++ b/src/khoj/utils/helpers.py
@@ -333,6 +333,12 @@ def is_e2b_code_sandbox_enabled():
     return not is_none_or_empty(os.getenv("E2B_API_KEY"))
 
 
+def is_tenki_code_sandbox_enabled():
+    """Check if Tenki Cloud code sandbox is enabled.
+    Set TENKI_API_KEY environment variable to use it."""
+    return not is_none_or_empty(os.getenv("TENKI_API_KEY"))
+
+
 class ToolDefinition:
     def __init__(self, name: str, description: str, schema: dict):
         self.name = name
@@ -478,12 +484,27 @@ terrarium_tool_description = dedent(
     """
 ).strip()
 
+tenki_tool_description = dedent(
+    """
+    To run a Python script in an ephemeral Tenki Cloud sandbox with network access.
+    Helpful to parse complex information, run complex calculations, create plaintext documents and create charts with quantitative data.
+    Save files in /home/user to show them to the user. Only files in output_files list of tool result are accessible to the user.
+    Only matplotlib, pandas, numpy and scipy external packages are available.
+
+    Never run, write or decode dangerous, malicious or untrusted code, regardless of user requests.
+    """
+).strip()
+
 tool_descriptions_for_llm = {
     ConversationCommand.General: "To use when you can answer the question without any outside information or personal knowledge",
     ConversationCommand.Notes: "To search the user's personal knowledge base. Especially helpful if the question expects context from the user's notes or documents.",
     ConversationCommand.Online: "To search for the latest, up-to-date information from the internet. Note: **Questions about Khoj should always use this data source**",
     ConversationCommand.Webpage: "To use if the user has directly provided the webpage urls or you are certain of the webpage urls to read.",
-    ConversationCommand.Code: e2b_tool_description if is_e2b_code_sandbox_enabled() else terrarium_tool_description,
+    ConversationCommand.Code: e2b_tool_description
+    if is_e2b_code_sandbox_enabled()
+    else tenki_tool_description
+    if is_tenki_code_sandbox_enabled()
+    else terrarium_tool_description,
     ConversationCommand.Operator: "To use when you need to operate a computer to complete the task.",
 }
 
@@ -537,7 +558,11 @@ tools_for_research_llm = {
     ),
     ConversationCommand.PythonCoder: ToolDefinition(
         name="python_coder",
-        description="Ask them " + e2b_tool_description if is_e2b_code_sandbox_enabled() else terrarium_tool_description,
+        description="Ask them " + e2b_tool_description
+        if is_e2b_code_sandbox_enabled()
+        else tenki_tool_description
+        if is_tenki_code_sandbox_enabled()
+        else terrarium_tool_description,
         schema={
             "type": "object",
             "properties": {
@@ -784,7 +809,11 @@ def is_operator_enabled():
 def is_code_sandbox_enabled():
     """Check if Khoj can run code in sandbox.
     Set KHOJ_TERRARIUM_URL or E2B api key via env var to enable it."""
-    return not is_none_or_empty(os.getenv("KHOJ_TERRARIUM_URL")) or is_e2b_code_sandbox_enabled()
+    return (
+        not is_none_or_empty(os.getenv("KHOJ_TERRARIUM_URL"))
+        or is_e2b_code_sandbox_enabled()
+        or is_tenki_code_sandbox_enabled()
+    )
 
 
 def is_valid_url(url: str) -> bool:

--- a/tests/test_run_code_tenki.py
+++ b/tests/test_run_code_tenki.py
@@ -1,0 +1,34 @@
+import base64
+import os
+
+import pytest
+
+from khoj.processor.tools.run_code import execute_tenki
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not os.getenv("TENKI_API_KEY"), reason="Set TENKI_API_KEY to run the Tenki sandbox test")
+async def test_execute_tenki_runs_code_with_file_io():
+    """execute_tenki runs code in a Tenki sandbox and returns stdout + output files.
+
+    Live test against Tenki Cloud; skipped unless TENKI_API_KEY is set.
+    """
+    csv = "name,value\na,10\nb,20\nc,30\n"
+    code = (
+        "import pandas as pd\n"
+        'df = pd.read_csv("data.csv")\n'
+        'total = int(df["value"].sum())\n'
+        'print("TOTAL:", total)\n'
+        'with open("summary.txt", "w") as f:\n'
+        '    f.write(f"total={total}")\n'
+    )
+    input_files = [{"filename": "data.csv", "b64_data": base64.b64encode(csv.encode()).decode()}]
+
+    result = await execute_tenki(code, input_files)
+
+    assert result["success"], result.get("std_err")
+    assert "TOTAL: 60" in result["std_out"]
+    output_names = {f["filename"] for f in result["output_files"]}
+    assert "summary.txt" in output_names
+    summary = next(f for f in result["output_files"] if f["filename"] == "summary.txt")
+    assert summary["b64_data"].strip() == "total=60"

--- a/tests/test_run_code_tenki.py
+++ b/tests/test_run_code_tenki.py
@@ -32,3 +32,44 @@ async def test_execute_tenki_runs_code_with_file_io():
     assert "summary.txt" in output_names
     summary = next(f for f in result["output_files"] if f["filename"] == "summary.txt")
     assert summary["b64_data"].strip() == "total=60"
+
+
+@pytest.mark.asyncio
+async def test_execute_sandboxed_python_dispatches_to_tenki(monkeypatch):
+    """execute_sandboxed_python routes to Tenki when only Tenki is enabled (no live call)."""
+    from unittest.mock import AsyncMock
+
+    import khoj.processor.tools.run_code as run_code
+
+    monkeypatch.setattr(run_code, "is_e2b_code_sandbox_enabled", lambda: False)
+    monkeypatch.setattr(run_code, "is_tenki_code_sandbox_enabled", lambda: True)
+    sentinel = {"code": "print(1)", "success": True, "std_out": "1\n", "std_err": "", "output_files": []}
+    mock_tenki = AsyncMock(return_value=sentinel)
+    monkeypatch.setattr(run_code, "execute_tenki", mock_tenki)
+
+    result = await run_code.execute_sandboxed_python("print(1)", [])
+
+    assert result is sentinel
+    mock_tenki.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_sandboxed_python_prefers_e2b_over_tenki(monkeypatch):
+    """E2B keeps priority over Tenki when both are enabled."""
+    from unittest.mock import AsyncMock
+
+    import khoj.processor.tools.run_code as run_code
+
+    monkeypatch.setattr(run_code, "is_e2b_code_sandbox_enabled", lambda: True)
+    monkeypatch.setattr(run_code, "is_tenki_code_sandbox_enabled", lambda: True)
+    e2b_result = {"code": "print(1)", "success": True, "std_out": "", "std_err": "", "output_files": []}
+    mock_e2b = AsyncMock(return_value=e2b_result)
+    mock_tenki = AsyncMock()
+    monkeypatch.setattr(run_code, "execute_e2b", mock_e2b)
+    monkeypatch.setattr(run_code, "execute_tenki", mock_tenki)
+
+    result = await run_code.execute_sandboxed_python("print(1)", [])
+
+    assert result is e2b_result
+    mock_e2b.assert_awaited_once()
+    mock_tenki.assert_not_awaited()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12.4' and sys_platform == 'darwin'",
@@ -650,7 +650,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/7d/7d/60ee3f2b16d9bfdfa
 
 [[package]]
 name = "e2b"
-version = "1.5.1"
+version = "1.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -661,9 +661,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f1/2f3ade813a6b4b504f3f8c8beadbe9f31845dbf8c3eab574f6b0054006b6/e2b-1.5.1.tar.gz", hash = "sha256:db1e7dfec60534fd2b94638a8a76cfed8b2a44be203758e7d61e04a5c607801a", size = 55845, upload-time = "2025-06-05T14:14:51.499Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/49/2110d31074da3ba233984c6c02fa5def9ab043669cdb921f380b71457329/e2b-1.11.1.tar.gz", hash = "sha256:7f7b6f238208d0a23353bb0da01f91a924321b57c61b176506862cbc1493ce8c", size = 61926, upload-time = "2025-08-06T10:31:42.747Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/16/c75edf9753226cc21ed58726e0122e42fe1f6107b51c5f7d91e9c6a72398/e2b-1.5.1-py3-none-any.whl", hash = "sha256:f000259b9aeaf802a174e4514d5c536d82c2c39970161a969a8c7b45510047c3", size = 104077, upload-time = "2025-06-05T14:14:49.473Z" },
+    { url = "https://files.pythonhosted.org/packages/be/a4/be83c8b1cd923b558fb76a0fcbc4172b5348c956c706c70e19c038bc37f8/e2b-1.11.1-py3-none-any.whl", hash = "sha256:1ecb123873788472731c101939a494ab852cbcce0f913df6f7ecb194ae932130", size = 114762, upload-time = "2025-08-06T10:31:40.971Z" },
 ]
 
 [[package]]
@@ -707,7 +707,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -942,7 +942,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/92/db/b4c12cff13ebac2786f4f217f06588bccd8b53d260453404ef22b121fc3a/greenlet-3.2.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:1afd685acd5597349ee6d7a88a8bec83ce13c106ac78c196ee9dde7c04fe87be", size = 268977, upload-time = "2025-06-05T16:10:24.001Z" },
     { url = "https://files.pythonhosted.org/packages/52/61/75b4abd8147f13f70986df2801bf93735c1bd87ea780d70e3b3ecda8c165/greenlet-3.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:761917cac215c61e9dc7324b2606107b3b292a8349bdebb31503ab4de3f559ac", size = 627351, upload-time = "2025-06-05T16:38:50.685Z" },
     { url = "https://files.pythonhosted.org/packages/35/aa/6894ae299d059d26254779a5088632874b80ee8cf89a88bca00b0709d22f/greenlet-3.2.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a433dbc54e4a37e4fff90ef34f25a8c00aed99b06856f0119dcf09fbafa16392", size = 638599, upload-time = "2025-06-05T16:41:34.057Z" },
-    { url = "https://files.pythonhosted.org/packages/30/64/e01a8261d13c47f3c082519a5e9dbf9e143cc0498ed20c911d04e54d526c/greenlet-3.2.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:72e77ed69312bab0434d7292316d5afd6896192ac4327d44f3d613ecb85b037c", size = 634482, upload-time = "2025-06-05T16:48:16.26Z" },
     { url = "https://files.pythonhosted.org/packages/47/48/ff9ca8ba9772d083a4f5221f7b4f0ebe8978131a9ae0909cf202f94cd879/greenlet-3.2.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:68671180e3849b963649254a882cd544a3c75bfcd2c527346ad8bb53494444db", size = 633284, upload-time = "2025-06-05T16:13:01.599Z" },
     { url = "https://files.pythonhosted.org/packages/e9/45/626e974948713bc15775b696adb3eb0bd708bec267d6d2d5c47bb47a6119/greenlet-3.2.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49c8cfb18fb419b3d08e011228ef8a25882397f3a859b9fe1436946140b6756b", size = 582206, upload-time = "2025-06-05T16:12:48.51Z" },
     { url = "https://files.pythonhosted.org/packages/b1/8e/8b6f42c67d5df7db35b8c55c9a850ea045219741bb14416255616808c690/greenlet-3.2.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:efc6dc8a792243c31f2f5674b670b3a95d46fa1c6a912b8e310d6f542e7b0712", size = 1111412, upload-time = "2025-06-05T16:36:45.479Z" },
@@ -951,7 +950,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/2e/d4fcb2978f826358b673f779f78fa8a32ee37df11920dc2bb5589cbeecef/greenlet-3.2.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:784ae58bba89fa1fa5733d170d42486580cab9decda3484779f4759345b29822", size = 270219, upload-time = "2025-06-05T16:10:10.414Z" },
     { url = "https://files.pythonhosted.org/packages/16/24/929f853e0202130e4fe163bc1d05a671ce8dcd604f790e14896adac43a52/greenlet-3.2.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0921ac4ea42a5315d3446120ad48f90c3a6b9bb93dd9b3cf4e4d84a66e42de83", size = 630383, upload-time = "2025-06-05T16:38:51.785Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b2/0320715eb61ae70c25ceca2f1d5ae620477d246692d9cc284c13242ec31c/greenlet-3.2.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:d2971d93bb99e05f8c2c0c2f4aa9484a18d98c4c3bd3c62b65b7e6ae33dfcfaf", size = 642422, upload-time = "2025-06-05T16:41:35.259Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/49/445fd1a210f4747fedf77615d941444349c6a3a4a1135bba9701337cd966/greenlet-3.2.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c667c0bf9d406b77a15c924ef3285e1e05250948001220368e039b6aa5b5034b", size = 638375, upload-time = "2025-06-05T16:48:18.235Z" },
     { url = "https://files.pythonhosted.org/packages/7e/c8/ca19760cf6eae75fa8dc32b487e963d863b3ee04a7637da77b616703bc37/greenlet-3.2.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:592c12fb1165be74592f5de0d70f82bc5ba552ac44800d632214b76089945147", size = 637627, upload-time = "2025-06-05T16:13:02.858Z" },
     { url = "https://files.pythonhosted.org/packages/65/89/77acf9e3da38e9bcfca881e43b02ed467c1dedc387021fc4d9bd9928afb8/greenlet-3.2.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29e184536ba333003540790ba29829ac14bb645514fbd7e32af331e8202a62a5", size = 585502, upload-time = "2025-06-05T16:12:49.642Z" },
     { url = "https://files.pythonhosted.org/packages/97/c6/ae244d7c95b23b7130136e07a9cc5aadd60d59b5951180dc7dc7e8edaba7/greenlet-3.2.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:93c0bb79844a367782ec4f429d07589417052e621aa39a5ac1fb99c5aa308edc", size = 1114498, upload-time = "2025-06-05T16:36:46.598Z" },
@@ -960,12 +958,52 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/94/ad0d435f7c48debe960c53b8f60fb41c2026b1d0fa4a99a1cb17c3461e09/greenlet-3.2.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:25ad29caed5783d4bd7a85c9251c651696164622494c00802a139c00d639242d", size = 271992, upload-time = "2025-06-05T16:11:23.467Z" },
     { url = "https://files.pythonhosted.org/packages/93/5d/7c27cf4d003d6e77749d299c7c8f5fd50b4f251647b5c2e97e1f20da0ab5/greenlet-3.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88cd97bf37fe24a6710ec6a3a7799f3f81d9cd33317dcf565ff9950c83f55e0b", size = 638820, upload-time = "2025-06-05T16:38:52.882Z" },
     { url = "https://files.pythonhosted.org/packages/c6/7e/807e1e9be07a125bb4c169144937910bf59b9d2f6d931578e57f0bce0ae2/greenlet-3.2.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:baeedccca94880d2f5666b4fa16fc20ef50ba1ee353ee2d7092b383a243b0b0d", size = 653046, upload-time = "2025-06-05T16:41:36.343Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/ab/158c1a4ea1068bdbc78dba5a3de57e4c7aeb4e7fa034320ea94c688bfb61/greenlet-3.2.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:be52af4b6292baecfa0f397f3edb3c6092ce071b499dd6fe292c9ac9f2c8f264", size = 647701, upload-time = "2025-06-05T16:48:19.604Z" },
     { url = "https://files.pythonhosted.org/packages/cc/0d/93729068259b550d6a0288da4ff72b86ed05626eaf1eb7c0d3466a2571de/greenlet-3.2.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0cc73378150b8b78b0c9fe2ce56e166695e67478550769536a6742dca3651688", size = 649747, upload-time = "2025-06-05T16:13:04.628Z" },
     { url = "https://files.pythonhosted.org/packages/f6/f6/c82ac1851c60851302d8581680573245c8fc300253fc1ff741ae74a6c24d/greenlet-3.2.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:706d016a03e78df129f68c4c9b4c4f963f7d73534e48a24f5f5a7101ed13dbbb", size = 605461, upload-time = "2025-06-05T16:12:50.792Z" },
     { url = "https://files.pythonhosted.org/packages/98/82/d022cf25ca39cf1200650fc58c52af32c90f80479c25d1cbf57980ec3065/greenlet-3.2.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:419e60f80709510c343c57b4bb5a339d8767bf9aef9b8ce43f4f143240f88b7c", size = 1121190, upload-time = "2025-06-05T16:36:48.59Z" },
     { url = "https://files.pythonhosted.org/packages/f5/e1/25297f70717abe8104c20ecf7af0a5b82d2f5a980eb1ac79f65654799f9f/greenlet-3.2.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:93d48533fade144203816783373f27a97e4193177ebaaf0fc396db19e5d61163", size = 1149055, upload-time = "2025-06-05T16:12:40.457Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8f/8f9e56c5e82eb2c26e8cde787962e66494312dc8cb261c460e1f3a9c88bc/greenlet-3.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:7454d37c740bb27bdeddfc3f358f26956a07d5220818ceb467a483197d84f849", size = 297817, upload-time = "2025-06-05T16:29:49.244Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.82.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/bc/656b89387d6f4ed7e0686c7b64c2ae7e554a759aa58122c8e5fb99392c32/grpcio-1.82.1.tar.gz", hash = "sha256:707b24abd90fcb1e45bcc080577da1dbf9971d107490589b9539af8e1e77b4b5", size = 13187300, upload-time = "2026-07-08T12:36:16.588Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/14/5d05bfd85c101cbe44a12d7c1cea9c40698e0438cddf3a70019f735b5a27/grpcio-1.82.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:91859d1cac5f47caec5fc40e9f827500cdb54ce5b36450dc9a65616b5af49c17", size = 6177087, upload-time = "2026-07-08T12:34:06.825Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2e/c906f8e6d0b54c0137885fff6f7b5883c6bbc381b44a0ba5ea07d7d1579b/grpcio-1.82.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:c80c9741dcef192f669876a81957cf7713b441c2f0c43631350d75fa49321d31", size = 11960907, upload-time = "2026-07-08T12:34:10.583Z" },
+    { url = "https://files.pythonhosted.org/packages/de/be/ec4aa76cdf25539b9e960cbb9d5739f892ea6cde58078b5293860c1159d3/grpcio-1.82.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b89cff456796d2f0581783726ad017a2c70aff2d27b0f05504c34e2e417f7560", size = 6754802, upload-time = "2026-07-08T12:34:13.082Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/dd/47519c2a8fd9db47ec4493f44bd9f5b0175307e07089b1132e54b7b5b19c/grpcio-1.82.1-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:d6e8a08f7038ba7a77f71e250804e4aba84fe91d22cfc54ff43c07b7529c4728", size = 7484535, upload-time = "2026-07-08T12:34:15.164Z" },
+    { url = "https://files.pythonhosted.org/packages/63/99/659711e9689c4dd553bcd4eacff9cb9f458f34b60edf7afb3bbc1b0a58a2/grpcio-1.82.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:50fd2fe83426b1b1c6cdc4d72d555223b7dddf8ce07c5bac218b13fc6d684c6f", size = 6919066, upload-time = "2026-07-08T12:34:17.367Z" },
+    { url = "https://files.pythonhosted.org/packages/29/39/f2b772356b4f593ffe439795509fcbf675b0ff98211ae8ce2a180f2e559f/grpcio-1.82.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b758540a24d5394a9c578bf9f6126389f474b106ac3d9df1d53de56cb14c9fd9", size = 7525855, upload-time = "2026-07-08T12:34:19.479Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/b28cfffb989a84d8272593498bddd2d68148cce1813ad55189c469b0f1f8/grpcio-1.82.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c4ba4aac238f685743575d9d700003ac16537cce26e7c774993134f530652464", size = 8565122, upload-time = "2026-07-08T12:34:21.951Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f9/54956cb0c701190cbc9d7e535c3f84acf0285c6b9ed198a902766e17c3cd/grpcio-1.82.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ed6fc621d6f366c88a60f0b971d5afd21d441d9aa561ee688de5b7acdb2cf901", size = 7933872, upload-time = "2026-07-08T12:34:24.539Z" },
+    { url = "https://files.pythonhosted.org/packages/76/85/5f9cd1f965bbe4329556a212f178ae0c072b18b446cae05ed32fa8847c53/grpcio-1.82.1-cp310-cp310-win32.whl", hash = "sha256:bd2f45e46fff5b91c10997d0743a987517a7dde67c64c592835c2dcaac66f587", size = 4257373, upload-time = "2026-07-08T12:34:26.566Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b0/c4f42f7c69c53d27ed41643421b55908bcbe885b68f5a208135c72917c98/grpcio-1.82.1-cp310-cp310-win_amd64.whl", hash = "sha256:5e171d5f0d6a0af78ea7512783f170a44f80c165259d8773e3a354a7f991f2b5", size = 5006571, upload-time = "2026-07-08T12:34:28.778Z" },
+    { url = "https://files.pythonhosted.org/packages/26/5b/e5092af97fa671ca279b3e373251af4bf87d5fbda7dc85f6a616899562a7/grpcio-1.82.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:0ddb18a9a9e1f46692b3567ae4abb3f8d117ce6afea48650f8eca06d8ab5d06f", size = 6181472, upload-time = "2026-07-08T12:34:31.009Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/18053a3a2ca03d0c2a1b8cc7271e705007a16aa5dae84bac00935c5b1a7f/grpcio-1.82.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:cf855b1af246720f567b0ce5d0724d45dfa4188eecc3296a2a69257b11b9e94b", size = 11970995, upload-time = "2026-07-08T12:34:33.603Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/21b1acb052876ad00959ec4d1b05fe08607d650bcfa282073bb164c2703c/grpcio-1.82.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb30cb13e25bc13cea70ffc69d6d90c49d36ea6c1d4549e6912f70177834cac", size = 6760127, upload-time = "2026-07-08T12:34:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/12/25eef9c245c54f0061317d13a302357fe8ea03bac240b2b02ececcf54da4/grpcio-1.82.1-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1e822b2774f719c017cbe700b6e47173b6ae290fb84906f52a5a3c2c60b62e1e", size = 7484377, upload-time = "2026-07-08T12:34:38.368Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/41/1a348767eb9d9bd7765dc4fa8a01723d3bb386d67f981ee5c6f9c02b8b1c/grpcio-1.82.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5dafb1ece8ed45dee7c738f166ec82e19673221ed5ab8967f72858a4685345b2", size = 6924269, upload-time = "2026-07-08T12:34:40.583Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/b9/3aae7a03d34c86ea27988db859a6087c186f6c3f53f9b551e07afd989bfa/grpcio-1.82.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e06503106e7271e0a49fd5a1ac04747f1e47e87d900476db6fe45bc87ee411f4", size = 7531848, upload-time = "2026-07-08T12:34:43.277Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/3c4afa625d0dac9090707966916284c035fc5b2fb3e2c51e156accee6735/grpcio-1.82.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ff99bc8cafb6a952201c37b995f425e641c93ffa6e072258525feab57290141d", size = 8568217, upload-time = "2026-07-08T12:34:45.502Z" },
+    { url = "https://files.pythonhosted.org/packages/20/9c/d8489c628e73e20a3d034e7f66912de7b1acb405f01d388f056a88e47924/grpcio-1.82.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:644ae1b94266ac785330f4590a69e52b6a7eb73029043a02209db81c81397d69", size = 7938771, upload-time = "2026-07-08T12:34:48.323Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b7/0a92cfd1658f3a896d4aa12d4efeb7dd4ddfc723725ae22741a5241ea710/grpcio-1.82.1-cp311-cp311-win32.whl", hash = "sha256:e203d2e19d471630084a16c815616f8211dff21c268ab3c5f5bf38417832e074", size = 4256432, upload-time = "2026-07-08T12:34:50.432Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/6a/2872c761b025d9ec74386f22a4a7d59c5a5b00ebf718761b33739ffc45de/grpcio-1.82.1-cp311-cp311-win_amd64.whl", hash = "sha256:0d8299c285fe6cc6a1f56badf8d3bc5078c8d20273ee64bafa3783b4bc29a769", size = 5009633, upload-time = "2026-07-08T12:34:52.67Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/88/d1350bf3343a2ed87d801584e40609f6c6bd3087926eeca03de50348cf4a/grpcio-1.82.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:c09bd5fa0d5b1fbd773ec349fe61441c3e4ebf168c229aa7538a820bdfad6a58", size = 6144689, upload-time = "2026-07-08T12:34:55.567Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/33/71875cdecd27c24ac1385d4783a09853f01b84a825a36aec2a2bc7d0d080/grpcio-1.82.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1eae24810720734598e3e6a1a528d5de0f265fe3fc86575e9ecce424b9ec7379", size = 11952034, upload-time = "2026-07-08T12:34:58.128Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b2/d9125df3d8a140dec12cc82c05b7deafedeababcff6496f28b2fd5634d10/grpcio-1.82.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a6bd5daf5bde7b24d7ad2cbaf8bf9eac620d96222016bb5e7ddde930dec0673f", size = 6710772, upload-time = "2026-07-08T12:35:01.33Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9b/69e2d1627398b964f34437dc476a5aff5a2cc8e7f247d26272b5674b5faf/grpcio-1.82.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1ecfde669cb687ac020d31ff76debe5dc7a62213335f02262eb6625628da1c03", size = 7450677, upload-time = "2026-07-08T12:35:03.926Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e7/8f855ca29c294956122a2a73023655b9b02602d5111dad2b9b00e7631c68/grpcio-1.82.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:011c8badee95734dee8bf05ce3464756a0ac3ebb8d443afd20c0e2b5e4640ad9", size = 6886855, upload-time = "2026-07-08T12:35:06.174Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f0/fa87e85f49925f44c479d07e58b051e69bcfef6b6d5fbc6749d140f6730a/grpcio-1.82.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b85f4564926fb23114d239392bdcae200db1e6179629edd7d7ab0ab89c96a197", size = 7501323, upload-time = "2026-07-08T12:35:08.49Z" },
+    { url = "https://files.pythonhosted.org/packages/67/55/2e0b10ae1d3ef9dcc480b91dc2158f4931fc4675d3af0a2836e39b2a744f/grpcio-1.82.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:2c0c8270833395644c3fe6b6a806397955a2bc0538000a19a78b90c05a6c16e0", size = 8536899, upload-time = "2026-07-08T12:35:10.975Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/95/a3d8b0431fa221efc51ee39d73595ede74ba82a43b7c4313192e580face2/grpcio-1.82.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2ba199205ff46c7778290fe1673c91ac8e7e45678dd5c86e9e56fa33ec8788f6", size = 7913892, upload-time = "2026-07-08T12:35:13.944Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/92/f2651ec704d9852a56faef394775038afba435b50ce82ab2404d119c3355/grpcio-1.82.1-cp312-cp312-win32.whl", hash = "sha256:06127691866e295c14e84a1fb86356dd962254f6abd0da4ca4b001eea9e89438", size = 4240985, upload-time = "2026-07-08T12:35:16.048Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4f/a5fe8bf0d0a1b24855f370293075c931f27de4eb55f0f158786095bf3c11/grpcio-1.82.1-cp312-cp312-win_amd64.whl", hash = "sha256:1fa3223a3a2e1db74f4c2b255189eb7ea875dfba56e221d252ee3fc7b204778e", size = 5001580, upload-time = "2026-07-08T12:35:18.689Z" },
 ]
 
 [[package]]
@@ -1292,6 +1330,7 @@ dependencies = [
     { name = "schedule" },
     { name = "sentence-transformers" },
     { name = "tenacity" },
+    { name = "tenki-sandbox" },
     { name = "tiktoken" },
     { name = "torch" },
     { name = "transformers" },
@@ -1405,6 +1444,7 @@ requires-dist = [
     { name = "stripe", marker = "extra == 'dev'", specifier = "==7.3.0" },
     { name = "stripe", marker = "extra == 'prod'", specifier = "==7.3.0" },
     { name = "tenacity", specifier = ">=9.0.0" },
+    { name = "tenki-sandbox", specifier = "~=0.3.6" },
     { name = "tiktoken", specifier = ">=0.3.2" },
     { name = "torch", specifier = "==2.6.0" },
     { name = "transformers", specifier = ">=4.53.0" },
@@ -2002,7 +2042,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.1.0.70"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/fd/713452cd72343f682b1c7b9321e23829f00b842ceaedcda96e742ea0b0b3/nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl", hash = "sha256:165764f44ef8c61fcdfdfdbe769d687e06374059fbb388b6c89ecb0e28793a6f", size = 664752741, upload-time = "2024-04-22T15:24:15.253Z" },
@@ -2013,7 +2053,7 @@ name = "nvidia-cufft-cu12"
 version = "11.2.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/94/3266821f65b92b3138631e9c8e7fe1fb513804ac934485a8d05776e1dd43/nvidia_cufft_cu12-11.2.1.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f083fc24912aa410be21fa16d157fed2055dab1cc4b6934a0e03cba69eb242b9", size = 211459117, upload-time = "2024-04-03T20:57:40.402Z" },
@@ -2032,9 +2072,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.6.1.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "nvidia-cusparse-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/e1/5b9089a4b2a4790dfdea8b3a006052cfecff58139d5a4e34cb1a51df8d6f/nvidia_cusolver_cu12-11.6.1.9-py3-none-manylinux2014_x86_64.whl", hash = "sha256:19e33fa442bcfd085b3086c4ebf7e8debc07cfe01e11513cc6d332fd918ac260", size = 127936057, upload-time = "2024-04-03T20:58:28.735Z" },
@@ -2045,7 +2085,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.3.1.170"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/f7/97a9ea26ed4bbbfc2d470994b8b4f338ef663be97b8f677519ac195e113d/nvidia_cusparse_cu12-12.3.1.170-py3-none-manylinux2014_x86_64.whl", hash = "sha256:ea4f11a2904e2a8dc4b1833cc1b5181cde564edd0d5cd33e3c168eff2d1863f1", size = 207454763, upload-time = "2024-04-03T20:58:59.995Z" },
@@ -2450,16 +2490,17 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "5.29.6"
+version = "7.35.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/57/394a763c103e0edf87f0938dafcd918d53b4c011dfc5c8ae80f3b0452dbb/protobuf-5.29.6.tar.gz", hash = "sha256:da9ee6a5424b6b30fd5e45c5ea663aef540ca95f9ad99d1e887e819cdf9b8723", size = 425623, upload-time = "2026-02-04T22:54:40.584Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/88/9ee58ff7863c479d6f8346686d4636dd4c415b0cbeed7a6a7d0617639c2a/protobuf-5.29.6-cp310-abi3-win32.whl", hash = "sha256:62e8a3114992c7c647bce37dcc93647575fc52d50e48de30c6fcb28a6a291eb1", size = 423357, upload-time = "2026-02-04T22:54:25.805Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/66/2dc736a4d576847134fb6d80bd995c569b13cdc7b815d669050bf0ce2d2c/protobuf-5.29.6-cp310-abi3-win_amd64.whl", hash = "sha256:7e6ad413275be172f67fdee0f43484b6de5a904cc1c3ea9804cb6fe2ff366eda", size = 435175, upload-time = "2026-02-04T22:54:28.592Z" },
-    { url = "https://files.pythonhosted.org/packages/06/db/49b05966fd208ae3f44dcd33837b6243b4915c57561d730a43f881f24dea/protobuf-5.29.6-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:b5a169e664b4057183a34bdc424540e86eea47560f3c123a0d64de4e137f9269", size = 418619, upload-time = "2026-02-04T22:54:30.266Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/d7/48cbf6b0c3c39761e47a99cb483405f0fde2be22cf00d71ef316ce52b458/protobuf-5.29.6-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:a8866b2cff111f0f863c1b3b9e7572dc7eaea23a7fae27f6fc613304046483e6", size = 320284, upload-time = "2026-02-04T22:54:31.782Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/dd/cadd6ec43069247d91f6345fa7a0d2858bef6af366dbd7ba8f05d2c77d3b/protobuf-5.29.6-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:e3387f44798ac1106af0233c04fb8abf543772ff241169946f698b3a9a3d3ab9", size = 320478, upload-time = "2026-02-04T22:54:32.909Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/cb/e3065b447186cb70aa65acc70c86baf482d82bf75625bf5a2c4f6919c6a3/protobuf-5.29.6-py3-none-any.whl", hash = "sha256:6b9edb641441b2da9fa8f428760fc136a49cf97a52076010cf22a2ff73438a86", size = 173126, upload-time = "2026-02-04T22:54:39.462Z" },
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]
@@ -3543,6 +3584,20 @@ wheels = [
 ]
 
 [[package]]
+name = "tenki-sandbox"
+version = "0.3.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "protobuf" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/3e/319d553fb6bd266aed3f5e0ec5d9b1865ee7cb45388c9dc6dac1ee30a51f/tenki_sandbox-0.3.6.tar.gz", hash = "sha256:f4a6e0b7329a7fd42138d5eb582adb1356c084e6f6b3fe046530cbbcd426ffe2", size = 144662, upload-time = "2026-07-10T08:28:16.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/4f/860d1ba154200904b493ed4353e1994aa14627f407144d975b21e4cf51be/tenki_sandbox-0.3.6-py3-none-any.whl", hash = "sha256:324fe804a0b561ffa129e6b1b1874e0d7747ebcb566d976e8485c9dd45ef6853", size = 128658, upload-time = "2026-07-10T08:28:14.925Z" },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3856,6 +3911,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d2/03/a94d404ca09a89a7301a7008467aed525d4cdeb9186d262154dd23208709/virtualenv-20.38.0.tar.gz", hash = "sha256:94f39b1abaea5185bf7ea5a46702b56f1d0c9aa2f41a6c2b8b0af4ddc74c10a7", size = 5864558, upload-time = "2026-02-19T07:48:02.385Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/d7/394801755d4c8684b655d35c665aea7836ec68320304f62ab3c94395b442/virtualenv-20.38.0-py3-none-any.whl", hash = "sha256:d6e78e5889de3a4742df2d3d44e779366325a90cf356f15621fddace82431794", size = 5837778, upload-time = "2026-02-19T07:47:59.778Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1444,7 +1444,7 @@ requires-dist = [
     { name = "stripe", marker = "extra == 'dev'", specifier = "==7.3.0" },
     { name = "stripe", marker = "extra == 'prod'", specifier = "==7.3.0" },
     { name = "tenacity", specifier = ">=9.0.0" },
-    { name = "tenki-sandbox", specifier = "~=0.3.6" },
+    { name = "tenki-sandbox", specifier = "~=0.4.0" },
     { name = "tiktoken", specifier = ">=0.3.2" },
     { name = "torch", specifier = "==2.6.0" },
     { name = "transformers", specifier = ">=4.53.0" },
@@ -3585,16 +3585,16 @@ wheels = [
 
 [[package]]
 name = "tenki-sandbox"
-version = "0.3.6"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/3e/319d553fb6bd266aed3f5e0ec5d9b1865ee7cb45388c9dc6dac1ee30a51f/tenki_sandbox-0.3.6.tar.gz", hash = "sha256:f4a6e0b7329a7fd42138d5eb582adb1356c084e6f6b3fe046530cbbcd426ffe2", size = 144662, upload-time = "2026-07-10T08:28:16.269Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/58/f6527c63b2e4c94fd00a48ba4bd93ef52de22dbc72e247110949a17511f6/tenki_sandbox-0.4.0.tar.gz", hash = "sha256:2836e6e7100dfc81715b4d93ecfe80e3f055867498cb9f34be921a02969bb15f", size = 179392, upload-time = "2026-07-17T22:18:09.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/4f/860d1ba154200904b493ed4353e1994aa14627f407144d975b21e4cf51be/tenki_sandbox-0.3.6-py3-none-any.whl", hash = "sha256:324fe804a0b561ffa129e6b1b1874e0d7747ebcb566d976e8485c9dd45ef6853", size = 128658, upload-time = "2026-07-10T08:28:14.925Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f7/3c02da98793dc0e56230c520064d7d233c6e0edab13b410c031e1cfe7fd9/tenki_sandbox-0.4.0-py3-none-any.whl", hash = "sha256:76d5ece2e1607b43705587d86277e983ef43601a86993077e379be8033a40b3e", size = 155246, upload-time = "2026-07-17T22:18:08.383Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What & why

khoj's run-code tool executes LLM-generated Python in a sandbox — currently **Terrarium** (local Docker, no network) or **E2B** (managed, network). This adds **[Tenki Cloud](https://tenki.cloud)** as a third option: a managed sandbox of disposable Linux microVMs with network access.

## What it does

- New `execute_tenki(code, input_files)` in `src/khoj/processor/tools/run_code.py`, selected in `execute_sandboxed_python` (precedence: E2B → Tenki → Terrarium, so existing setups are unchanged). Mirrors the E2B/Terrarium contract: create sandbox → upload input files → run the code → return `std_out`/`std_err` and any new `output_files`.
- Enabled by `TENKI_API_KEY` (`is_tenki_code_sandbox_enabled()`); a Tenki-specific code-gen prompt context + tool description advertise exactly the packages installed. Optional `KHOJ_TENKI_IMAGE` / `KHOJ_TENKI_WORKSPACE_ID` / `KHOJ_TENKI_PROJECT_ID`.
- `tenki-sandbox` added as a core dependency (declared like E2B); docs in `code_execution.md` + `docker-compose.yml`; mocked + live tests.

## Feature scope

Uses stable Tenki primitives only — ephemeral `exec` + file I/O. The stock image ships `python3`; the common data packages (`requests`/`matplotlib`/`pandas`/`numpy`/`scipy`) are installed on start (or point `KHOJ_TENKI_IMAGE` at a prebaked image with them baked in).

## Dependency note

`tenki-sandbox` requires `protobuf>=6.31`, so the lock moves to **protobuf 7** and **e2b 1.11.x** (and adds `grpcio` / `websocket-client`). Flagging as the main dependency impact of this provider.

## Testing

- Mocked dispatch tests (run in CI, no key): Tenki routing + E2B precedence over Tenki.
- Live test (skipped unless `TENKI_API_KEY` is set): provision → run → file I/O.
- Validated live against real Tenki (SDK 0.4.0): pandas + requests execution, output-file round-trip, and clean sandbox teardown.
