### PR TITLE
Stop sending client IP in telemetry so it matches the privacy docs

### DIFF
--- a/src/khoj/routers/helpers.py
+++ b/src/khoj/routers/helpers.py
@@ -208,7 +208,6 @@ def update_telemetry_state(
     client_app: ClientApplication = request.user.client_app if request.user.is_authenticated else None
     subscription: Subscription = user.subscription if user and hasattr(user, "subscription") else None
     user_state = {
-        "client_host": request.client.host if request.client else None,
         "user_agent": user_agent or "unknown",
         "referer": referer or "unknown",
         "host": host or "unknown",


### PR DESCRIPTION
Closes #1374. Taking this up per @debanjum's offer on the issue — thanks for confirming it.

## What

Removes one line from `update_telemetry_state` in `src/khoj/routers/helpers.py`: the `client_host` property, which was set to `request.client.host` — the caller's IP address.

## Why

The documentation says the opposite of what the code did:

- `documentation/docs/get-started/privacy-security.md:15` — *"We do not log your IP address, nor upload any of your personal data to PostHog."*
- `documentation/docs/miscellaneous/telemetry.md` lists what is collected: client, API usage, configured content types, and *"Request metadata (e.g., host, referrer)"* — no client IP.

@debanjum confirmed on the issue that the IP is already dropped at the PostHog layer and that it shouldn't be sent in the first place:

> *"we do drop client I.P at posthog layer, so not sure why client host was still being passed. We should stop passing client host as telemetry so it agrees with the docs for sure."*

This removes it at the source, so the payload matches the promise regardless of what any downstream layer does.

## Scope, and why it's safe

I checked every reference before cutting it rather than assuming:

- `client_host` occurs **exactly once** in the entire repository — the line removed here. `grep -rn client_host .` now returns zero hits.
- Nothing reads it back. `log_telemetry` in `src/khoj/utils/helpers.py` merges `properties` into the request body verbatim (`request_body.update(properties or {})`) and has no field-specific handling.
- No other telemetry field is touched. `user_agent`, `referer`, `host`, `server_id`, `subscription_type`, `is_recurring` and `client_id` are all unchanged.

One line, one file. Happy to adjust the framing or the commit message to whatever you prefer.

---

*Disclosure: I used AI assistance (Claude Opus 5) to help investigate this and draft the change. I verified the call site, the reference count and the documentation quotes myself, and I take responsibility for it.*