### PR TITLE
Fix Emacs cleanup deleting unrelated processes

### DIFF
--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -1117,11 +1117,13 @@ Run CALLBACK with CBARGS on formatted message."
 
 (defun khoj--delete-open-network-connections-to-server ()
   "Delete all network connections to khoj server."
-  (dolist (proc (process-list))
-    (let ((proc-buf (buffer-name (process-buffer proc)))
-          (khoj-network-proc-buf (string-join (split-string khoj-server-url "://") " ")))
-      (when (string-match (format "%s" khoj-network-proc-buf) proc-buf)
-        (ignore-errors (delete-process proc))))))
+  (let ((khoj-network-proc-buf (string-join (split-string khoj-server-url "://") " ")))
+    (dolist (proc (process-list))
+      (let ((proc-buf (process-buffer proc)))
+        (when (and proc-buf
+                   (buffer-live-p proc-buf)
+                   (string-match-p (regexp-quote khoj-network-proc-buf) (buffer-name proc-buf)))
+          (ignore-errors (delete-process proc)))))))
 
 (defun khoj--teardown-incremental-search ()
   "Teardown hooks used for incremental search."

--- a/src/interface/emacs/tests/khoj-tests.el
+++ b/src/interface/emacs/tests/khoj-tests.el
@@ -28,6 +28,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'dash)
 (require 'ert)
 (require 'khoj)
@@ -261,6 +262,30 @@ Content-Type: text/org\r\n\r\n\
 --khoj--\r\n" upgrade-file act-file "/tmp/deleted-file.org"))))
       (delete-file upgrade-file)
       (delete-file act-file))))
+
+(ert-deftest khoj-tests--delete-open-network-connections-to-server ()
+  "Test only network processes connected to the Khoj server are deleted."
+  (let* ((khoj-server-url "https://app.khoj.dev")
+         (khoj-buffer (generate-new-buffer " *https app.khoj.dev*"))
+         (regexp-lookalike-buffer (generate-new-buffer " *https appXkhojYdev*"))
+         (unrelated-buffer (generate-new-buffer " *https example.com*"))
+         (process-buffers `((khoj-process . ,khoj-buffer)
+                            (regexp-lookalike-process . ,regexp-lookalike-buffer)
+                            (unrelated-process . ,unrelated-buffer)
+                            (bufferless-process . nil)))
+         deleted-processes)
+    (unwind-protect
+        (cl-letf (((symbol-function 'process-list)
+                   (lambda () (mapcar #'car process-buffers)))
+                  ((symbol-function 'process-buffer)
+                   (lambda (proc) (alist-get proc process-buffers)))
+                  ((symbol-function 'delete-process)
+                   (lambda (proc) (push proc deleted-processes))))
+          ;; Reproduce the failure callback running in a matching URL buffer.
+          (with-current-buffer khoj-buffer
+            (khoj--delete-open-network-connections-to-server))
+          (should (equal deleted-processes '(khoj-process))))
+      (mapc #'kill-buffer (list khoj-buffer regexp-lookalike-buffer unrelated-buffer)))))
 
 (ert-deftest khoj-tests--extract-online-references ()
   (let* (;; Arrange


### PR DESCRIPTION
## Summary

Prevent `khoj--delete-open-network-connections-to-server` from deleting unrelated bufferless Emacs processes when a Khoj request fails.

## Root cause

`(buffer-name (process-buffer proc))` treats a `nil` process buffer as the current buffer. The failed request callback runs in a Khoj URL buffer, so every bufferless process can appear to match the Khoj server and be deleted. This includes the Emacs server listener.

## Changes

- Only inspect processes that own a live buffer.
- Match the derived Khoj URL buffer name literally.
- Add an ERT regression test covering the matching connection, a bufferless process, an unrelated process, and a regex-lookalike buffer.

## Impact

Failed indexing requests still clean up Khoj URL connections, but no longer terminate the Emacs server listener or other unrelated bufferless processes.

## Validation

- `git diff --check`
- Added an ERT regression test that fails against the previous implementation.
- [Emacs CI matrix](https://github.com/tianmind-studio/khoj/actions/runs/30208371910) passed on the fork with Emacs 28.2, 29.4, 30.2, and snapshot.
- The upstream workflow is pending the standard first-time fork approval.

Fixes #1378

AI assistance disclosure: this change was prepared with Codex. The diff and test assertions were reviewed locally and verified with the repository's Emacs CI matrix.
