### PR TITLE
docs: use Docker Compose plugin command in setup guide

### DIFF
--- a/documentation/docs/get-started/setup.mdx
+++ b/documentation/docs/get-started/setup.mdx
@@ -48,7 +48,7 @@ Restart your Khoj server after the first run to ensure all settings are applied 
         3. Start Khoj by running the following command in the same directory as your docker-compose.yml file.
            ```shell
            cd ~/.khoj
-           docker-compose up
+           docker compose up
            ```
       </TabItem>
       <TabItem value="windows" label="Windows">
@@ -75,7 +75,7 @@ Restart your Khoj server after the first run to ensure all settings are applied 
          ```shell
          # Windows users should use their WSL2 terminal to run these commands
          cd ~/.khoj
-         docker-compose up
+         docker compose up
          ```
       </TabItem>
       <TabItem value="linux" label="Linux">
@@ -96,7 +96,7 @@ Restart your Khoj server after the first run to ensure all settings are applied 
         3. Start Khoj by running the following command in the same directory as your docker-compose.yml file.
            ```shell
            cd ~/.khoj
-           docker-compose up
+           docker compose up
            ```
       </TabItem>
     </Tabs>
@@ -359,7 +359,7 @@ Set the host URL on your clients settings page to your Khoj server URL. By defau
       ```shell
       # Windows users should use their WSL2 terminal to run these commands
       cd ~/.khoj  # assuming your khoj docker-compose.yml file is here
-      docker-compose up --build
+      docker compose up --build
       ```
     </TabItem>
   </Tabs>


### PR DESCRIPTION
## Summary

- update the setup guide to use the Docker Compose plugin command
- apply the correction to every executable startup example in the page while keeping `docker-compose.yml` file references unchanged

Closes #1380

## Verification

- `git diff --check`
- confirmed the page has no remaining `docker-compose up` examples

## Notes

I attempted `yarn build`, but the local documentation dependencies were absent and `yarn install --frozen-lockfile` stalled during package download with no error output.