### PR TITLE
Fix: pgvector docker image tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   database:
-    image: docker.io/pgvector/pgvector:pg15
+    image: docker.io/pgvector/pgvector:pg15-trixie
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
Description:
Corrects the pgvector image tag in docker-compose.yml, which was pinned to an invalid tag[pg15]. Updated to [pg15-trixie].

Testing: Verified docker compose up pulls the image and starts successfully.