### PR TITLE
fix(pdf): don't reopen NamedTemporaryFile while it's still held open

### DIFF
--- a/src/khoj/processor/content/pdf/pdf_to_entries.py
+++ b/src/khoj/processor/content/pdf/pdf_to_entries.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import tempfile
 from typing import Dict, Final, List, Tuple
 
@@ -95,21 +96,31 @@ class PdfToEntries(TextToEntries):
     def extract_text(pdf_file):
         """Extract text from specified PDF files"""
         pdf_entry_by_pages = []
+        tmp_file_path = None
         try:
-            # Create temp file with .pdf extension that gets auto-deleted
-            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=True) as tmpf:
+            # delete=False: on Windows a NamedTemporaryFile can't be reopened by
+            # PyMuPDFLoader while this handle is still open, so close it first and
+            # unlink it ourselves once we're done reading.
+            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmpf:
                 tmpf.write(pdf_file)
                 tmpf.flush()  # Ensure all data is written
+                tmp_file_path = tmpf.name
 
-                # Load the content using PyMuPDFLoader
-                loader = PyMuPDFLoader(tmpf.name)
-                pdf_entries_per_file = loader.load()
+            # Load the content using PyMuPDFLoader
+            loader = PyMuPDFLoader(tmp_file_path)
+            pdf_entries_per_file = loader.load()
 
-                # Convert the loaded entries into the desired format
-                pdf_entry_by_pages = [PdfToEntries.clean_text(page.page_content) for page in pdf_entries_per_file]
+            # Convert the loaded entries into the desired format
+            pdf_entry_by_pages = [PdfToEntries.clean_text(page.page_content) for page in pdf_entries_per_file]
         except Exception as e:
             logger.warning(f"Unable to process file: {pdf_file}. This file will not be indexed.")
             logger.warning(e, exc_info=True)
+        finally:
+            if tmp_file_path:
+                try:
+                    os.unlink(tmp_file_path)
+                except OSError:
+                    pass
 
         return pdf_entry_by_pages
 


### PR DESCRIPTION
## Summary

Fixes #1368. On Windows, `PdfToEntries.extract_text` fails to index any PDF because `PyMuPDFLoader` is passed the path of a still-open `NamedTemporaryFile(delete=True)`, and Windows doesn't allow reopening a file that's still held open by another handle.

- Create the temp file with `delete=False` and close the `with` block before handing the path to `PyMuPDFLoader`
- Clean up the temp file ourselves via `os.unlink()` in a `finally` block, so behavior is unchanged on close/error paths

## Test plan

- [x] Ran `PdfToEntries.extract_pdf_entries` directly against `tests/data/pdf/singlepage.pdf` and `tests/data/pdf/multipage.pdf` — entry counts match what `tests/test_pdf_to_entries.py` expects (1 and 6 entries respectively)
- [x] Confirmed no temp files are leaked after extraction (checked `tempfile.gettempdir()` before/after)
- [ ] Could not run the full pytest suite locally (requires a Postgres instance for Django test DB setup, unrelated to this change) — happy to have CI confirm