### PR TITLE
fix(markdown): use a real tokenizer for the heading-split length check

### DIFF
--- a/src/khoj/processor/content/markdown/markdown_to_entries.py
+++ b/src/khoj/processor/content/markdown/markdown_to_entries.py
@@ -84,7 +84,7 @@ class MarkdownToEntries(TextToEntries):
         markdown_content_with_ancestry = f"{ancestry_string}{markdown_content}"
 
         # If content is small or content has no children headings, save it as a single entry
-        if len(TextToEntries.tokenizer(markdown_content_with_ancestry)) <= max_tokens or not re.search(
+        if TextToEntries.token_count(markdown_content_with_ancestry) <= max_tokens or not re.search(
             rf"^#{{{len(ancestry) + 1},}}\s", markdown_content, flags=re.MULTILINE
         ):
             # Create entry with line number information

--- a/src/khoj/processor/content/text_to_entries.py
+++ b/src/khoj/processor/content/text_to_entries.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from itertools import repeat
 from typing import Any, Callable, List, Set, Tuple
 
+import tiktoken
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from tqdm import tqdm
 
@@ -56,6 +57,21 @@ class TextToEntries(ABC):
     def tokenizer(text: str) -> List[str]:
         "Tokenize text into words."
         return text.split()
+
+    @staticmethod
+    def token_count(text: str) -> int:
+        """Count tokens in text using a real subword tokenizer.
+
+        Unlike `tokenizer`, which approximates length via whitespace-split
+        word count, this stays accurate for languages without word
+        separators (e.g. Chinese, Japanese, Korean), where `text.split()`
+        undercounts length and skips chunking that should happen.
+        """
+        if not hasattr(TextToEntries, "_tiktoken_encoder"):
+            TextToEntries._tiktoken_encoder = tiktoken.get_encoding("cl100k_base")
+        # disallowed_special=() avoids raising if document content happens to
+        # contain a substring that looks like a special token (e.g. "<|endoftext|>")
+        return len(TextToEntries._tiktoken_encoder.encode(text, disallowed_special=()))
 
     @staticmethod
     def split_entries_by_max_tokens(


### PR DESCRIPTION
## Summary

Fixes #1354. Markdown files with CJK (Chinese, Japanese, Korean) content are indexed as a single entry instead of being chunked by heading, because the heading-split decision in `MarkdownToEntries.process_single_markdown_file` uses `TextToEntries.tokenizer()` (`text.split()`) to estimate length. `text.split()` relies on whitespace between words, which CJK text doesn't have, so it drastically undercounts length and the `<= max_tokens` check passes when it shouldn't — the doc never reaches the heading-splitting logic. This degrades search quality since the bi-encoder ends up averaging the semantics of the whole document.

**Note on approach**: the issue's suggested fix was to swap `TextToEntries.tokenizer()` itself for a tiktoken-based implementation. I went with a narrower fix instead — `tokenizer()` is also used as the `length_function` for `RecursiveCharacterTextSplitter` in `split_entries_by_max_tokens`, which controls chunk sizing for *every* content type (markdown, org, plaintext, PDF, etc.), not just this heading-split check. Swapping it globally would change chunk sizes for all users and file types, since tiktoken's subword counts don't map 1:1 to `text.split()`'s word counts even for English. Instead I added `TextToEntries.token_count()` (tiktoken `cl100k_base`) and used it only at the specific gate described in the issue, leaving the rest of the chunking pipeline untouched.

## Test plan

Verified directly against `MarkdownToEntries.extract_markdown_entries` (couldn't run the full suite locally — it needs a Postgres instance for Django's test DB setup, unrelated to this change):

- CJK doc with 3 headed sections (per the issue's repro): before the fix, collapses to **1** entry; after the fix, correctly splits into **4** (YAML frontmatter + 3 sections)
- Equivalent English doc with 2 headed sections: **2** entries before and after — no regression
- Short doc with no content over the token budget: stays as **1** entry before and after — no regression